### PR TITLE
User by email

### DIFF
--- a/config/assignment.go
+++ b/config/assignment.go
@@ -126,12 +126,10 @@ func GetAssignmentConfig(course, assignment string, onlyForStudentsOrGroups ...s
 	return assignmentConfig
 }
 
-// Using email addresses instead of usernames/user-id's results in @ and . in the student's name.
+// Using email addresses instead of usernames/user-id's results in @ in the student's name.
 // This is incompatible to the filesystem and gitlab so replacing the values is necessary.
 func (cfg *AssignmentConfig) EscapeUserName(name string) string {
-	name = strings.ReplaceAll(name, "@", "_")
-	name = strings.ReplaceAll(name, ".", "_")
-	return name
+	return strings.ReplaceAll(name, "@", "_at_")
 }
 
 func assignmentPath(course, assignment string) string {

--- a/config/assignment.go
+++ b/config/assignment.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -106,6 +107,14 @@ func GetAssignmentConfig(course, assignment string, onlyForStudentsOrGroups ...s
 	}
 
 	return assignmentConfig
+}
+
+// Using email addresses instead of usernames/user-id's results in @ and . in the student's name.
+// This is incompatible to the filesystem and gitlab so replacing the values is necessary.
+func (cfg *AssignmentConfig) EscapeUserName(name string) string {
+	name = strings.ReplaceAll(name, "@", "_")
+	name = strings.ReplaceAll(name, ".", "_")
+	return name
 }
 
 func assignmentPath(course, assignment string) string {

--- a/git/clone.go
+++ b/git/clone.go
@@ -25,6 +25,7 @@ func Clone(cfg *config.AssignmentConfig) {
 	switch cfg.Per {
 	case config.PerStudent:
 		for _, suffix := range cfg.Students {
+			suffix = cfg.EscapeUserName(suffix)
 			clone(localpath(cfg, suffix), cfg.Clone.Branch, cloneurl(cfg, suffix), auth, cfg.Clone.Force)
 		}
 	case config.PerGroup:

--- a/gitlab/check.go
+++ b/gitlab/check.go
@@ -1,6 +1,8 @@
 package gitlab
 
 import (
+	"strings"
+
 	"github.com/gookit/color"
 	"github.com/obcode/glabs/config"
 )
@@ -61,14 +63,20 @@ func (c *Client) CheckCourse(cfg *config.CourseConfig) bool {
 	return true
 }
 
-func (c *Client) checkStudent(name, prefix string) bool {
-	user, err := c.getUser(name)
+func (c *Client) checkStudent(searchPattern, prefix string) bool {
+	user, err := c.getUser(searchPattern)
 	if err != nil {
-		color.Red.Printf("    # %s, error: %v\n", name, err)
-		return false
+		if strings.Contains(searchPattern, "@") {
+			color.Yellow.Printf("%s     - %s # Inviting via email\n", prefix, searchPattern)
+			return true
+		} else {
+			color.Red.Printf("    # %s, error: %v\n", searchPattern, err)
+			return false
+		}
+
 	}
 	color.Cyan.Printf("%s     - %s", prefix, user.Username)
-	color.Green.Printf(" # %s\n", user.Name)
+	color.Green.Printf(" # %s (%s)\n", user.Name, searchPattern)
 	return true
 }
 

--- a/gitlab/generate.go
+++ b/gitlab/generate.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/logrusorgru/aurora"
@@ -10,6 +11,7 @@ import (
 	"github.com/obcode/glabs/git"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
+	"github.com/xanzy/go-gitlab"
 )
 
 func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) {
@@ -138,11 +140,31 @@ func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGrou
 
 		userID, err := c.getUserID(student)
 		if err != nil {
-			spinner.StopFailMessage(fmt.Sprintf("cannot get user id: %v", err))
+			if strings.Contains(student, "@") {
+				info, err := c.inviteByEmail(assignmentCfg, project.ID, student)
+				if err != nil {
+					spinner.StopFailMessage(fmt.Sprintf("%v", err))
 
-			err := spinner.StopFail()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
+					err := spinner.StopFail()
+					if err != nil {
+						log.Debug().Err(err).Msg("cannot stop spinner")
+					}
+				} else {
+
+					spinner.StopMessage(aurora.Sprintf(aurora.Green(info)))
+					err = spinner.Stop()
+					if err != nil {
+						log.Debug().Err(err).Msg("cannot stop spinner")
+					}
+				}
+				continue
+			} else {
+				spinner.StopFailMessage(fmt.Sprintf("cannot get user id: %v", err))
+
+				err := spinner.StopFail()
+				if err != nil {
+					log.Debug().Err(err).Msg("cannot stop spinner")
+				}
 			}
 			continue
 		}
@@ -175,6 +197,22 @@ func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGrou
 
 }
 
+func (c *Client) inviteByEmail(cfg *config.AssignmentConfig, projectID int, email string) (string, error) {
+
+	m := &gitlab.InvitesOptions{
+		Email:       &email,
+		AccessLevel: gitlab.AccessLevel(gitlab.AccessLevelValue(cfg.AccessLevel)),
+	}
+	resp, _, err := c.Invites.ProjectInvites(projectID, m)
+	if err != nil {
+		return "", err
+	}
+	if resp.Status != "success" {
+		return "", fmt.Errorf("inviting user %s failed with %s", email, resp.Message[email])
+	}
+	return fmt.Sprintf("successfully invited user %s", email), nil
+}
+
 func (c *Client) generatePerStudent(assignmentCfg *config.AssignmentConfig, assignmentGroupID int,
 	starterrepo *git.Starterrepo) {
 	if len(assignmentCfg.Students) == 0 {
@@ -183,7 +221,8 @@ func (c *Client) generatePerStudent(assignmentCfg *config.AssignmentConfig, assi
 	}
 
 	for _, student := range assignmentCfg.Students {
-		c.generate(assignmentCfg, assignmentGroupID, assignmentCfg.Name+"-"+student, []string{student}, starterrepo)
+		name := assignmentCfg.Name + "-" + assignmentCfg.EscapeUserName(student)
+		c.generate(assignmentCfg, assignmentGroupID, name, []string{student}, starterrepo)
 	}
 }
 

--- a/gitlab/users.go
+++ b/gitlab/users.go
@@ -9,9 +9,9 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-func (c *Client) getUser(username string) (*gitlab.User, error) {
+func (c *Client) getUser(searchPattern string) (*gitlab.User, error) {
 	u := &gitlab.ListUsersOptions{
-		Username: gitlab.String(username),
+		Search: gitlab.String(searchPattern),
 	}
 	users, _, err := c.Users.ListUsers(u)
 	if err != nil {
@@ -19,26 +19,26 @@ func (c *Client) getUser(username string) (*gitlab.User, error) {
 	}
 
 	if len(users) == 0 {
-		log.Debug().Str("username", username).Msg("user not found")
+		log.Debug().Str("searchPattern", searchPattern).Msg("user not found")
 		return nil, errors.New("user not found")
 	} else if len(users) > 1 {
-		log.Debug().Str("username", username).Msg("more than one user found")
+		log.Debug().Str("searchPattern", searchPattern).Msg("more than one user found")
 		return nil, errors.New("more than one user found")
 	}
 
 	return users[0], nil
 }
 
-func (c *Client) getUserID(username string) (int, error) {
-	user, err := c.getUser(username)
+func (c *Client) getUserID(searchPattern string) (int, error) {
+	user, err := c.getUser(searchPattern)
 
 	if err != nil {
-		log.Debug().Err(err).Str("username", username).Msg("cannot get User")
+		log.Debug().Err(err).Str("searchPattern", searchPattern).Msg("cannot get User")
 		return 0, fmt.Errorf("cannot get user: %w", err)
 	}
 
 	userID := user.ID
-	log.Debug().Str("username", username).Int("userID", userID).Msg("found user with id")
+	log.Debug().Str("searchPattern", searchPattern).Int("userID", userID).Msg("found user with id")
 
 	return userID, nil
 }


### PR DESCRIPTION
As allready discused via email, defining users on the email is much more reliable in our case then using the userid.

Existing configurations must not be changed because the search pattern only gets less specific and does not try to only match the username. Users that can't be resolved directly but defined via their email get invited manually. Due to some limitations in paths/urls/... the @ and the . get replaced by an _.
