### PR TITLE
Don't Panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Contents:
       <name of snd group>:
         <array of student in group>
       ...
-    <name of assignemnt>:
+    <name of assignment>:
       assignmentpath: <gitlab subgroup of semesterpath (or coursepath, if semesterpath is empty)
                        used for assignment>
       # also optional
@@ -124,7 +124,7 @@ Flags:
 Use "glabs [command] --help" for more information about a command.
 ```
 
-Before generating check wheter all students exist or not using the command
+Before generating check whether all students exist or not using the command
 
 ```
 glabs check [course]
@@ -153,7 +153,7 @@ Command line options (`-b` and `-p`) override the config file settings.
 
 ## Using starter code as a template
 
-Currently glabs does not support rewritting git history.
+Currently glabs does not support rewriting git history.
 
 What you can do is the following:
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/obcode/glabs/cmd"
 	"github.com/spf13/viper"
 )
@@ -19,6 +22,10 @@ func main() {
 	viper.Set("BuiltBy", builtBy)
 	err := cmd.Execute()
 	if err != nil {
-		panic(err)
+		_, err := fmt.Fprintln(os.Stderr, "Error:", err)
+		if err != nil {
+			panic(err)
+		}
+		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
Currently, a `./glabs check` terminates with a panic and an unhelpful traceback.

This PR changes it to print the Error in friendly letters to os.Stderr, prefixed with "Error:".

It also fixes some typos.