### PR TITLE
Add support for SSH Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Contents:
 gitlab:
   host: <URL of GitLab host>
   token: <personal access token>
+  sshprivatekey: <optional path to an unencrypted ssh private key; uses ssh-agent otherwise>
 coursesfilepath: <path where config files for courses are>
 courses:
   - <basenames of coursesfiles>

--- a/git/auth.go
+++ b/git/auth.go
@@ -5,13 +5,15 @@ import (
 	"os"
 
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/spf13/viper"
 )
 
-func publickeys() (*ssh.PublicKeys, error) {
-	privateKeyFile := fmt.Sprintf("%s/.ssh/id_rsa", os.Getenv("HOME"))
-	// if pkf := startercode["privatekeyfile"]; pkf != "" {
-	// 	privateKeyFile = pkf
-	// }
+func getAuth() (ssh.AuthMethod, error) {
+	privateKeyFile := viper.GetString("gitlab.sshprivatekey")
+
+	if privateKeyFile == "" {
+		return nil, nil
+	}
 
 	_, err := os.Stat(privateKeyFile)
 	if err != nil {

--- a/git/clone.go
+++ b/git/clone.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Clone(cfg *config.AssignmentConfig) {
-	publickeys, err := publickeys()
+	auth, err := getAuth()
 	if err != nil {
 		fmt.Printf("error: %v", err)
 		return
@@ -24,11 +24,11 @@ func Clone(cfg *config.AssignmentConfig) {
 	switch cfg.Per {
 	case config.PerStudent:
 		for _, suffix := range cfg.Students {
-			clone(localpath(cfg, suffix), cfg.Clone.Branch, cloneurl(cfg, suffix), publickeys)
+			clone(localpath(cfg, suffix), cfg.Clone.Branch, cloneurl(cfg, suffix), auth)
 		}
 	case config.PerGroup:
 		for _, grp := range cfg.Groups {
-			clone(localpath(cfg, grp.Name), cfg.Clone.Branch, cloneurl(cfg, grp.Name), publickeys)
+			clone(localpath(cfg, grp.Name), cfg.Clone.Branch, cloneurl(cfg, grp.Name), auth)
 		}
 	}
 }
@@ -43,7 +43,7 @@ func localpath(cfg *config.AssignmentConfig, suffix string) string {
 	return fmt.Sprintf("%s/%s-%s", cfg.Clone.LocalPath, cfg.Name, suffix)
 }
 
-func clone(localpath, branch, cloneurl string, publickeys *ssh.PublicKeys) {
+func clone(localpath, branch, cloneurl string, auth ssh.AuthMethod) {
 	cfg := yacspin.Config{
 		Frequency: 100 * time.Millisecond,
 		CharSet:   yacspin.CharSets[69],
@@ -70,7 +70,7 @@ func clone(localpath, branch, cloneurl string, publickeys *ssh.PublicKeys) {
 	}
 
 	_, err = git.PlainClone(localpath, false, &git.CloneOptions{
-		Auth:          publickeys,
+		Auth:          auth,
 		URL:           cloneurl,
 		ReferenceName: plumbing.ReferenceName("refs/heads/" + branch),
 	})

--- a/git/starterrepo.go
+++ b/git/starterrepo.go
@@ -15,8 +15,8 @@ import (
 )
 
 type Starterrepo struct {
-	Repo       *git.Repository
-	Publickeys *ssh.PublicKeys
+	Repo *git.Repository
+	Auth ssh.AuthMethod
 }
 
 func PrepareStartercodeRepo(assignmentCfg *config.AssignmentConfig) (*Starterrepo, error) {
@@ -52,7 +52,7 @@ func PrepareStartercodeRepo(assignmentCfg *config.AssignmentConfig) (*Starterrep
 		log.Debug().Err(err).Msg("cannot start spinner")
 	}
 
-	publicKeys, err := publickeys()
+	auth, err := getAuth()
 	if err != nil {
 		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
 
@@ -64,7 +64,7 @@ func PrepareStartercodeRepo(assignmentCfg *config.AssignmentConfig) (*Starterrep
 	}
 
 	r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
-		Auth:          publicKeys,
+		Auth:          auth,
 		URL:           assignmentCfg.Startercode.URL,
 		ReferenceName: plumbing.ReferenceName("refs/heads/" + assignmentCfg.Startercode.FromBranch),
 	})
@@ -79,7 +79,7 @@ func PrepareStartercodeRepo(assignmentCfg *config.AssignmentConfig) (*Starterrep
 	}
 
 	return &Starterrepo{
-		Repo:       r,
-		Publickeys: publicKeys,
+		Repo: r,
+		Auth: auth,
 	}, nil
 }

--- a/gitlab/starterrepo.go
+++ b/gitlab/starterrepo.go
@@ -39,7 +39,7 @@ func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.St
 	pushOpts := &git.PushOptions{
 		RemoteName: remote.Config().Name,
 		RefSpecs:   []config.RefSpec{refSpec},
-		Auth:       from.Publickeys,
+		Auth:       from.Auth,
 	}
 	err = from.Repo.Push(pushOpts)
 	if err != nil {


### PR DESCRIPTION
The private ssh key to use for cloning is currently hardcoded. 

In this PR, the location is read from the gitlab.sshprivatekey configuration value.
If this is unset, the ssh-agent is used for authentication.