### PR TITLE
allow optionally specifying users by their user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ algdati:
     per: student
 ```
 
+**Using Student User IDs instead of Student Account Names**
+
+Instead of specifying the users to be added to a project by using the student account name, you can also specify them by using the corresponding user IDs if the prefix "id:" is used. 
+
+Example:
+```.yaml
+[...]
+  students:
+   - id:8183
+[...]
+```
+
 ## Usage
 
 ```

--- a/gitlab/setaccess.go
+++ b/gitlab/setaccess.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"strconv"
 	"time"
 
 	"github.com/logrusorgru/aurora"
@@ -80,7 +81,19 @@ func (c *Client) setaccess(assignmentCfg *config.AssignmentConfig,
 			log.Debug().Err(err).Msg("cannot start spinner")
 		}
 
-		userID, err := c.getUserID(student)
+		var userID int
+
+		if strings.HasPrefix(student, "id:") {
+			asRunes := []rune(student)
+			userIDStr := string(asRunes[3:])
+			userID, err = strconv.Atoi(userIDStr)
+			if err != nil {
+				log.Debug().Err(err).Msg("cannot interpret specified user id as numeric id")
+			}
+		} else {
+			userID, err = c.getUserID(student)
+		}
+
 		if err != nil {
 			if strings.Contains(student, "@") {
 				info, err := c.inviteByEmail(assignmentCfg, project.ID, student)


### PR DESCRIPTION
added mini-feature: allow specifying users by their gitlab user-id

disclaimer: never coded anything in go...