### PR TITLE
✨ Add devBranch as default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,19 @@ Contents:
         url: <url to repo> # only via SSH atm
         fromBranch: <branchName in startercode> # default main
         toBranch: <branchName in generated repo> # default main
+        devBranch: <branchName used as default branch> # default toBranch
         protectToBranch: <false|true> # whether only maintainer can push, default false
       # accesslevel should be guest, developer, reporter, maintainer
       # if not defined accesslevel is developer
       accesslevel: <accesslevel for students>
-      # It is possible to seed repositories using a custom tool instead of using a startercode.      
+      # It is possible to seed repositories using a custom tool instead of using a startercode.
       seeder:
         cmd: <path to seeding tool> # e.g. python
         args:
           - <list of arguments passed. %s gets replaced by the path of the repository>
         name: <name of the author used for commit>
         email: <email of the author used for commit>
-        toBranch: <branch to commit to> # default main 
+        toBranch: <branch to commit to> # default main
         signKey: <plaintext private key for signing commits> # Optional key for signing the commit. If the key is encrypted the password will be requested on running the tool.
         protectToBranch:  <false|true> # whether only maintainer can push, default false
       clone:

--- a/config/assignment.go
+++ b/config/assignment.go
@@ -51,6 +51,7 @@ type Startercode struct {
 	URL             string
 	FromBranch      string
 	ToBranch        string
+	DevBranch       string
 	ProtectToBranch bool
 }
 
@@ -278,10 +279,16 @@ func startercode(assignmentKey string) *Startercode {
 		toBranch = tB
 	}
 
+	devBranch := toBranch
+	if dB := viper.GetString(assignmentKey + ".startercode.devBranch"); len(dB) > 0 {
+		devBranch = dB
+	}
+
 	return &Startercode{
 		URL:             url,
 		FromBranch:      fromBranch,
 		ToBranch:        toBranch,
+		DevBranch:       devBranch,
 		ProtectToBranch: viper.GetBool(assignmentKey + ".startercode.protectToBranch"),
 	}
 }

--- a/config/show.go
+++ b/config/show.go
@@ -19,10 +19,12 @@ func (cfg *AssignmentConfig) Show() {
   URL:              %s
   FromBranch:       %s
   ToBranch:         %s
+  DevBranch:        %s
   ProtectToBranch:  %t`),
 			aurora.Yellow(cfg.Startercode.URL),
 			aurora.Yellow(cfg.Startercode.FromBranch),
 			aurora.Yellow(cfg.Startercode.ToBranch),
+			aurora.Yellow(cfg.Startercode.DevBranch),
 			aurora.Yellow(cfg.Startercode.ProtectToBranch),
 		)
 	}

--- a/gitlab/starterrepo.go
+++ b/gitlab/starterrepo.go
@@ -34,6 +34,7 @@ func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.St
 		Str("toURL", project.SSHURLToRepo).
 		Str("fromBranch", assignmentCfg.Startercode.FromBranch).
 		Str("toBranch", assignmentCfg.Startercode.ToBranch).
+		Str("devBranch", assignmentCfg.Startercode.DevBranch).
 		Msg("pushing starter code")
 
 	pushOpts := &git.PushOptions{
@@ -49,8 +50,53 @@ func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.St
 		return fmt.Errorf("cannot push to remote: %w", err)
 	}
 
+	if assignmentCfg.Startercode.DevBranch != assignmentCfg.Startercode.ToBranch {
+		return c.devBranch(assignmentCfg, project)
+	}
+
 	if assignmentCfg.Startercode.ProtectToBranch {
 		return c.protectBranch(assignmentCfg, project)
+	}
+
+	return nil
+}
+
+func (c *Client) devBranch(assignmentCfg *cfg.AssignmentConfig, project *gitlab.Project) error {
+	if assignmentCfg.Startercode.ProtectToBranch {
+		log.Debug().
+			Str("name", project.Name).
+			Str("toURL", project.SSHURLToRepo).
+			Str("branch", assignmentCfg.Startercode.DevBranch).
+			Msg("switching to development branch")
+
+		opts := &gitlab.CreateBranchOptions{
+			Branch: gitlab.String(assignmentCfg.Startercode.DevBranch),
+			Ref:    gitlab.String(assignmentCfg.Startercode.ToBranch),
+		}
+
+		_, _, err := c.Branches.CreateBranch(project.ID, opts)
+		if err != nil {
+			log.Debug().Err(err).
+				Str("name", project.Name).
+				Str("toURL", project.SSHURLToRepo).
+				Str("branch", assignmentCfg.Startercode.DevBranch).
+				Msg("error creating development branch")
+			return fmt.Errorf("error while trying to create development branch: %w", err)
+		}
+
+		projectOpts := &gitlab.EditProjectOptions{
+			DefaultBranch: gitlab.String(assignmentCfg.Startercode.DevBranch),
+		}
+
+		_, _, err = c.Projects.EditProject(project.ID, projectOpts)
+		if err != nil {
+			log.Debug().Err(err).
+				Str("name", project.Name).
+				Str("toURL", project.SSHURLToRepo).
+				Str("branch", assignmentCfg.Startercode.DevBranch).
+				Msg("error switching default to development branch")
+			return fmt.Errorf("error while switching default to development branch: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
You could now use a toBranch and a different devBranch.

Use Case:

- `main`-Branch contains the starter code and is protected
- `develop`-Branch is default branch for students
- the students hand in their work by creating a merge request from `develop` to `main`