### PR TITLE
feat: implement merge request approval rules and settings, #52

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/git"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/git"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab"
-	"github.com/obcode/glabs/gitlab/report"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v2/gitlab/report"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/setaccess.go
+++ b/cmd/setaccess.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,11 +16,15 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Glabs",
 	Long:  `All software has versions. This is Glabs'`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Glabs version %s, commit %s, build date %s, build by %s\n",
-			viper.GetString("Version"),
-			viper.GetString("Commit"),
-			viper.GetString("Date"),
-			viper.GetString("BuiltBy"),
-		)
+		if viper.GetString("Commit") == "none" {
+			fmt.Printf("Glabs version %s\n", viper.GetString("Version"))
+		} else {
+			fmt.Printf("Glabs version %s, commit %s, build date %s, build by %s\n",
+				viper.GetString("Version"),
+				viper.GetString("Commit"),
+				viper.GetString("Date"),
+				viper.GetString("BuiltBy"),
+			)
+		}
 	},
 }

--- a/config/assignment.go
+++ b/config/assignment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 )
@@ -172,5 +173,208 @@ func mergeRequest(assignmentKey string) *MergeRequest {
 		SkippedPipelinesAreSuccessful: viper.GetBool(assignmentKey + ".mergeRequest.skippedPipelinesAreSuccessful"),
 		AllThreadsMustBeResolved:      viper.GetBool(assignmentKey + ".mergeRequest.allThreadsMustBeResolved"),
 		StatusChecksMustSucceed:       viper.GetBool(assignmentKey + ".mergeRequest.statusChecksMustSucceed"),
+		Approvals:                     mergeRequestApprovals(assignmentKey),
+		ApprovalSettings:              mergeRequestApprovalSettings(assignmentKey),
+	}
+}
+
+func mergeRequestApprovals(assignmentKey string) []MergeRequestApprovalRule {
+	raw := viper.Get(assignmentKey + ".mergeRequest.approvals")
+	raw = extractMergeRequestApprovalRulesRaw(raw)
+	raw = normalizeMergeRequestApprovalConfigKeys(raw)
+	if raw == nil {
+		return nil
+	}
+
+	if containsLegacyApprovalUsersKey(raw) {
+		log.Fatal().Str("assignmentKey", assignmentKey).Msg("mergeRequest.approvals.rules[].users is no longer supported; use usernames")
+	}
+
+	var configured []MergeRequestApprovalRule
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &configured,
+		TagName:          "mapstructure",
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
+		log.Fatal().Err(err).Str("assignmentKey", assignmentKey).Msg("cannot create mergeRequest.approvals decoder")
+	}
+	if err := decoder.Decode(raw); err != nil {
+		log.Fatal().Err(err).Str("assignmentKey", assignmentKey).Msg("cannot parse mergeRequest.approvals config")
+	}
+
+	normalized := make([]MergeRequestApprovalRule, 0, len(configured))
+	for _, rule := range configured {
+		rule.Name = strings.TrimSpace(rule.Name)
+		rule.Branch = strings.TrimSpace(rule.Branch)
+		if rule.Branch != "" {
+			rule.Branches = append(rule.Branches, rule.Branch)
+		}
+
+		seenBranches := make(map[string]struct{})
+		branches := make([]string, 0, len(rule.Branches))
+		for _, branch := range rule.Branches {
+			branch = strings.TrimSpace(branch)
+			if branch == "" {
+				continue
+			}
+			if _, ok := seenBranches[branch]; ok {
+				continue
+			}
+			seenBranches[branch] = struct{}{}
+			branches = append(branches, branch)
+		}
+		rule.Branches = branches
+		rule.Branch = ""
+
+		usernames := make([]string, 0, len(rule.Usernames))
+		for _, username := range rule.Usernames {
+			username = strings.TrimSpace(username)
+			if username != "" {
+				usernames = append(usernames, username)
+			}
+		}
+		rule.Usernames = usernames
+
+		groups := make([]string, 0, len(rule.Groups))
+		for _, group := range rule.Groups {
+			group = strings.TrimSpace(group)
+			if group != "" {
+				groups = append(groups, group)
+			}
+		}
+		rule.Groups = groups
+
+		if rule.RequiredApprovals < 0 {
+			rule.RequiredApprovals = 0
+		}
+
+		if len(rule.Branches) == 0 {
+			continue
+		}
+		normalized = append(normalized, rule)
+	}
+
+	return normalized
+}
+
+func extractMergeRequestApprovalRulesRaw(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		if rules, ok := typed["rules"]; ok {
+			return rules
+		}
+		return nil
+	default:
+		// Backward compatibility: approvals can still be configured directly as a list.
+		return value
+	}
+}
+
+func containsLegacyApprovalUsersKey(value any) bool {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			if containsLegacyApprovalUsersKey(item) {
+				return true
+			}
+		}
+		return false
+	case []map[string]any:
+		for _, item := range typed {
+			if containsLegacyApprovalUsersKey(item) {
+				return true
+			}
+		}
+		return false
+	case map[string]any:
+		for key, item := range typed {
+			if key == "users" {
+				return true
+			}
+			if containsLegacyApprovalUsersKey(item) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func mergeRequestApprovalSettings(assignmentKey string) *MergeRequestApprovalSettings {
+	prefix := assignmentKey + ".mergeRequest.approvals.settings"
+	if !viper.IsSet(prefix) {
+		return nil
+	}
+
+	settings := &MergeRequestApprovalSettings{}
+
+	if viper.IsSet(prefix + ".preventApprovalByMergeRequestCreator") {
+		v := viper.GetBool(prefix + ".preventApprovalByMergeRequestCreator")
+		settings.PreventApprovalByMergeRequestCreator = &v
+	}
+	if viper.IsSet(prefix + ".preventApprovalsByUsersWhoAddCommits") {
+		v := viper.GetBool(prefix + ".preventApprovalsByUsersWhoAddCommits")
+		settings.PreventApprovalsByUsersWhoAddCommits = &v
+	}
+	if viper.IsSet(prefix + ".preventEditingApprovalRulesInMergeRequests") {
+		v := viper.GetBool(prefix + ".preventEditingApprovalRulesInMergeRequests")
+		settings.PreventEditingApprovalRulesInMergeRequests = &v
+	}
+	if viper.IsSet(prefix + ".requireUserReauthenticationToApprove") {
+		v := viper.GetBool(prefix + ".requireUserReauthenticationToApprove")
+		settings.RequireUserReauthenticationToApprove = &v
+	}
+	if viper.IsSet(prefix + ".whenCommitAdded") {
+		v := ApprovalWhenCommitAdded(viper.GetString(prefix + ".whenCommitAdded"))
+		switch v {
+		case ApprovalKeepApprovals, ApprovalRemoveAllApprovals, ApprovalRemoveCodeOwnerApprovalsIfFilesChanged:
+			settings.WhenCommitAdded = &v
+		default:
+			log.Fatal().
+				Str("assignmentKey", assignmentKey).
+				Str("whenCommitAdded", string(v)).
+				Msg("invalid mergeRequest.approvals.settings.whenCommitAdded")
+		}
+	}
+
+	if settings.PreventApprovalByMergeRequestCreator == nil &&
+		settings.PreventApprovalsByUsersWhoAddCommits == nil &&
+		settings.PreventEditingApprovalRulesInMergeRequests == nil &&
+		settings.RequireUserReauthenticationToApprove == nil &&
+		settings.WhenCommitAdded == nil {
+		return nil
+	}
+
+	return settings
+}
+
+func normalizeMergeRequestApprovalConfigKeys(value any) any {
+	switch typed := value.(type) {
+	case []any:
+		normalized := make([]any, len(typed))
+		for i, item := range typed {
+			normalized[i] = normalizeMergeRequestApprovalConfigKeys(item)
+		}
+		return normalized
+	case []map[string]any:
+		normalized := make([]any, len(typed))
+		for i, item := range typed {
+			normalized[i] = normalizeMergeRequestApprovalConfigKeys(item)
+		}
+		return normalized
+	case map[string]any:
+		normalized := make(map[string]any, len(typed))
+		for key, item := range typed {
+			switch key {
+			case "required_approvals", "approvalsRequired":
+				key = "requiredApprovals"
+			}
+			normalized[key] = normalizeMergeRequestApprovalConfigKeys(item)
+		}
+		return normalized
+	default:
+		return value
 	}
 }

--- a/config/assignment_test.go
+++ b/config/assignment_test.go
@@ -227,3 +227,78 @@ func TestGetAssignmentConfig_MergeRequestChecks(t *testing.T) {
 		t.Fatal("StatusChecksMustSucceed = false, want true")
 	}
 }
+
+func TestGetAssignmentConfig_MergeRequestApprovals(t *testing.T) {
+	resetViper(t)
+
+	viper.Set("gitlab.host", "https://gitlab.example.org")
+	viper.Set("course", true)
+	viper.Set("course.coursepath", "mpd")
+	viper.Set("course.a1", true)
+	viper.Set("course.a1.assignmentpath", "blatt-01")
+	viper.Set("course.a1.mergeRequest.approvals", map[string]any{
+		"settings": map[string]any{
+			"preventApprovalByMergeRequestCreator":       true,
+			"preventApprovalsByUsersWhoAddCommits":       true,
+			"preventEditingApprovalRulesInMergeRequests": true,
+			"requireUserReauthenticationToApprove":       true,
+			"whenCommitAdded":                            "removeAllApprovals",
+		},
+		"rules": []map[string]any{
+			{
+				"name":                  "review-main",
+				"branches":              []string{"main", "develop"},
+				"usernames":             []string{"me", "mentor"},
+				"groups":                []string{"mpd/tutors", "17"},
+				"multiMemberGroupsOnly": true,
+				"requiredApprovals":     2,
+			},
+			{
+				"name":               "legacy-release",
+				"branch":             "release",
+				"usernames":          []string{"owner"},
+				"required_approvals": 1,
+			},
+		},
+	})
+
+	cfg := GetAssignmentConfig("course", "a1")
+	if cfg.MergeRequest == nil {
+		t.Fatal("MergeRequest should not be nil")
+	}
+	if len(cfg.MergeRequest.Approvals) != 2 {
+		t.Fatalf("len(MergeRequest.Approvals) = %d, want 2", len(cfg.MergeRequest.Approvals))
+	}
+
+	first := cfg.MergeRequest.Approvals[0]
+	if first.Name != "review-main" {
+		t.Fatalf("first.Name = %q, want review-main", first.Name)
+	}
+	if len(first.Branches) != 2 || first.Branches[0] != "main" || first.Branches[1] != "develop" {
+		t.Fatalf("first.Branches = %#v, want [main develop]", first.Branches)
+	}
+	if first.RequiredApprovals != 2 {
+		t.Fatalf("first.RequiredApprovals = %d, want 2", first.RequiredApprovals)
+	}
+	if !first.MultiMemberGroupsOnly {
+		t.Fatal("first.MultiMemberGroupsOnly = false, want true")
+	}
+
+	second := cfg.MergeRequest.Approvals[1]
+	if len(second.Branches) != 1 || second.Branches[0] != "release" {
+		t.Fatalf("second.Branches = %#v, want [release]", second.Branches)
+	}
+	if second.RequiredApprovals != 1 {
+		t.Fatalf("second.RequiredApprovals = %d, want 1", second.RequiredApprovals)
+	}
+
+	if cfg.MergeRequest.ApprovalSettings == nil {
+		t.Fatal("MergeRequest.ApprovalSettings should not be nil")
+	}
+	if cfg.MergeRequest.ApprovalSettings.PreventApprovalByMergeRequestCreator == nil || !*cfg.MergeRequest.ApprovalSettings.PreventApprovalByMergeRequestCreator {
+		t.Fatal("PreventApprovalByMergeRequestCreator should be true")
+	}
+	if cfg.MergeRequest.ApprovalSettings.WhenCommitAdded == nil || *cfg.MergeRequest.ApprovalSettings.WhenCommitAdded != ApprovalRemoveAllApprovals {
+		t.Fatalf("WhenCommitAdded = %#v, want %q", cfg.MergeRequest.ApprovalSettings.WhenCommitAdded, ApprovalRemoveAllApprovals)
+	}
+}

--- a/config/show.go
+++ b/config/show.go
@@ -10,13 +10,43 @@ import (
 func (cfg *AssignmentConfig) Show() {
 	var out strings.Builder
 
-	const (
-		topLabelWidth     = 19
-		sectionLabelWidth = 28
+	maxLabelWidth := func(labels ...string) int {
+		width := 0
+		for _, label := range labels {
+			if len(label)+1 > width {
+				width = len(label) + 1
+			}
+		}
+		return width
+	}
+
+	fieldValueColumn := func(candidates ...int) int {
+		width := 0
+		for _, candidate := range candidates {
+			if candidate > width {
+				width = candidate
+			}
+		}
+		return width
+	}
+
+	fieldCandidate := func(indent int, label string) int {
+		return indent + len(label) + 2
+	}
+
+	valueColumn := 0
+
+	approvalSettingsLabelWidth := maxLabelWidth(
+		"PreventApprovalByMergeRequestCreator",
+		"PreventApprovalsByUsersWhoAddCommits",
+		"PreventEditingApprovalRulesInMergeRequests",
+		"RequireUserReauthenticationToApprove",
+		"WhenCommitAdded",
 	)
 
 	writeTopField := func(label string, value any) {
-		fmt.Fprintf(&out, "%-*v %v\n", topLabelWidth, aurora.Cyan(label+":"), aurora.Yellow(value))
+		labelWidth := valueColumn - 1
+		fmt.Fprintf(&out, "%-*v %v\n", labelWidth, aurora.Cyan(label+":"), aurora.Yellow(value))
 	}
 
 	writeSectionHeader := func(name string) {
@@ -24,11 +54,28 @@ func (cfg *AssignmentConfig) Show() {
 	}
 
 	writeSectionField := func(label string, value any) {
-		fmt.Fprintf(&out, "  %-*v %v\n", sectionLabelWidth, aurora.Cyan(label+":"), aurora.Yellow(value))
+		labelWidth := valueColumn - 3
+		fmt.Fprintf(&out, "  %-*v %v\n", labelWidth, aurora.Cyan(label+":"), aurora.Yellow(value))
+	}
+
+	writeIndentedHeader := func(indent int, label string) {
+		fmt.Fprintf(&out, "%s%s\n", strings.Repeat(" ", indent), aurora.Cyan(label+":"))
+	}
+
+	writeIndentedField := func(indent int, labelWidth int, label string, value any) {
+		adjustedWidth := valueColumn - indent - 1
+		if adjustedWidth < labelWidth {
+			adjustedWidth = labelWidth
+		}
+		fmt.Fprintf(&out, "%s%-*v %v\n", strings.Repeat(" ", indent), adjustedWidth, aurora.Cyan(label+":"), aurora.Yellow(value))
 	}
 
 	writeSectionNotDefined := func() {
 		fmt.Fprintf(&out, "  %s\n", aurora.Red("not defined"))
+	}
+
+	writeIndentedNotDefined := func(indent int) {
+		fmt.Fprintf(&out, "%s%s\n", strings.Repeat(" ", indent), aurora.Red("not defined"))
 	}
 
 	mergeMethod := MergeCommit
@@ -37,6 +84,8 @@ func (cfg *AssignmentConfig) Show() {
 	skippedPipelinesAreSuccessful := false
 	allThreadsMustBeResolved := false
 	statusChecksMustSucceed := false
+	var approvals []MergeRequestApprovalRule
+	var approvalSettings *MergeRequestApprovalSettings
 	if cfg.MergeRequest != nil {
 		mergeMethod = cfg.MergeRequest.MergeMethod
 		squashOption = cfg.MergeRequest.SquashOption
@@ -44,6 +93,58 @@ func (cfg *AssignmentConfig) Show() {
 		skippedPipelinesAreSuccessful = cfg.MergeRequest.SkippedPipelinesAreSuccessful
 		allThreadsMustBeResolved = cfg.MergeRequest.AllThreadsMustBeResolved
 		statusChecksMustSucceed = cfg.MergeRequest.StatusChecksMustSucceed
+		approvals = cfg.MergeRequest.Approvals
+		approvalSettings = cfg.MergeRequest.ApprovalSettings
+	}
+
+	valueColumn = fieldValueColumn(
+		fieldCandidate(0, "Course"),
+		fieldCandidate(0, "Assignment"),
+		fieldCandidate(0, "Coursename-Prefix"),
+		fieldCandidate(0, "Per"),
+		fieldCandidate(0, "Base-URL"),
+		fieldCandidate(0, "Description"),
+		fieldCandidate(0, "AccessLevel"),
+		fieldCandidate(0, "Container-Registry"),
+		fieldCandidate(2, "URL"),
+		fieldCandidate(2, "FromBranch"),
+		fieldCandidate(2, "ToBranch"),
+		fieldCandidate(2, "AdditionalBranches"),
+		fieldCandidate(2, "ReplicateFromStartercode"),
+		fieldCandidate(2, "IssueNumbers"),
+		fieldCandidate(2, "MergeMethod"),
+		fieldCandidate(2, "SquashOption"),
+		fieldCandidate(2, "PipelineMustSucceed"),
+		fieldCandidate(2, "SkippedPipelinesAreSuccessful"),
+		fieldCandidate(2, "AllThreadsMustBeResolved"),
+		fieldCandidate(2, "StatusChecksMustSucceed"),
+		fieldCandidate(2, "Command"),
+		fieldCandidate(2, "Args"),
+		fieldCandidate(2, "Author"),
+		fieldCandidate(2, "EMail"),
+		fieldCandidate(2, "ProtectToBranch"),
+		fieldCandidate(2, "MergeRequest"),
+		fieldCandidate(2, "MergeRequest.SourceBranch"),
+		fieldCandidate(2, "MergeRequest.TargetBranch"),
+		fieldCandidate(2, "MergeRequest.Pipeline"),
+		fieldCandidate(2, "DockerImages"),
+		fieldCandidate(2, "Localpath"),
+		fieldCandidate(2, "Branch"),
+		fieldCandidate(2, "Force"),
+		fieldCandidate(6, "PreventApprovalByMergeRequestCreator"),
+		fieldCandidate(6, "PreventApprovalsByUsersWhoAddCommits"),
+		fieldCandidate(6, "PreventEditingApprovalRulesInMergeRequests"),
+		fieldCandidate(6, "RequireUserReauthenticationToApprove"),
+		fieldCandidate(6, "WhenCommitAdded"),
+	)
+	for _, branch := range cfg.Branches {
+		valueColumn = fieldValueColumn(valueColumn, fieldCandidate(2, "- "+branch.Name))
+	}
+	for _, approval := range approvals {
+		valueColumn = fieldValueColumn(valueColumn, fieldCandidate(6, "- "+approval.Name))
+	}
+	for _, grp := range cfg.Groups {
+		valueColumn = fieldValueColumn(valueColumn, fieldCandidate(2, "- "+grp.Name))
 	}
 
 	containerRegistry := aurora.Red("disabled")
@@ -60,14 +161,6 @@ func (cfg *AssignmentConfig) Show() {
 	writeTopField("AccessLevel", cfg.AccessLevel.String())
 	writeTopField("Container-Registry", containerRegistry)
 
-	writeSectionHeader("MergeRequest")
-	writeSectionField("MergeMethod", mergeMethod)
-	writeSectionField("SquashOption", squashOption)
-	writeSectionField("PipelineMustSucceed", pipelineMustSucceed)
-	writeSectionField("SkippedPipelinesAreSuccessful", skippedPipelinesAreSuccessful)
-	writeSectionField("AllThreadsMustBeResolved", allThreadsMustBeResolved)
-	writeSectionField("StatusChecksMustSucceed", statusChecksMustSucceed)
-
 	writeSectionHeader("Startercode")
 	if cfg.Startercode == nil {
 		writeSectionNotDefined()
@@ -76,24 +169,6 @@ func (cfg *AssignmentConfig) Show() {
 		writeSectionField("FromBranch", cfg.Startercode.FromBranch)
 		writeSectionField("ToBranch", cfg.Startercode.ToBranch)
 		writeSectionField("AdditionalBranches", cfg.Startercode.AdditionalBranches)
-	}
-
-	writeSectionHeader("Branches")
-	if len(cfg.Branches) == 0 {
-		writeSectionNotDefined()
-	} else {
-		for _, branch := range cfg.Branches {
-			fmt.Fprintf(
-				&out,
-				"  - %-20v (%v=%-5v, %v=%-5v, %v=%-5v, %v=%-5v, %v=%-5v)\n",
-				aurora.Yellow(branch.Name),
-				aurora.Cyan("protect"), aurora.Yellow(branch.Protect),
-				aurora.Cyan("mergeOnly"), aurora.Yellow(branch.MergeOnly),
-				aurora.Cyan("default"), aurora.Yellow(branch.Default),
-				aurora.Cyan("allowForcePush"), aurora.Yellow(branch.AllowForcePush),
-				aurora.Cyan("codeOwnerApprovalRequired"), aurora.Yellow(branch.CodeOwnerApprovalRequired),
-			)
-		}
 	}
 
 	writeSectionHeader("Issues")
@@ -105,6 +180,97 @@ func (cfg *AssignmentConfig) Show() {
 			writeSectionField("IssueNumbers", cfg.Issues.IssueNumbers)
 		} else {
 			writeSectionField("IssueNumbers", "not used")
+		}
+	}
+
+	writeSectionHeader("Branches")
+	if len(cfg.Branches) == 0 {
+		writeSectionNotDefined()
+	} else {
+		for _, branch := range cfg.Branches {
+			flags := make([]string, 0, 5)
+			if branch.Protect {
+				flags = append(flags, "protect")
+			}
+			if branch.MergeOnly {
+				flags = append(flags, "mergeOnly")
+			}
+			if branch.Default {
+				flags = append(flags, "default")
+			}
+			if branch.AllowForcePush {
+				flags = append(flags, "allowForcePush")
+			}
+			if branch.CodeOwnerApprovalRequired {
+				flags = append(flags, "codeOwnerApprovalRequired")
+			}
+
+			if len(flags) == 0 {
+				writeSectionField("- "+branch.Name, "")
+				continue
+			}
+
+			writeSectionField("- "+branch.Name, aurora.Cyan(strings.Join(flags, ", ")))
+		}
+	}
+
+	writeSectionHeader("MergeRequest")
+	writeSectionField("MergeMethod", mergeMethod)
+	writeSectionField("SquashOption", squashOption)
+	writeSectionField("PipelineMustSucceed", pipelineMustSucceed)
+	writeSectionField("SkippedPipelinesAreSuccessful", skippedPipelinesAreSuccessful)
+	writeSectionField("AllThreadsMustBeResolved", allThreadsMustBeResolved)
+	writeSectionField("StatusChecksMustSucceed", statusChecksMustSucceed)
+	writeIndentedHeader(2, "Approvals")
+	writeIndentedHeader(4, "Settings")
+	if approvalSettings == nil {
+		writeIndentedNotDefined(6)
+	} else {
+		hasApprovalSetting := false
+		if approvalSettings.PreventApprovalByMergeRequestCreator != nil {
+			hasApprovalSetting = true
+			writeIndentedField(6, approvalSettingsLabelWidth, "PreventApprovalByMergeRequestCreator", *approvalSettings.PreventApprovalByMergeRequestCreator)
+		}
+		if approvalSettings.PreventApprovalsByUsersWhoAddCommits != nil {
+			hasApprovalSetting = true
+			writeIndentedField(6, approvalSettingsLabelWidth, "PreventApprovalsByUsersWhoAddCommits", *approvalSettings.PreventApprovalsByUsersWhoAddCommits)
+		}
+		if approvalSettings.PreventEditingApprovalRulesInMergeRequests != nil {
+			hasApprovalSetting = true
+			writeIndentedField(6, approvalSettingsLabelWidth, "PreventEditingApprovalRulesInMergeRequests", *approvalSettings.PreventEditingApprovalRulesInMergeRequests)
+		}
+		if approvalSettings.RequireUserReauthenticationToApprove != nil {
+			hasApprovalSetting = true
+			writeIndentedField(6, approvalSettingsLabelWidth, "RequireUserReauthenticationToApprove", *approvalSettings.RequireUserReauthenticationToApprove)
+		}
+		if approvalSettings.WhenCommitAdded != nil {
+			hasApprovalSetting = true
+			writeIndentedField(6, approvalSettingsLabelWidth, "WhenCommitAdded", *approvalSettings.WhenCommitAdded)
+		}
+		if !hasApprovalSetting {
+			writeIndentedNotDefined(6)
+		}
+	}
+	writeIndentedHeader(4, "Rules")
+	if len(approvals) == 0 {
+		writeIndentedNotDefined(6)
+	} else {
+		for _, approval := range approvals {
+			ruleParts := []string{
+				fmt.Sprintf("%v=%v", aurora.Cyan("branches"), aurora.Yellow(approval.Branches)),
+			}
+			if len(approval.Usernames) > 0 {
+				ruleParts = append(ruleParts, fmt.Sprintf("%v=%v", aurora.Cyan("usernames"), aurora.Yellow(approval.Usernames)))
+			}
+			if len(approval.Groups) > 0 {
+				ruleParts = append(ruleParts, fmt.Sprintf("%v=%v", aurora.Cyan("groups"), aurora.Yellow(approval.Groups)))
+			}
+			if approval.MultiMemberGroupsOnly {
+				ruleParts = append(ruleParts, fmt.Sprintf("%v=%v", aurora.Cyan("multiMemberGroupsOnly"), aurora.Yellow(true)))
+			}
+			ruleParts = append(ruleParts, fmt.Sprintf("%v=%v", aurora.Cyan("requiredApprovals"), aurora.Yellow(approval.RequiredApprovals)))
+
+			writeIndentedField(6, 0, "- "+approval.Name, strings.Join(ruleParts, ", "))
 		}
 	}
 
@@ -167,7 +333,13 @@ func (cfg *AssignmentConfig) Show() {
 				for _, m := range grp.Members {
 					members = append(members, m.Raw)
 				}
-				fmt.Fprintf(&out, "  - %s: %s\n", aurora.Yellow(grp.Name), aurora.Green(strings.Join(members, ", ")))
+				fmt.Fprintf(
+					&out,
+					"  - %s %s: %s\n",
+					aurora.Yellow(grp.Name),
+					aurora.Cyan(fmt.Sprintf("(%d)", len(grp.Members))),
+					aurora.Green(strings.Join(members, ", ")),
+				)
 			}
 		}
 	}

--- a/config/types.go
+++ b/config/types.go
@@ -87,7 +87,35 @@ type MergeRequest struct {
 	SkippedPipelinesAreSuccessful bool
 	AllThreadsMustBeResolved      bool
 	StatusChecksMustSucceed       bool
+	Approvals                     []MergeRequestApprovalRule
+	ApprovalSettings              *MergeRequestApprovalSettings
 }
+
+type MergeRequestApprovalRule struct {
+	Name                  string   `mapstructure:"name"`
+	Branch                string   `mapstructure:"branch"`
+	Branches              []string `mapstructure:"branches"`
+	Usernames             []string `mapstructure:"usernames"`
+	Groups                []string `mapstructure:"groups"`
+	MultiMemberGroupsOnly bool     `mapstructure:"multiMemberGroupsOnly"`
+	RequiredApprovals     int      `mapstructure:"requiredApprovals"`
+}
+
+type MergeRequestApprovalSettings struct {
+	PreventApprovalByMergeRequestCreator       *bool
+	PreventApprovalsByUsersWhoAddCommits       *bool
+	PreventEditingApprovalRulesInMergeRequests *bool
+	RequireUserReauthenticationToApprove       *bool
+	WhenCommitAdded                            *ApprovalWhenCommitAdded
+}
+
+type ApprovalWhenCommitAdded string
+
+const (
+	ApprovalKeepApprovals                          ApprovalWhenCommitAdded = "keepApprovals"
+	ApprovalRemoveAllApprovals                     ApprovalWhenCommitAdded = "removeAllApprovals"
+	ApprovalRemoveCodeOwnerApprovalsIfFilesChanged ApprovalWhenCommitAdded = "removeCodeOwnerApprovalsIfTheirFilesChanged"
+)
 
 type ReleaseMergeRequest struct {
 	SourceBranch string

--- a/config/urls_show_test.go
+++ b/config/urls_show_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -141,11 +142,19 @@ func TestShow_WithBranches(t *testing.T) {
 		Branches: []BranchRule{{Name: "main", Protect: true, Default: true, AllowForcePush: true}, {Name: "develop", MergeOnly: true, CodeOwnerApprovalRequired: true}},
 	}
 	out := captureStdout(t, func() { cfg.Show() })
+	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	plain := ansiPattern.ReplaceAllString(out, "")
 	if !strings.Contains(out, "Branches:") || !strings.Contains(out, "develop") {
 		t.Fatalf("Show() output does not contain branches block: %q", out)
 	}
-	if !strings.Contains(out, "mergeOnly") || !strings.Contains(out, "default") || !strings.Contains(out, "allowForcePush") || !strings.Contains(out, "codeOwnerApprovalRequired") {
-		t.Fatalf("Show() output does not contain compact branch flags: %q", out)
+	if !strings.Contains(plain, "- main:") || !strings.Contains(plain, "protect, default, allowForcePush") {
+		t.Fatalf("Show() output does not contain enabled branch flags for main: %q", plain)
+	}
+	if !strings.Contains(plain, "- develop:") || !strings.Contains(plain, "mergeOnly, codeOwnerApprovalRequired") {
+		t.Fatalf("Show() output does not contain enabled branch flags for develop: %q", plain)
+	}
+	if strings.Contains(plain, "protect=false") || strings.Contains(plain, "mergeOnly=false") || strings.Contains(plain, "default=false") {
+		t.Fatalf("Show() output still contains disabled branch flags: %q", plain)
 	}
 }
 
@@ -253,6 +262,14 @@ func TestShow_PerGroup_ListsGroups(t *testing.T) {
 	if !strings.Contains(out, "team1") {
 		t.Fatalf("Show(PerGroup) output does not contain team1: %q", out)
 	}
+	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	plain := ansiPattern.ReplaceAllString(out, "")
+	if !strings.Contains(plain, "- team1 (2): alice, bob") {
+		t.Fatalf("Show(PerGroup) output does not contain inline group count for team1: %q", plain)
+	}
+	if !strings.Contains(plain, "- team2 (1): carol") {
+		t.Fatalf("Show(PerGroup) output does not contain inline group count for team2: %q", plain)
+	}
 }
 
 func TestShow_WithMergeMethod(t *testing.T) {
@@ -307,6 +324,170 @@ func TestShow_WithMergeChecks(t *testing.T) {
 	}
 	if !strings.Contains(out, "StatusChecksMustSucceed:") {
 		t.Fatalf("Show() output does not contain StatusChecksMustSucceed key: %q", out)
+	}
+}
+
+func TestShow_WithMergeRequestApprovals(t *testing.T) {
+	cfg := &AssignmentConfig{
+		MergeRequest: &MergeRequest{
+			Approvals: []MergeRequestApprovalRule{{
+				Name:                  "review-main",
+				Branches:              []string{"main", "develop"},
+				Usernames:             []string{"alice"},
+				Groups:                []string{"mpd/tutors"},
+				MultiMemberGroupsOnly: true,
+				RequiredApprovals:     2,
+			}},
+		},
+	}
+	out := captureStdout(t, func() { cfg.Show() })
+	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	plain := ansiPattern.ReplaceAllString(out, "")
+	if !strings.Contains(out, "Approvals:") {
+		t.Fatalf("Show() output does not contain Approvals label: %q", out)
+	}
+	if !strings.Contains(out, "Settings:") {
+		t.Fatalf("Show() output does not contain approval settings header: %q", out)
+	}
+	if !strings.Contains(out, "Rules:") {
+		t.Fatalf("Show() output does not contain approval rules header: %q", out)
+	}
+	if !strings.Contains(out, "review-main") {
+		t.Fatalf("Show() output does not contain approval rule name: %q", out)
+	}
+	if !strings.Contains(plain, "\n      - review-main:") {
+		t.Fatalf("Show() output does not contain aligned approval rule label: %q", plain)
+	}
+	if !strings.Contains(out, "requiredApprovals") {
+		t.Fatalf("Show() output does not contain requiredApprovals field: %q", out)
+	}
+	if !strings.Contains(out, "branches") {
+		t.Fatalf("Show() output does not contain branches field for approval rule: %q", out)
+	}
+	if !strings.Contains(out, "usernames") {
+		t.Fatalf("Show() output does not contain usernames field for approval rule: %q", out)
+	}
+	if !strings.Contains(out, "multiMemberGroupsOnly") {
+		t.Fatalf("Show() output does not contain multiMemberGroupsOnly field for approval rule: %q", out)
+	}
+}
+
+func TestShow_WithMergeRequestApprovals_OmitsEmptyUsersAndGroups(t *testing.T) {
+	cfg := &AssignmentConfig{
+		MergeRequest: &MergeRequest{
+			Approvals: []MergeRequestApprovalRule{{
+				Name:              "review-main",
+				Branches:          []string{"main"},
+				Usernames:         []string{},
+				Groups:            []string{},
+				RequiredApprovals: 1,
+			}},
+		},
+	}
+	out := captureStdout(t, func() { cfg.Show() })
+	if strings.Contains(out, "usernames") {
+		t.Fatalf("Show() output should omit empty usernames field for approval rule: %q", out)
+	}
+	if strings.Contains(out, "groups") {
+		t.Fatalf("Show() output should omit empty groups field for approval rule: %q", out)
+	}
+	if !strings.Contains(out, "branches") || !strings.Contains(out, "requiredApprovals") {
+		t.Fatalf("Show() output should keep non-empty approval rule fields: %q", out)
+	}
+}
+
+func TestShow_WithMergeRequestApprovalSettings(t *testing.T) {
+	preventCreator := true
+	preventCommitters := true
+	preventEditing := true
+	reauth := true
+	whenCommitAdded := ApprovalRemoveAllApprovals
+
+	cfg := &AssignmentConfig{
+		MergeRequest: &MergeRequest{
+			ApprovalSettings: &MergeRequestApprovalSettings{
+				PreventApprovalByMergeRequestCreator:       &preventCreator,
+				PreventApprovalsByUsersWhoAddCommits:       &preventCommitters,
+				PreventEditingApprovalRulesInMergeRequests: &preventEditing,
+				RequireUserReauthenticationToApprove:       &reauth,
+				WhenCommitAdded:                            &whenCommitAdded,
+			},
+		},
+	}
+	out := captureStdout(t, func() { cfg.Show() })
+	if !strings.Contains(out, "Approvals:") || !strings.Contains(out, "Settings:") {
+		t.Fatalf("Show() output does not contain nested approvals settings block: %q", out)
+	}
+	if !strings.Contains(out, "PreventApprovalByMergeRequestCreator") {
+		t.Fatalf("Show() output does not contain approval settings key: %q", out)
+	}
+	if !strings.Contains(out, "WhenCommitAdded") || !strings.Contains(out, string(ApprovalRemoveAllApprovals)) {
+		t.Fatalf("Show() output does not contain approval whenCommitAdded setting: %q", out)
+	}
+}
+
+func TestShow_WithUndefinedApprovalsBlocks(t *testing.T) {
+	cfg := &AssignmentConfig{
+		MergeRequest: &MergeRequest{},
+	}
+
+	out := captureStdout(t, func() { cfg.Show() })
+	if !strings.Contains(out, "Approvals:") || !strings.Contains(out, "Settings:") || !strings.Contains(out, "Rules:") {
+		t.Fatalf("Show() output does not contain nested approvals headers: %q", out)
+	}
+	if strings.Count(out, "not defined") < 2 {
+		t.Fatalf("Show() output does not contain not defined markers for empty approvals blocks: %q", out)
+	}
+}
+
+func TestShow_MergeRequestValuesAlign(t *testing.T) {
+	cfg := &AssignmentConfig{
+		MergeRequest: &MergeRequest{
+			MergeMethod:                   SemiLinearHistory,
+			SquashOption:                  SquashNever,
+			PipelineMustSucceed:           true,
+			SkippedPipelinesAreSuccessful: true,
+			AllThreadsMustBeResolved:      true,
+			StatusChecksMustSucceed:       true,
+		},
+	}
+
+	out := captureStdout(t, func() { cfg.Show() })
+	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	plain := ansiPattern.ReplaceAllString(out, "")
+	lines := strings.Split(plain, "\n")
+
+	var mergeMethodLine, skippedLine, statusChecksLine string
+	for _, line := range lines {
+		switch {
+		case strings.Contains(line, "MergeMethod:"):
+			mergeMethodLine = line
+		case strings.Contains(line, "SkippedPipelinesAreSuccessful:"):
+			skippedLine = line
+		case strings.Contains(line, "StatusChecksMustSucceed:"):
+			statusChecksLine = line
+		}
+	}
+
+	if mergeMethodLine == "" || skippedLine == "" || statusChecksLine == "" {
+		t.Fatalf("Show() output is missing merge request lines: %q", plain)
+	}
+
+	mergeMethodValueIndex := strings.Index(mergeMethodLine, string(SemiLinearHistory))
+	skippedValueIndex := strings.Index(skippedLine, "true")
+	statusChecksValueIndex := strings.Index(statusChecksLine, "true")
+	if mergeMethodValueIndex < 0 || skippedValueIndex < 0 || statusChecksValueIndex < 0 {
+		t.Fatalf("Show() output is missing expected values: %q", plain)
+	}
+
+	if mergeMethodValueIndex != skippedValueIndex || mergeMethodValueIndex != statusChecksValueIndex {
+		t.Fatalf(
+			"Show() merge request values are not aligned: mergeMethod=%d skipped=%d statusChecks=%d in %q",
+			mergeMethodValueIndex,
+			skippedValueIndex,
+			statusChecksValueIndex,
+			plain,
+		)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -445,6 +445,9 @@ Requirements for approval rules:
 | `default_off` | Allow | Squash checkbox visible but unchecked by default (GitLab default) |
 | `default_on` | Encourage | Squash checkbox visible and checked by default |
 
+> **Warning:**
+> Although the GitLab UI sometimes displays squash settings in the context of individual branch rules, **squash options are always project-wide**. Changing the squash setting in any branch rule or merge request rule will affect all branches in the project. There is currently no way to configure squash behavior per branch. This is a known limitation of GitLab, even if the UI suggests otherwise.
+
 **Example:**
 
 ```yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -372,6 +372,24 @@ Control how merge requests are merged in every generated project:
     skippedPipelinesAreSuccessful: false
     allThreadsMustBeResolved: false
     statusChecksMustSucceed: false
+    approvals:
+      settings:
+        preventApprovalByMergeRequestCreator: true
+        preventApprovalsByUsersWhoAddCommits: false
+        preventEditingApprovalRulesInMergeRequests: false
+        requireUserReauthenticationToApprove: false
+        whenCommitAdded: removeAllApprovals
+      rules:
+        - name: review-main
+          branch: main
+          usernames: [myusername]
+          groups: []
+          requiredApprovals: 1
+        - name: review-release
+          branches: [release, stable]
+          usernames: [release-owner]
+          groups: [mpd/tutors]
+          requiredApprovals: 2
 ```
 
 ### Merge Request keys
@@ -384,6 +402,31 @@ Control how merge requests are merged in every generated project:
 | `mergeRequest.skippedPipelinesAreSuccessful` | Treat skipped pipelines as successful | `false` | Only relevant when `mergeRequest.pipeline=true` |
 | `mergeRequest.allThreadsMustBeResolved` | All threads must be resolved | `false` | Maps to GitLab merge check |
 | `mergeRequest.statusChecksMustSucceed` | Status checks must succeed | `false` | Maps to GitLab merge check |
+| `mergeRequest.approvals` | Approval configuration block | `{}` | Contains `settings` and `rules` |
+| `mergeRequest.approvals.settings` | Project-level approval settings | `{}` | Maps to GitLab approval settings API |
+| `mergeRequest.approvals.settings.preventApprovalByMergeRequestCreator` | Prevent approval by MR creator | unset | Inverted and mapped to GitLab `merge_requests_author_approval` |
+| `mergeRequest.approvals.settings.preventApprovalsByUsersWhoAddCommits` | Prevent approval by committers | unset | Maps to GitLab `merge_requests_disable_committers_approval` |
+| `mergeRequest.approvals.settings.preventEditingApprovalRulesInMergeRequests` | Prevent editing rules in MRs | unset | Maps to GitLab `disable_overriding_approvers_per_merge_request` |
+| `mergeRequest.approvals.settings.requireUserReauthenticationToApprove` | Require user re-authentication to approve | unset | Maps to GitLab `require_reauthentication_to_approve` |
+| `mergeRequest.approvals.settings.whenCommitAdded` | Approval reset mode on push | unset | `keepApprovals` \| `removeAllApprovals` \| `removeCodeOwnerApprovalsIfTheirFilesChanged` |
+| `mergeRequest.approvals.rules` | Project approval rules (per protected branch) | `[]` | Applied by `generate` and `protect` |
+| `mergeRequest.approvals.rules[].name` | Rule name in GitLab | auto (`glabs-approval-<branch>`) | For multiple branches in one rule, branch name is appended |
+| `mergeRequest.approvals.rules[].branch` | Single target branch | — | Convenience alias for one branch |
+| `mergeRequest.approvals.rules[].branches` | Target branches | `[]` | Each branch becomes one project approval rule |
+| `mergeRequest.approvals.rules[].usernames` | Approvers (GitLab usernames) | `[]` | `@` prefix is allowed and removed automatically |
+| `mergeRequest.approvals.rules[].groups` | Approver groups (full path or numeric ID) | `[]` | Example full path: `mpd/tutors` |
+| `mergeRequest.approvals.rules[].multiMemberGroupsOnly` | Only apply rule for groups with more than one member | `false` | Skipped for `per: student` and one-person groups |
+| `mergeRequest.approvals.rules[].requiredApprovals` | Required number of approvals | `0` | `0` + empty usernames/groups removes an existing rule |
+
+Note: Email addresses and numeric user IDs are not accepted in `mergeRequest.approvals.rules[].usernames` and result in an explicit error. Use usernames only.
+
+Note: Approval rules for branches that are not protected in the target project are skipped with a warning; other valid approval rules are still applied.
+
+Requirements for approval rules:
+- Each target branch must exist in the repository.
+- Each target branch must be protected (configured with `protect: true` or `mergeOnly: true`).
+- Configured approvers must have project/group access in GitLab so they are eligible approvers.
+- Rules with `multiMemberGroupsOnly: true` are only applied for `per: group` projects with more than one member.
 
 ### Merge method values
 
@@ -413,6 +456,32 @@ blatt01:
     skippedPipelinesAreSuccessful: false
     allThreadsMustBeResolved: true
     statusChecksMustSucceed: true
+    approvals:
+      settings:
+        preventApprovalByMergeRequestCreator: true
+        preventApprovalsByUsersWhoAddCommits: false
+        preventEditingApprovalRulesInMergeRequests: false
+        requireUserReauthenticationToApprove: false
+        whenCommitAdded: removeAllApprovals
+      rules:
+        - name: review-main
+          branch: main
+          usernames:
+            - instructor
+          requiredApprovals: 1
+        - name: review-release
+          branches: [release]
+          usernames:
+            - release-owner
+          groups:
+            - mpd/tutors
+          multiMemberGroupsOnly: true
+          requiredApprovals: 2
+        - name: no-review-next
+          branch: next
+          usernames: []
+          groups: []
+          requiredApprovals: 0
 ```
 
 ## Full example

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -145,7 +145,71 @@ In GitLab UI you see wrong permissions or "Allowed to push and merge" instead of
 
 ```sh
 # Reapply protection rules
+## Branch protection
+
+### Branch protection not as expected
+
+**Symptoms:**
+
+In GitLab UI you see wrong permissions or "Allowed to push and merge" instead of merge-only.
+
+**Verification:**
+
+```sh
+# Reapply protection rules
 glabs protect <course> <assignment>
+```
+
+Then check GitLab UI for expected behavior.
+
+**For merge-only dev branch:**
+
+Expected:
+- **Allowed to merge**: Developers and Maintainers
+- **Allowed to push and merge**: No one
+
+If wrong, check config:
+
+```yaml
+branches:
+  - name: main
+    mergeOnly: true  # Must be true
+    default: true
+```
+
+### Approval rule for multiple branches not shown correctly in UI
+
+**Problem:**
+When you configure an approval rule in glabs for multiple branches with "any eligible user" (no specific approvers), glabs (and the GitLab API) will create only a single any-approver rule per project, covering all specified branches.
+
+**UI Limitation:**
+In the GitLab web interface, the Approvals tab may display only the first branch for which the rule applies. However, the rule is actually active for all branches listed in your glabs YAML configuration.
+
+- The rule is enforced for all configured branches, even if only one is shown in the UI.
+- This is a display issue in GitLab, not a bug in glabs or your YAML config.
+- You can verify this by creating a merge request on any of the other branches—the rule will be enforced there as well.
+
+**Example:**
+
+```yaml
+rules:
+  - name: main-review
+    branches:
+      - main
+      - startercode
+    requiredApprovals: 1
+  - name: startercode-result
+    branch: startercode
+    usernames:
+      - obcode
+    requiredApprovals: 1
+```
+
+In the GitLab UI, "Minimum required approvals" may show only `main`, but the rule also applies to `startercode`.
+
+---
+**Note:**
+This is a known GitLab behavior and cannot be changed by glabs.
 ```
 
 Then check GitLab UI for expected behavior.

--- a/git/clone.go
+++ b/git/clone.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 )

--- a/git/clone_helpers_test.go
+++ b/git/clone_helpers_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 func TestCloneurl_HTTPS(t *testing.T) {

--- a/git/clone_runtime_test.go
+++ b/git/clone_runtime_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 func TestClone_NoSpinner_CloneErrorNoPanic(t *testing.T) {

--- a/git/starterrepo.go
+++ b/git/starterrepo.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 )

--- a/gitlab/approvals.go
+++ b/gitlab/approvals.go
@@ -131,15 +131,15 @@ func (c *Client) applyMergeRequestApprovalRulesForMemberCount(assignmentCfg *con
 				continue
 			}
 
+			// Sammle alle any-approver Regeln (ohne usernames/groups) für alle Branches
 			if len(usernames) == 0 && len(groupIDs) == 0 {
 				approvalsRequired := int64(configuredRule.RequiredApprovals)
-				if anyApproverConfigured && anyApproverApprovalsRequired != approvalsRequired {
-					return fmt.Errorf("cannot configure approval rules %q and %q without usernames/groups: GitLab allows only one any-approver rule per project, but they require different approvals (%d and %d)", anyApproverRuleName, ruleName, anyApproverApprovalsRequired, approvalsRequired)
-				}
 				if !anyApproverConfigured {
 					anyApproverConfigured = true
 					anyApproverRuleName = ruleName
 					anyApproverApprovalsRequired = approvalsRequired
+				} else if anyApproverApprovalsRequired != approvalsRequired {
+					return fmt.Errorf("cannot configure multiple any-approver rules with different requiredApprovals (%d vs %d)", anyApproverApprovalsRequired, approvalsRequired)
 				}
 				anyApproverBranchIDByName[branchName] = protectedBranchID
 				continue

--- a/gitlab/approvals.go
+++ b/gitlab/approvals.go
@@ -1,0 +1,370 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/mail"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/obcode/glabs/v2/config"
+	"github.com/rs/zerolog/log"
+	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func (c *Client) applyMergeRequestApprovalRules(assignmentCfg *config.AssignmentConfig, project *gitlab.Project) error {
+	return c.applyMergeRequestApprovalRulesForMemberCount(assignmentCfg, project, 0)
+}
+
+func (c *Client) applyMergeRequestApprovalRulesForMemberCount(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, memberCount int) error {
+	if assignmentCfg.MergeRequest == nil {
+		return nil
+	}
+
+	if err := c.applyMergeRequestApprovalSettings(assignmentCfg.MergeRequest.ApprovalSettings, project); err != nil {
+		return err
+	}
+
+	if len(assignmentCfg.MergeRequest.Approvals) == 0 {
+		return nil
+	}
+
+	protectedBranches, _, err := c.ProtectedBranches.ListProtectedBranches(project.ID, nil)
+	if err != nil {
+		return fmt.Errorf("cannot list protected branches for approval rules: %w", err)
+	}
+
+	protectedBranchIDByName := make(map[string]int64, len(protectedBranches))
+	protectedBranchNames := make([]string, 0, len(protectedBranches))
+	for _, branch := range protectedBranches {
+		if branch == nil || branch.Name == "" || branch.ID <= 0 {
+			continue
+		}
+		protectedBranchIDByName[branch.Name] = branch.ID
+		protectedBranchNames = append(protectedBranchNames, branch.Name)
+	}
+
+	log.Debug().
+		Str("project", project.Name).
+		Strs("protectedBranches", protectedBranchNames).
+		Msg("protected branches found")
+
+	existingRules, _, err := c.Projects.GetProjectApprovalRules(project.ID, nil)
+	if err != nil {
+		return fmt.Errorf("cannot list existing project approval rules: %w", err)
+	}
+
+	existingByName := make(map[string]*gitlab.ProjectApprovalRule, len(existingRules))
+	var existingAnyApproverRule *gitlab.ProjectApprovalRule
+	for _, rule := range existingRules {
+		if rule == nil {
+			continue
+		}
+		if rule.RuleType == "any_approver" && existingAnyApproverRule == nil {
+			existingAnyApproverRule = rule
+		}
+		if strings.TrimSpace(rule.Name) == "" {
+			continue
+		}
+		existingByName[rule.Name] = rule
+	}
+
+	var anyApproverRuleName string
+	var anyApproverApprovalsRequired int64
+	var anyApproverConfigured bool
+	anyApproverBranchIDByName := make(map[string]int64)
+
+	for _, configuredRule := range assignmentCfg.MergeRequest.Approvals {
+		if !approvalRuleAppliesForMemberCount(configuredRule, assignmentCfg.Per, memberCount) {
+			for _, branchName := range configuredRule.Branches {
+				ruleName := approvalRuleName(configuredRule, branchName)
+				if existingRule, ok := existingByName[ruleName]; ok {
+					_, err := c.Projects.DeleteProjectApprovalRule(project.ID, existingRule.ID)
+					if err != nil {
+						return fmt.Errorf("cannot delete approval rule %q for branch %q: %w", ruleName, branchName, err)
+					}
+					delete(existingByName, ruleName)
+				}
+			}
+			continue
+		}
+
+		usernames, err := c.resolveApprovalUsernames(configuredRule.Usernames)
+		if err != nil {
+			return fmt.Errorf("cannot resolve usernames for approval rule %q: %w", configuredRule.Name, err)
+		}
+		groupIDs, err := c.resolveApprovalGroupIDs(configuredRule.Groups)
+		if err != nil {
+			return fmt.Errorf("cannot resolve groups for approval rule %q: %w", configuredRule.Name, err)
+		}
+
+		log.Debug().
+			Str("project", project.Name).
+			Str("rule", configuredRule.Name).
+			Strs("branches", configuredRule.Branches).
+			Msg("processing approval rule branches")
+
+		for _, branchName := range configuredRule.Branches {
+			protectedBranchID, ok := protectedBranchIDByName[branchName]
+			if !ok {
+				msg := fmt.Sprintf("skipping approval rule %q for branch %q in project %s: branch is not protected (configure it in branches with protect or mergeOnly)", configuredRule.Name, branchName, project.Name)
+				fmt.Printf("warning: %s\n", msg)
+				log.Warn().Str("project", project.Name).Str("rule", configuredRule.Name).Str("branch", branchName).Msg("skipping merge request approval rule for unprotected branch")
+				continue
+			}
+
+			ruleName := approvalRuleName(configuredRule, branchName)
+			if ruleName == "" {
+				return fmt.Errorf("approval rule for branch %q has no name", branchName)
+			}
+
+			branchIDs := []int64{protectedBranchID}
+			clearRule := configuredRule.RequiredApprovals == 0 && len(usernames) == 0 && len(groupIDs) == 0
+			if clearRule {
+				if existingRule, ok := existingByName[ruleName]; ok {
+					_, err := c.Projects.DeleteProjectApprovalRule(project.ID, existingRule.ID)
+					if err != nil {
+						return fmt.Errorf("cannot delete approval rule %q for branch %q: %w", ruleName, branchName, err)
+					}
+					delete(existingByName, ruleName)
+				}
+				continue
+			}
+
+			if len(usernames) == 0 && len(groupIDs) == 0 {
+				approvalsRequired := int64(configuredRule.RequiredApprovals)
+				if anyApproverConfigured && anyApproverApprovalsRequired != approvalsRequired {
+					return fmt.Errorf("cannot configure approval rules %q and %q without usernames/groups: GitLab allows only one any-approver rule per project, but they require different approvals (%d and %d)", anyApproverRuleName, ruleName, anyApproverApprovalsRequired, approvalsRequired)
+				}
+				if !anyApproverConfigured {
+					anyApproverConfigured = true
+					anyApproverRuleName = ruleName
+					anyApproverApprovalsRequired = approvalsRequired
+				}
+				anyApproverBranchIDByName[branchName] = protectedBranchID
+				continue
+			}
+
+			approvalsRequired := int64(configuredRule.RequiredApprovals)
+			createOpts := &gitlab.CreateProjectLevelRuleOptions{
+				Name:                          gitlab.Ptr(ruleName),
+				ApprovalsRequired:             gitlab.Ptr(approvalsRequired),
+				Usernames:                     &usernames,
+				GroupIDs:                      &groupIDs,
+				ProtectedBranchIDs:            &branchIDs,
+				AppliesToAllProtectedBranches: gitlab.Ptr(false),
+			}
+
+			if existingRule, ok := existingByName[ruleName]; ok {
+				updateOpts := &gitlab.UpdateProjectLevelRuleOptions{
+					Name:                          gitlab.Ptr(ruleName),
+					ApprovalsRequired:             gitlab.Ptr(approvalsRequired),
+					Usernames:                     &usernames,
+					GroupIDs:                      &groupIDs,
+					ProtectedBranchIDs:            &branchIDs,
+					AppliesToAllProtectedBranches: gitlab.Ptr(false),
+				}
+				_, _, err = c.Projects.UpdateProjectApprovalRule(project.ID, existingRule.ID, updateOpts)
+				if err != nil {
+					return fmt.Errorf("cannot update approval rule %q for branch %q: %w", ruleName, branchName, err)
+				}
+				continue
+			}
+
+			_, _, err = c.Projects.CreateProjectApprovalRule(project.ID, createOpts)
+			if err != nil {
+				return fmt.Errorf("cannot create approval rule %q for branch %q: %w", ruleName, branchName, err)
+			}
+		}
+	}
+
+	if anyApproverConfigured {
+		branchNames := make([]string, 0, len(anyApproverBranchIDByName))
+		for branchName := range anyApproverBranchIDByName {
+			branchNames = append(branchNames, branchName)
+		}
+		sort.Strings(branchNames)
+
+		branchIDs := make([]int64, 0, len(branchNames))
+		for _, branchName := range branchNames {
+			branchIDs = append(branchIDs, anyApproverBranchIDByName[branchName])
+		}
+
+		if existingAnyApproverRule != nil {
+			updateOpts := &gitlab.UpdateProjectLevelRuleOptions{
+				Name:                          gitlab.Ptr(anyApproverRuleName),
+				ApprovalsRequired:             gitlab.Ptr(anyApproverApprovalsRequired),
+				ProtectedBranchIDs:            &branchIDs,
+				AppliesToAllProtectedBranches: gitlab.Ptr(false),
+			}
+			_, _, err = c.Projects.UpdateProjectApprovalRule(project.ID, existingAnyApproverRule.ID, updateOpts)
+			if err != nil {
+				return fmt.Errorf("cannot update any-approver approval rule for branches %v: %w", branchNames, err)
+			}
+		} else {
+			createOpts := &gitlab.CreateProjectLevelRuleOptions{
+				Name:                          gitlab.Ptr(anyApproverRuleName),
+				ApprovalsRequired:             gitlab.Ptr(anyApproverApprovalsRequired),
+				RuleType:                      gitlab.Ptr("any_approver"),
+				ProtectedBranchIDs:            &branchIDs,
+				AppliesToAllProtectedBranches: gitlab.Ptr(false),
+			}
+			_, _, err = c.Projects.CreateProjectApprovalRule(project.ID, createOpts)
+			if err != nil {
+				return fmt.Errorf("cannot create any-approver approval rule for branches %v: %w", branchNames, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) applyMergeRequestApprovalSettings(settings *config.MergeRequestApprovalSettings, project *gitlab.Project) error {
+	if settings == nil {
+		return nil
+	}
+
+	opts := &gitlab.ChangeApprovalConfigurationOptions{}
+	configured := false
+
+	if settings.PreventApprovalByMergeRequestCreator != nil {
+		v := !*settings.PreventApprovalByMergeRequestCreator
+		opts.MergeRequestsAuthorApproval = &v
+		configured = true
+	}
+	if settings.PreventApprovalsByUsersWhoAddCommits != nil {
+		v := *settings.PreventApprovalsByUsersWhoAddCommits
+		opts.MergeRequestsDisableCommittersApproval = &v
+		configured = true
+	}
+	if settings.PreventEditingApprovalRulesInMergeRequests != nil {
+		v := *settings.PreventEditingApprovalRulesInMergeRequests
+		opts.DisableOverridingApproversPerMergeRequest = &v
+		configured = true
+	}
+	if settings.RequireUserReauthenticationToApprove != nil {
+		v := *settings.RequireUserReauthenticationToApprove
+		opts.RequireReauthenticationToApprove = &v
+		configured = true
+	}
+	if settings.WhenCommitAdded != nil {
+		switch *settings.WhenCommitAdded {
+		case config.ApprovalKeepApprovals:
+			reset := false
+			selective := false
+			opts.ResetApprovalsOnPush = &reset
+			opts.SelectiveCodeOwnerRemovals = &selective
+		case config.ApprovalRemoveAllApprovals:
+			reset := true
+			selective := false
+			opts.ResetApprovalsOnPush = &reset
+			opts.SelectiveCodeOwnerRemovals = &selective
+		case config.ApprovalRemoveCodeOwnerApprovalsIfFilesChanged:
+			reset := false
+			selective := true
+			opts.ResetApprovalsOnPush = &reset
+			opts.SelectiveCodeOwnerRemovals = &selective
+		default:
+			return fmt.Errorf("unsupported approval setting whenCommitAdded=%q", *settings.WhenCommitAdded)
+		}
+		configured = true
+	}
+
+	if !configured {
+		return nil
+	}
+
+	_, _, err := c.Projects.ChangeApprovalConfiguration(project.ID, opts)
+	if err != nil {
+		return fmt.Errorf("cannot set merge request approval settings for project %s: %w", project.Name, err)
+	}
+
+	return nil
+}
+
+func approvalRuleName(rule config.MergeRequestApprovalRule, branchName string) string {
+	if rule.Name == "" {
+		return fmt.Sprintf("glabs-approval-%s", branchName)
+	}
+	if len(rule.Branches) <= 1 {
+		return rule.Name
+	}
+	return fmt.Sprintf("%s-%s", rule.Name, branchName)
+}
+
+func approvalRuleAppliesForMemberCount(rule config.MergeRequestApprovalRule, per config.Per, memberCount int) bool {
+	if !rule.MultiMemberGroupsOnly {
+		return true
+	}
+	if per != config.PerGroup {
+		return false
+	}
+	return memberCount > 1
+}
+
+func (c *Client) resolveApprovalUsernames(identifiers []string) ([]string, error) {
+	usernames := make([]string, 0, len(identifiers))
+	seenUsernames := make(map[string]struct{})
+
+	for _, identifier := range identifiers {
+		identifier = strings.TrimSpace(identifier)
+		if identifier == "" {
+			continue
+		}
+
+		if _, err := mail.ParseAddress(identifier); err == nil {
+			return nil, fmt.Errorf("email %q is not supported for mergeRequest.approvals.rules[].usernames; use username", identifier)
+		}
+
+		if isNumericIdentifier(identifier) {
+			return nil, fmt.Errorf("numeric id %q is not supported for mergeRequest.approvals.rules[].usernames; use username", identifier)
+		}
+
+		username := strings.TrimSpace(strings.TrimPrefix(identifier, "@"))
+		if username == "" {
+			return nil, fmt.Errorf("invalid username %q in mergeRequest.approvals.rules[].usernames", identifier)
+		}
+		if _, ok := seenUsernames[username]; ok {
+			continue
+		}
+		seenUsernames[username] = struct{}{}
+		usernames = append(usernames, username)
+	}
+
+	return usernames, nil
+}
+
+func (c *Client) resolveApprovalGroupIDs(identifiers []string) ([]int64, error) {
+	ids := make([]int64, 0, len(identifiers))
+	seen := make(map[int64]struct{})
+
+	for _, identifier := range identifiers {
+		var id int64
+		if isNumericIdentifier(identifier) {
+			parsed, _ := strconv.ParseInt(identifier, 10, 64)
+			id = parsed
+		} else {
+			resolved, err := c.getGroupIDByFullPath(identifier)
+			if err != nil {
+				return nil, fmt.Errorf("cannot resolve group %q: %w", identifier, err)
+			}
+			id = resolved
+		}
+
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
+func isNumericIdentifier(value string) bool {
+	if strings.HasPrefix(value, "0") {
+		return false
+	}
+	_, err := strconv.Atoi(value)
+	return err == nil
+}

--- a/gitlab/approvals.go
+++ b/gitlab/approvals.go
@@ -1,0 +1,370 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/mail"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/obcode/glabs/config"
+	"github.com/rs/zerolog/log"
+	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func (c *Client) applyMergeRequestApprovalRules(assignmentCfg *config.AssignmentConfig, project *gitlab.Project) error {
+	return c.applyMergeRequestApprovalRulesForMemberCount(assignmentCfg, project, 0)
+}
+
+func (c *Client) applyMergeRequestApprovalRulesForMemberCount(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, memberCount int) error {
+	if assignmentCfg.MergeRequest == nil {
+		return nil
+	}
+
+	if err := c.applyMergeRequestApprovalSettings(assignmentCfg.MergeRequest.ApprovalSettings, project); err != nil {
+		return err
+	}
+
+	if len(assignmentCfg.MergeRequest.Approvals) == 0 {
+		return nil
+	}
+
+	protectedBranches, _, err := c.ProtectedBranches.ListProtectedBranches(project.ID, nil)
+	if err != nil {
+		return fmt.Errorf("cannot list protected branches for approval rules: %w", err)
+	}
+
+	protectedBranchIDByName := make(map[string]int64, len(protectedBranches))
+	protectedBranchNames := make([]string, 0, len(protectedBranches))
+	for _, branch := range protectedBranches {
+		if branch == nil || branch.Name == "" || branch.ID <= 0 {
+			continue
+		}
+		protectedBranchIDByName[branch.Name] = branch.ID
+		protectedBranchNames = append(protectedBranchNames, branch.Name)
+	}
+
+	log.Debug().
+		Str("project", project.Name).
+		Strs("protectedBranches", protectedBranchNames).
+		Msg("protected branches found")
+
+	existingRules, _, err := c.Projects.GetProjectApprovalRules(project.ID, nil)
+	if err != nil {
+		return fmt.Errorf("cannot list existing project approval rules: %w", err)
+	}
+
+	existingByName := make(map[string]*gitlab.ProjectApprovalRule, len(existingRules))
+	var existingAnyApproverRule *gitlab.ProjectApprovalRule
+	for _, rule := range existingRules {
+		if rule == nil {
+			continue
+		}
+		if rule.RuleType == "any_approver" && existingAnyApproverRule == nil {
+			existingAnyApproverRule = rule
+		}
+		if strings.TrimSpace(rule.Name) == "" {
+			continue
+		}
+		existingByName[rule.Name] = rule
+	}
+
+	var anyApproverRuleName string
+	var anyApproverApprovalsRequired int64
+	var anyApproverConfigured bool
+	anyApproverBranchIDByName := make(map[string]int64)
+
+	for _, configuredRule := range assignmentCfg.MergeRequest.Approvals {
+		if !approvalRuleAppliesForMemberCount(configuredRule, assignmentCfg.Per, memberCount) {
+			for _, branchName := range configuredRule.Branches {
+				ruleName := approvalRuleName(configuredRule, branchName)
+				if existingRule, ok := existingByName[ruleName]; ok {
+					_, err := c.Projects.DeleteProjectApprovalRule(project.ID, existingRule.ID)
+					if err != nil {
+						return fmt.Errorf("cannot delete approval rule %q for branch %q: %w", ruleName, branchName, err)
+					}
+					delete(existingByName, ruleName)
+				}
+			}
+			continue
+		}
+
+		usernames, err := c.resolveApprovalUsernames(configuredRule.Usernames)
+		if err != nil {
+			return fmt.Errorf("cannot resolve usernames for approval rule %q: %w", configuredRule.Name, err)
+		}
+		groupIDs, err := c.resolveApprovalGroupIDs(configuredRule.Groups)
+		if err != nil {
+			return fmt.Errorf("cannot resolve groups for approval rule %q: %w", configuredRule.Name, err)
+		}
+
+		log.Debug().
+			Str("project", project.Name).
+			Str("rule", configuredRule.Name).
+			Strs("branches", configuredRule.Branches).
+			Msg("processing approval rule branches")
+
+		for _, branchName := range configuredRule.Branches {
+			protectedBranchID, ok := protectedBranchIDByName[branchName]
+			if !ok {
+				msg := fmt.Sprintf("skipping approval rule %q for branch %q in project %s: branch is not protected (configure it in branches with protect or mergeOnly)", configuredRule.Name, branchName, project.Name)
+				fmt.Printf("warning: %s\n", msg)
+				log.Warn().Str("project", project.Name).Str("rule", configuredRule.Name).Str("branch", branchName).Msg("skipping merge request approval rule for unprotected branch")
+				continue
+			}
+
+			ruleName := approvalRuleName(configuredRule, branchName)
+			if ruleName == "" {
+				return fmt.Errorf("approval rule for branch %q has no name", branchName)
+			}
+
+			branchIDs := []int64{protectedBranchID}
+			clearRule := configuredRule.RequiredApprovals == 0 && len(usernames) == 0 && len(groupIDs) == 0
+			if clearRule {
+				if existingRule, ok := existingByName[ruleName]; ok {
+					_, err := c.Projects.DeleteProjectApprovalRule(project.ID, existingRule.ID)
+					if err != nil {
+						return fmt.Errorf("cannot delete approval rule %q for branch %q: %w", ruleName, branchName, err)
+					}
+					delete(existingByName, ruleName)
+				}
+				continue
+			}
+
+			if len(usernames) == 0 && len(groupIDs) == 0 {
+				approvalsRequired := int64(configuredRule.RequiredApprovals)
+				if anyApproverConfigured && anyApproverApprovalsRequired != approvalsRequired {
+					return fmt.Errorf("cannot configure approval rules %q and %q without usernames/groups: GitLab allows only one any-approver rule per project, but they require different approvals (%d and %d)", anyApproverRuleName, ruleName, anyApproverApprovalsRequired, approvalsRequired)
+				}
+				if !anyApproverConfigured {
+					anyApproverConfigured = true
+					anyApproverRuleName = ruleName
+					anyApproverApprovalsRequired = approvalsRequired
+				}
+				anyApproverBranchIDByName[branchName] = protectedBranchID
+				continue
+			}
+
+			approvalsRequired := int64(configuredRule.RequiredApprovals)
+			createOpts := &gitlab.CreateProjectLevelRuleOptions{
+				Name:                          gitlab.Ptr(ruleName),
+				ApprovalsRequired:             gitlab.Ptr(approvalsRequired),
+				Usernames:                     &usernames,
+				GroupIDs:                      &groupIDs,
+				ProtectedBranchIDs:            &branchIDs,
+				AppliesToAllProtectedBranches: gitlab.Ptr(false),
+			}
+
+			if existingRule, ok := existingByName[ruleName]; ok {
+				updateOpts := &gitlab.UpdateProjectLevelRuleOptions{
+					Name:                          gitlab.Ptr(ruleName),
+					ApprovalsRequired:             gitlab.Ptr(approvalsRequired),
+					Usernames:                     &usernames,
+					GroupIDs:                      &groupIDs,
+					ProtectedBranchIDs:            &branchIDs,
+					AppliesToAllProtectedBranches: gitlab.Ptr(false),
+				}
+				_, _, err = c.Projects.UpdateProjectApprovalRule(project.ID, existingRule.ID, updateOpts)
+				if err != nil {
+					return fmt.Errorf("cannot update approval rule %q for branch %q: %w", ruleName, branchName, err)
+				}
+				continue
+			}
+
+			_, _, err = c.Projects.CreateProjectApprovalRule(project.ID, createOpts)
+			if err != nil {
+				return fmt.Errorf("cannot create approval rule %q for branch %q: %w", ruleName, branchName, err)
+			}
+		}
+	}
+
+	if anyApproverConfigured {
+		branchNames := make([]string, 0, len(anyApproverBranchIDByName))
+		for branchName := range anyApproverBranchIDByName {
+			branchNames = append(branchNames, branchName)
+		}
+		sort.Strings(branchNames)
+
+		branchIDs := make([]int64, 0, len(branchNames))
+		for _, branchName := range branchNames {
+			branchIDs = append(branchIDs, anyApproverBranchIDByName[branchName])
+		}
+
+		if existingAnyApproverRule != nil {
+			updateOpts := &gitlab.UpdateProjectLevelRuleOptions{
+				Name:                          gitlab.Ptr(anyApproverRuleName),
+				ApprovalsRequired:             gitlab.Ptr(anyApproverApprovalsRequired),
+				ProtectedBranchIDs:            &branchIDs,
+				AppliesToAllProtectedBranches: gitlab.Ptr(false),
+			}
+			_, _, err = c.Projects.UpdateProjectApprovalRule(project.ID, existingAnyApproverRule.ID, updateOpts)
+			if err != nil {
+				return fmt.Errorf("cannot update any-approver approval rule for branches %v: %w", branchNames, err)
+			}
+		} else {
+			createOpts := &gitlab.CreateProjectLevelRuleOptions{
+				Name:                          gitlab.Ptr(anyApproverRuleName),
+				ApprovalsRequired:             gitlab.Ptr(anyApproverApprovalsRequired),
+				RuleType:                      gitlab.Ptr("any_approver"),
+				ProtectedBranchIDs:            &branchIDs,
+				AppliesToAllProtectedBranches: gitlab.Ptr(false),
+			}
+			_, _, err = c.Projects.CreateProjectApprovalRule(project.ID, createOpts)
+			if err != nil {
+				return fmt.Errorf("cannot create any-approver approval rule for branches %v: %w", branchNames, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) applyMergeRequestApprovalSettings(settings *config.MergeRequestApprovalSettings, project *gitlab.Project) error {
+	if settings == nil {
+		return nil
+	}
+
+	opts := &gitlab.ChangeApprovalConfigurationOptions{}
+	configured := false
+
+	if settings.PreventApprovalByMergeRequestCreator != nil {
+		v := !*settings.PreventApprovalByMergeRequestCreator
+		opts.MergeRequestsAuthorApproval = &v
+		configured = true
+	}
+	if settings.PreventApprovalsByUsersWhoAddCommits != nil {
+		v := *settings.PreventApprovalsByUsersWhoAddCommits
+		opts.MergeRequestsDisableCommittersApproval = &v
+		configured = true
+	}
+	if settings.PreventEditingApprovalRulesInMergeRequests != nil {
+		v := *settings.PreventEditingApprovalRulesInMergeRequests
+		opts.DisableOverridingApproversPerMergeRequest = &v
+		configured = true
+	}
+	if settings.RequireUserReauthenticationToApprove != nil {
+		v := *settings.RequireUserReauthenticationToApprove
+		opts.RequireReauthenticationToApprove = &v
+		configured = true
+	}
+	if settings.WhenCommitAdded != nil {
+		switch *settings.WhenCommitAdded {
+		case config.ApprovalKeepApprovals:
+			reset := false
+			selective := false
+			opts.ResetApprovalsOnPush = &reset
+			opts.SelectiveCodeOwnerRemovals = &selective
+		case config.ApprovalRemoveAllApprovals:
+			reset := true
+			selective := false
+			opts.ResetApprovalsOnPush = &reset
+			opts.SelectiveCodeOwnerRemovals = &selective
+		case config.ApprovalRemoveCodeOwnerApprovalsIfFilesChanged:
+			reset := false
+			selective := true
+			opts.ResetApprovalsOnPush = &reset
+			opts.SelectiveCodeOwnerRemovals = &selective
+		default:
+			return fmt.Errorf("unsupported approval setting whenCommitAdded=%q", *settings.WhenCommitAdded)
+		}
+		configured = true
+	}
+
+	if !configured {
+		return nil
+	}
+
+	_, _, err := c.Projects.ChangeApprovalConfiguration(project.ID, opts)
+	if err != nil {
+		return fmt.Errorf("cannot set merge request approval settings for project %s: %w", project.Name, err)
+	}
+
+	return nil
+}
+
+func approvalRuleName(rule config.MergeRequestApprovalRule, branchName string) string {
+	if rule.Name == "" {
+		return fmt.Sprintf("glabs-approval-%s", branchName)
+	}
+	if len(rule.Branches) <= 1 {
+		return rule.Name
+	}
+	return fmt.Sprintf("%s-%s", rule.Name, branchName)
+}
+
+func approvalRuleAppliesForMemberCount(rule config.MergeRequestApprovalRule, per config.Per, memberCount int) bool {
+	if !rule.MultiMemberGroupsOnly {
+		return true
+	}
+	if per != config.PerGroup {
+		return false
+	}
+	return memberCount > 1
+}
+
+func (c *Client) resolveApprovalUsernames(identifiers []string) ([]string, error) {
+	usernames := make([]string, 0, len(identifiers))
+	seenUsernames := make(map[string]struct{})
+
+	for _, identifier := range identifiers {
+		identifier = strings.TrimSpace(identifier)
+		if identifier == "" {
+			continue
+		}
+
+		if _, err := mail.ParseAddress(identifier); err == nil {
+			return nil, fmt.Errorf("email %q is not supported for mergeRequest.approvals.rules[].usernames; use username", identifier)
+		}
+
+		if isNumericIdentifier(identifier) {
+			return nil, fmt.Errorf("numeric id %q is not supported for mergeRequest.approvals.rules[].usernames; use username", identifier)
+		}
+
+		username := strings.TrimSpace(strings.TrimPrefix(identifier, "@"))
+		if username == "" {
+			return nil, fmt.Errorf("invalid username %q in mergeRequest.approvals.rules[].usernames", identifier)
+		}
+		if _, ok := seenUsernames[username]; ok {
+			continue
+		}
+		seenUsernames[username] = struct{}{}
+		usernames = append(usernames, username)
+	}
+
+	return usernames, nil
+}
+
+func (c *Client) resolveApprovalGroupIDs(identifiers []string) ([]int64, error) {
+	ids := make([]int64, 0, len(identifiers))
+	seen := make(map[int64]struct{})
+
+	for _, identifier := range identifiers {
+		var id int64
+		if isNumericIdentifier(identifier) {
+			parsed, _ := strconv.ParseInt(identifier, 10, 64)
+			id = parsed
+		} else {
+			resolved, err := c.getGroupIDByFullPath(identifier)
+			if err != nil {
+				return nil, fmt.Errorf("cannot resolve group %q: %w", identifier, err)
+			}
+			id = resolved
+		}
+
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
+func isNumericIdentifier(value string) bool {
+	if strings.HasPrefix(value, "0") {
+		return false
+	}
+	_, err := strconv.Atoi(value)
+	return err == nil
+}

--- a/gitlab/archive.go
+++ b/gitlab/archive.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"

--- a/gitlab/archive_contract_test.go
+++ b/gitlab/archive_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/branches.go
+++ b/gitlab/branches.go
@@ -41,6 +41,7 @@ func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, 
 
 	if err := c.protectBranch(assignmentCfg, project, false); err != nil {
 		log.Debug().Err(err).Str("project", project.Name).Msg("cannot protect configured branches")
+		return fmt.Errorf("error while protecting configured branches for %s: %w", project.Name, err)
 	}
 
 	return nil

--- a/gitlab/branches.go
+++ b/gitlab/branches.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/obcode/glabs/config"
-	"github.com/rs/zerolog/log"
+	"github.com/obcode/glabs/v2/config"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, baseBranch string) error {
+func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, baseBranch string, memberCount int) error {
 	if len(assignmentCfg.Branches) == 0 {
 		return nil
 	}
@@ -39,12 +38,7 @@ func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, 
 		return fmt.Errorf("error while switching default branch to %s: %w", defaultBranch, err)
 	}
 
-	if err := c.protectBranch(assignmentCfg, project, false); err != nil {
-		log.Debug().Err(err).Str("project", project.Name).Msg("cannot protect configured branches")
-		return fmt.Errorf("error while protecting configured branches for %s: %w", project.Name, err)
-	}
-
-	return nil
+	return c.protectBranchForMemberCount(assignmentCfg, project, false, memberCount)
 }
 
 func defaultBranchName(branches []config.BranchRule, fallback string) string {

--- a/gitlab/branches.go
+++ b/gitlab/branches.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 
 	"github.com/obcode/glabs/config"
-	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, baseBranch string) error {
+func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, baseBranch string, memberCount int) error {
 	if len(assignmentCfg.Branches) == 0 {
 		return nil
 	}
@@ -39,11 +38,7 @@ func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, 
 		return fmt.Errorf("error while switching default branch to %s: %w", defaultBranch, err)
 	}
 
-	if err := c.protectBranch(assignmentCfg, project, false); err != nil {
-		log.Debug().Err(err).Str("project", project.Name).Msg("cannot protect configured branches")
-	}
-
-	return nil
+	return c.protectBranchForMemberCount(assignmentCfg, project, false, memberCount)
 }
 
 func defaultBranchName(branches []config.BranchRule, fallback string) string {

--- a/gitlab/branches.go
+++ b/gitlab/branches.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 
 	"github.com/obcode/glabs/config"
-	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, baseBranch string) error {
+func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, baseBranch string, memberCount int) error {
 	if len(assignmentCfg.Branches) == 0 {
 		return nil
 	}
@@ -39,12 +38,7 @@ func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, 
 		return fmt.Errorf("error while switching default branch to %s: %w", defaultBranch, err)
 	}
 
-	if err := c.protectBranch(assignmentCfg, project, false); err != nil {
-		log.Debug().Err(err).Str("project", project.Name).Msg("cannot protect configured branches")
-		return fmt.Errorf("error while protecting configured branches for %s: %w", project.Name, err)
-	}
-
-	return nil
+	return c.protectBranchForMemberCount(assignmentCfg, project, false, memberCount)
 }
 
 func defaultBranchName(branches []config.BranchRule, fallback string) string {

--- a/gitlab/branches.go
+++ b/gitlab/branches.go
@@ -10,6 +10,9 @@ import (
 
 func (c *Client) syncConfiguredBranches(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, baseBranch string, memberCount int) error {
 	if len(assignmentCfg.Branches) == 0 {
+		if hasMergeRequestApprovalConfig(assignmentCfg.MergeRequest) {
+			return c.protectBranchForMemberCount(assignmentCfg, project, false, memberCount)
+		}
 		return nil
 	}
 

--- a/gitlab/branches_contract_test.go
+++ b/gitlab/branches_contract_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
@@ -31,7 +31,7 @@ func TestSyncConfiguredBranches_ReturnsErrorWhenProtectionFails(t *testing.T) {
 	}
 	project := &gitlabapi.Project{ID: 1, Name: "repo"}
 
-	err := client.syncConfiguredBranches(cfg, project, "main")
+	err := client.syncConfiguredBranches(cfg, project, "main", 0)
 	if err == nil {
 		t.Fatal("syncConfiguredBranches() expected error when branch protection fails, got nil")
 	}

--- a/gitlab/branches_contract_test.go
+++ b/gitlab/branches_contract_test.go
@@ -31,7 +31,7 @@ func TestSyncConfiguredBranches_ReturnsErrorWhenProtectionFails(t *testing.T) {
 	}
 	project := &gitlabapi.Project{ID: 1, Name: "repo"}
 
-	err := client.syncConfiguredBranches(cfg, project, "main")
+	err := client.syncConfiguredBranches(cfg, project, "main", 0)
 	if err == nil {
 		t.Fatal("syncConfiguredBranches() expected error when branch protection fails, got nil")
 	}

--- a/gitlab/branches_contract_test.go
+++ b/gitlab/branches_contract_test.go
@@ -1,0 +1,38 @@
+package gitlab
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/obcode/glabs/config"
+	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func TestSyncConfiguredBranches_ReturnsErrorWhenProtectionFails(t *testing.T) {
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v4/projects/1":
+			_, _ = w.Write([]byte(`{"id":1,"name":"repo"}`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/v4/projects/1/protected_branches/main"):
+			_, _ = w.Write([]byte(`{"id":1,"name":"main","push_access_levels":[{"id":10,"access_level":40}],"merge_access_levels":[{"id":11,"access_level":40}],"unprotect_access_levels":[{"id":12,"access_level":40}]}`))
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/api/v4/projects/1/protected_branches/main"):
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/api/v4/projects/1/protected_branches"):
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"500 Internal Server Error"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Branches: []config.BranchRule{{Name: "main", MergeOnly: true, Default: true}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "repo"}
+
+	err := client.syncConfiguredBranches(cfg, project, "main")
+	if err == nil {
+		t.Fatal("syncConfiguredBranches() expected error when branch protection fails, got nil")
+	}
+}

--- a/gitlab/check.go
+++ b/gitlab/check.go
@@ -2,7 +2,7 @@ package gitlab
 
 import (
 	"github.com/gookit/color"
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 )
 

--- a/gitlab/check_test.go
+++ b/gitlab/check_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/delete.go
+++ b/gitlab/delete.go
@@ -3,7 +3,7 @@ package gitlab
 import (
 	"fmt"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/delete_contract_test.go
+++ b/gitlab/delete_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 // groupSearchHandler returns a handler that mocks getGroupID + Search.ProjectsByGroup + DeleteProject.

--- a/gitlab/generate.go
+++ b/gitlab/generate.go
@@ -169,8 +169,9 @@ func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGrou
 			baseBranch = assignmentCfg.Seeder.ToBranch
 		}
 
-		if err := c.syncConfiguredBranches(assignmentCfg, project, baseBranch); err != nil {
-			log.Debug().Err(err).Str("project", project.Name).Msg("cannot apply configured branch rules")
+		if err := c.syncConfiguredBranches(assignmentCfg, project, baseBranch, len(members)); err != nil {
+			log.Error().Err(err).Str("project", project.Name).Msg("cannot apply configured branch rules")
+			fmt.Printf("error: cannot apply branch/approval rules for project %s: %v\n", project.Name, err)
 		}
 	}
 

--- a/gitlab/generate.go
+++ b/gitlab/generate.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/git"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/git"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 )
@@ -169,8 +169,9 @@ func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGrou
 			baseBranch = assignmentCfg.Seeder.ToBranch
 		}
 
-		if err := c.syncConfiguredBranches(assignmentCfg, project, baseBranch); err != nil {
-			log.Debug().Err(err).Str("project", project.Name).Msg("cannot apply configured branch rules")
+		if err := c.syncConfiguredBranches(assignmentCfg, project, baseBranch, len(members)); err != nil {
+			log.Error().Err(err).Str("project", project.Name).Msg("cannot apply configured branch rules")
+			fmt.Printf("error: cannot apply branch/approval rules for project %s: %v\n", project.Name, err)
 		}
 	}
 

--- a/gitlab/groups.go
+++ b/gitlab/groups.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/groups_contract_test.go
+++ b/gitlab/groups_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 func TestGetGroupIDByFullPath_FindsGroup(t *testing.T) {

--- a/gitlab/integration_gitlab_test.go
+++ b/gitlab/integration_gitlab_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"

--- a/gitlab/issues.go
+++ b/gitlab/issues.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/issues_contract_test.go
+++ b/gitlab/issues_contract_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/projects.go
+++ b/gitlab/projects.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/projects_contract_test.go
+++ b/gitlab/projects_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 func TestGetProjectByName_FindsSingleProject(t *testing.T) {

--- a/gitlab/protect.go
+++ b/gitlab/protect.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
@@ -31,70 +31,85 @@ func (c *Client) ProtectToBranch(assignmentCfg *config.AssignmentConfig) {
 }
 
 func (c *Client) protectBranch(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, spin bool) error {
-	if hasProtectedBranches(assignmentCfg.Branches) {
-		// var cfg yacspin.Config
-		var spinner *yacspin.Spinner
-		if spin {
-			cfg := yacspin.Config{
-				Frequency: 100 * time.Millisecond,
-				CharSet:   yacspin.CharSets[69],
-				Suffix: aurora.Sprintf(aurora.Cyan(" protect branch for project %s at %s"),
-					aurora.Yellow(project.Name),
-					aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
-				),
-				SuffixAutoColon:   true,
-				StopCharacter:     "✓",
-				StopColors:        []string{"fgGreen"},
-				StopFailMessage:   "error",
-				StopFailCharacter: "✗",
-				StopFailColors:    []string{"fgRed"},
-			}
-			var err error
-			spinner, err = yacspin.New(cfg)
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot create spinner")
-			}
-			err = spinner.Start()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot start spinner")
-			}
+	return c.protectBranchForMemberCount(assignmentCfg, project, spin, 0)
+}
+
+func (c *Client) protectBranchForMemberCount(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, spin bool, memberCount int) error {
+	if !hasProtectedBranches(assignmentCfg.Branches) && !hasMergeRequestApprovalConfig(assignmentCfg.MergeRequest) {
+		return nil
+	}
+
+	var spinner *yacspin.Spinner
+	if spin {
+		cfg := yacspin.Config{
+			Frequency: 100 * time.Millisecond,
+			CharSet:   yacspin.CharSets[69],
+			Suffix: aurora.Sprintf(aurora.Cyan(" protect branch for project %s at %s"),
+				aurora.Yellow(project.Name),
+				aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
+			),
+			SuffixAutoColon:   true,
+			StopCharacter:     "✓",
+			StopColors:        []string{"fgGreen"},
+			StopFailMessage:   "error",
+			StopFailCharacter: "✗",
+			StopFailColors:    []string{"fgRed"},
+		}
+		var err error
+		spinner, err = yacspin.New(cfg)
+		if err != nil {
+			log.Debug().Err(err).Msg("cannot create spinner")
+		}
+		err = spinner.Start()
+		if err != nil {
+			log.Debug().Err(err).Msg("cannot start spinner")
+		}
+	}
+
+	log.Debug().
+		Str("name", project.Name).
+		Str("toURL", project.SSHURLToRepo).
+		Interface("branches", assignmentCfg.Branches).
+		Msg("protecting branch")
+
+	for _, branch := range assignmentCfg.Branches {
+		if !branch.Protect && !branch.MergeOnly {
+			continue
 		}
 
-		log.Debug().
-			Str("name", project.Name).
-			Str("toURL", project.SSHURLToRepo).
-			Interface("branches", assignmentCfg.Branches).
-			Msg("protecting branch")
+		pushLevel := gitlab.MaintainerPermissions
+		mergeLevel := gitlab.MaintainerPermissions
+		if branch.MergeOnly {
+			pushLevel = gitlab.NoPermissions
+			mergeLevel = gitlab.DeveloperPermissions
+		}
 
-		for _, branch := range assignmentCfg.Branches {
-			if !branch.Protect && !branch.MergeOnly {
-				continue
-			}
-
-			pushLevel := gitlab.MaintainerPermissions
-			mergeLevel := gitlab.MaintainerPermissions
-			if branch.MergeOnly {
-				pushLevel = gitlab.NoPermissions
-				mergeLevel = gitlab.DeveloperPermissions
-			}
-
-			err := c.protectSingleBranch(project, branch, pushLevel, mergeLevel)
-			if err != nil {
-				if spin {
-					err := spinner.StopFail()
-					if err != nil {
-						log.Debug().Err(err).Msg("cannot stop spinner")
-					}
+		err := c.protectSingleBranch(project, branch, pushLevel, mergeLevel)
+		if err != nil {
+			if spin {
+				err := spinner.StopFail()
+				if err != nil {
+					log.Debug().Err(err).Msg("cannot stop spinner")
 				}
-				return err
 			}
+			return err
 		}
+	}
 
+	if err := c.applyMergeRequestApprovalRulesForMemberCount(assignmentCfg, project, memberCount); err != nil {
 		if spin {
-			spinner.StopMessage(aurora.Sprintf(aurora.Green("ok")))
-			if err := spinner.Stop(); err != nil {
+			err := spinner.StopFail()
+			if err != nil {
 				log.Debug().Err(err).Msg("cannot stop spinner")
 			}
+		}
+		return err
+	}
+
+	if spin {
+		spinner.StopMessage(aurora.Sprintf(aurora.Green("ok")))
+		if err := spinner.Stop(); err != nil {
+			log.Debug().Err(err).Msg("cannot stop spinner")
 		}
 	}
 
@@ -109,6 +124,14 @@ func hasProtectedBranches(branches []config.BranchRule) bool {
 	}
 
 	return false
+}
+
+func hasMergeRequestApprovalConfig(mergeRequest *config.MergeRequest) bool {
+	if mergeRequest == nil {
+		return false
+	}
+
+	return len(mergeRequest.Approvals) > 0 || mergeRequest.ApprovalSettings != nil
 }
 
 func (c *Client) protectSingleBranch(
@@ -244,7 +267,7 @@ func (c *Client) protectToBranchPerStudent(assignmentCfg *config.AssignmentConfi
 			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
 			return
 		}
-		if err := c.protectBranch(assignmentCfg, project, true); err != nil {
+		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, 1); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot protect the branch")
 		}
 	}
@@ -266,7 +289,7 @@ func (c *Client) protectToBranchPerGroup(assignmentCfg *config.AssignmentConfig)
 			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
 			return
 		}
-		if err := c.protectBranch(assignmentCfg, project, true); err != nil {
+		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, len(grp.Members)); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot protect the branch")
 		}
 	}

--- a/gitlab/protect.go
+++ b/gitlab/protect.go
@@ -31,70 +31,85 @@ func (c *Client) ProtectToBranch(assignmentCfg *config.AssignmentConfig) {
 }
 
 func (c *Client) protectBranch(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, spin bool) error {
-	if hasProtectedBranches(assignmentCfg.Branches) {
-		// var cfg yacspin.Config
-		var spinner *yacspin.Spinner
-		if spin {
-			cfg := yacspin.Config{
-				Frequency: 100 * time.Millisecond,
-				CharSet:   yacspin.CharSets[69],
-				Suffix: aurora.Sprintf(aurora.Cyan(" protect branch for project %s at %s"),
-					aurora.Yellow(project.Name),
-					aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
-				),
-				SuffixAutoColon:   true,
-				StopCharacter:     "✓",
-				StopColors:        []string{"fgGreen"},
-				StopFailMessage:   "error",
-				StopFailCharacter: "✗",
-				StopFailColors:    []string{"fgRed"},
-			}
-			var err error
-			spinner, err = yacspin.New(cfg)
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot create spinner")
-			}
-			err = spinner.Start()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot start spinner")
-			}
+	return c.protectBranchForMemberCount(assignmentCfg, project, spin, 0)
+}
+
+func (c *Client) protectBranchForMemberCount(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, spin bool, memberCount int) error {
+	if !hasProtectedBranches(assignmentCfg.Branches) && !hasMergeRequestApprovalConfig(assignmentCfg.MergeRequest) {
+		return nil
+	}
+
+	var spinner *yacspin.Spinner
+	if spin {
+		cfg := yacspin.Config{
+			Frequency: 100 * time.Millisecond,
+			CharSet:   yacspin.CharSets[69],
+			Suffix: aurora.Sprintf(aurora.Cyan(" protect branch for project %s at %s"),
+				aurora.Yellow(project.Name),
+				aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
+			),
+			SuffixAutoColon:   true,
+			StopCharacter:     "✓",
+			StopColors:        []string{"fgGreen"},
+			StopFailMessage:   "error",
+			StopFailCharacter: "✗",
+			StopFailColors:    []string{"fgRed"},
+		}
+		var err error
+		spinner, err = yacspin.New(cfg)
+		if err != nil {
+			log.Debug().Err(err).Msg("cannot create spinner")
+		}
+		err = spinner.Start()
+		if err != nil {
+			log.Debug().Err(err).Msg("cannot start spinner")
+		}
+	}
+
+	log.Debug().
+		Str("name", project.Name).
+		Str("toURL", project.SSHURLToRepo).
+		Interface("branches", assignmentCfg.Branches).
+		Msg("protecting branch")
+
+	for _, branch := range assignmentCfg.Branches {
+		if !branch.Protect && !branch.MergeOnly {
+			continue
 		}
 
-		log.Debug().
-			Str("name", project.Name).
-			Str("toURL", project.SSHURLToRepo).
-			Interface("branches", assignmentCfg.Branches).
-			Msg("protecting branch")
+		pushLevel := gitlab.MaintainerPermissions
+		mergeLevel := gitlab.MaintainerPermissions
+		if branch.MergeOnly {
+			pushLevel = gitlab.NoPermissions
+			mergeLevel = gitlab.DeveloperPermissions
+		}
 
-		for _, branch := range assignmentCfg.Branches {
-			if !branch.Protect && !branch.MergeOnly {
-				continue
-			}
-
-			pushLevel := gitlab.MaintainerPermissions
-			mergeLevel := gitlab.MaintainerPermissions
-			if branch.MergeOnly {
-				pushLevel = gitlab.NoPermissions
-				mergeLevel = gitlab.DeveloperPermissions
-			}
-
-			err := c.protectSingleBranch(project, branch, pushLevel, mergeLevel)
-			if err != nil {
-				if spin {
-					err := spinner.StopFail()
-					if err != nil {
-						log.Debug().Err(err).Msg("cannot stop spinner")
-					}
+		err := c.protectSingleBranch(project, branch, pushLevel, mergeLevel)
+		if err != nil {
+			if spin {
+				err := spinner.StopFail()
+				if err != nil {
+					log.Debug().Err(err).Msg("cannot stop spinner")
 				}
-				return err
 			}
+			return err
 		}
+	}
 
+	if err := c.applyMergeRequestApprovalRulesForMemberCount(assignmentCfg, project, memberCount); err != nil {
 		if spin {
-			spinner.StopMessage(aurora.Sprintf(aurora.Green("ok")))
-			if err := spinner.Stop(); err != nil {
+			err := spinner.StopFail()
+			if err != nil {
 				log.Debug().Err(err).Msg("cannot stop spinner")
 			}
+		}
+		return err
+	}
+
+	if spin {
+		spinner.StopMessage(aurora.Sprintf(aurora.Green("ok")))
+		if err := spinner.Stop(); err != nil {
+			log.Debug().Err(err).Msg("cannot stop spinner")
 		}
 	}
 
@@ -109,6 +124,14 @@ func hasProtectedBranches(branches []config.BranchRule) bool {
 	}
 
 	return false
+}
+
+func hasMergeRequestApprovalConfig(mergeRequest *config.MergeRequest) bool {
+	if mergeRequest == nil {
+		return false
+	}
+
+	return len(mergeRequest.Approvals) > 0 || mergeRequest.ApprovalSettings != nil
 }
 
 func (c *Client) protectSingleBranch(
@@ -212,7 +235,7 @@ func (c *Client) protectToBranchPerStudent(assignmentCfg *config.AssignmentConfi
 			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
 			return
 		}
-		if err := c.protectBranch(assignmentCfg, project, true); err != nil {
+		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, 1); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot protect the branch")
 		}
 	}
@@ -234,7 +257,7 @@ func (c *Client) protectToBranchPerGroup(assignmentCfg *config.AssignmentConfig)
 			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
 			return
 		}
-		if err := c.protectBranch(assignmentCfg, project, true); err != nil {
+		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, len(grp.Members)); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot protect the branch")
 		}
 	}

--- a/gitlab/protect.go
+++ b/gitlab/protect.go
@@ -31,70 +31,85 @@ func (c *Client) ProtectToBranch(assignmentCfg *config.AssignmentConfig) {
 }
 
 func (c *Client) protectBranch(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, spin bool) error {
-	if hasProtectedBranches(assignmentCfg.Branches) {
-		// var cfg yacspin.Config
-		var spinner *yacspin.Spinner
-		if spin {
-			cfg := yacspin.Config{
-				Frequency: 100 * time.Millisecond,
-				CharSet:   yacspin.CharSets[69],
-				Suffix: aurora.Sprintf(aurora.Cyan(" protect branch for project %s at %s"),
-					aurora.Yellow(project.Name),
-					aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
-				),
-				SuffixAutoColon:   true,
-				StopCharacter:     "✓",
-				StopColors:        []string{"fgGreen"},
-				StopFailMessage:   "error",
-				StopFailCharacter: "✗",
-				StopFailColors:    []string{"fgRed"},
-			}
-			var err error
-			spinner, err = yacspin.New(cfg)
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot create spinner")
-			}
-			err = spinner.Start()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot start spinner")
-			}
+	return c.protectBranchForMemberCount(assignmentCfg, project, spin, 0)
+}
+
+func (c *Client) protectBranchForMemberCount(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, spin bool, memberCount int) error {
+	if !hasProtectedBranches(assignmentCfg.Branches) && !hasMergeRequestApprovalConfig(assignmentCfg.MergeRequest) {
+		return nil
+	}
+
+	var spinner *yacspin.Spinner
+	if spin {
+		cfg := yacspin.Config{
+			Frequency: 100 * time.Millisecond,
+			CharSet:   yacspin.CharSets[69],
+			Suffix: aurora.Sprintf(aurora.Cyan(" protect branch for project %s at %s"),
+				aurora.Yellow(project.Name),
+				aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
+			),
+			SuffixAutoColon:   true,
+			StopCharacter:     "✓",
+			StopColors:        []string{"fgGreen"},
+			StopFailMessage:   "error",
+			StopFailCharacter: "✗",
+			StopFailColors:    []string{"fgRed"},
+		}
+		var err error
+		spinner, err = yacspin.New(cfg)
+		if err != nil {
+			log.Debug().Err(err).Msg("cannot create spinner")
+		}
+		err = spinner.Start()
+		if err != nil {
+			log.Debug().Err(err).Msg("cannot start spinner")
+		}
+	}
+
+	log.Debug().
+		Str("name", project.Name).
+		Str("toURL", project.SSHURLToRepo).
+		Interface("branches", assignmentCfg.Branches).
+		Msg("protecting branch")
+
+	for _, branch := range assignmentCfg.Branches {
+		if !branch.Protect && !branch.MergeOnly {
+			continue
 		}
 
-		log.Debug().
-			Str("name", project.Name).
-			Str("toURL", project.SSHURLToRepo).
-			Interface("branches", assignmentCfg.Branches).
-			Msg("protecting branch")
+		pushLevel := gitlab.MaintainerPermissions
+		mergeLevel := gitlab.MaintainerPermissions
+		if branch.MergeOnly {
+			pushLevel = gitlab.NoPermissions
+			mergeLevel = gitlab.DeveloperPermissions
+		}
 
-		for _, branch := range assignmentCfg.Branches {
-			if !branch.Protect && !branch.MergeOnly {
-				continue
-			}
-
-			pushLevel := gitlab.MaintainerPermissions
-			mergeLevel := gitlab.MaintainerPermissions
-			if branch.MergeOnly {
-				pushLevel = gitlab.NoPermissions
-				mergeLevel = gitlab.DeveloperPermissions
-			}
-
-			err := c.protectSingleBranch(project, branch, pushLevel, mergeLevel)
-			if err != nil {
-				if spin {
-					err := spinner.StopFail()
-					if err != nil {
-						log.Debug().Err(err).Msg("cannot stop spinner")
-					}
+		err := c.protectSingleBranch(project, branch, pushLevel, mergeLevel)
+		if err != nil {
+			if spin {
+				err := spinner.StopFail()
+				if err != nil {
+					log.Debug().Err(err).Msg("cannot stop spinner")
 				}
-				return err
 			}
+			return err
 		}
+	}
 
+	if err := c.applyMergeRequestApprovalRulesForMemberCount(assignmentCfg, project, memberCount); err != nil {
 		if spin {
-			spinner.StopMessage(aurora.Sprintf(aurora.Green("ok")))
-			if err := spinner.Stop(); err != nil {
+			err := spinner.StopFail()
+			if err != nil {
 				log.Debug().Err(err).Msg("cannot stop spinner")
 			}
+		}
+		return err
+	}
+
+	if spin {
+		spinner.StopMessage(aurora.Sprintf(aurora.Green("ok")))
+		if err := spinner.Stop(); err != nil {
+			log.Debug().Err(err).Msg("cannot stop spinner")
 		}
 	}
 
@@ -109,6 +124,14 @@ func hasProtectedBranches(branches []config.BranchRule) bool {
 	}
 
 	return false
+}
+
+func hasMergeRequestApprovalConfig(mergeRequest *config.MergeRequest) bool {
+	if mergeRequest == nil {
+		return false
+	}
+
+	return len(mergeRequest.Approvals) > 0 || mergeRequest.ApprovalSettings != nil
 }
 
 func (c *Client) protectSingleBranch(
@@ -244,7 +267,7 @@ func (c *Client) protectToBranchPerStudent(assignmentCfg *config.AssignmentConfi
 			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
 			return
 		}
-		if err := c.protectBranch(assignmentCfg, project, true); err != nil {
+		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, 1); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot protect the branch")
 		}
 	}
@@ -266,7 +289,7 @@ func (c *Client) protectToBranchPerGroup(assignmentCfg *config.AssignmentConfig)
 			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
 			return
 		}
-		if err := c.protectBranch(assignmentCfg, project, true); err != nil {
+		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, len(grp.Members)); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot protect the branch")
 		}
 	}

--- a/gitlab/protect.go
+++ b/gitlab/protect.go
@@ -119,6 +119,15 @@ func (c *Client) protectSingleBranch(
 ) error {
 	existing, _, err := c.ProtectedBranches.GetProtectedBranch(project.ID, branch.Name)
 	if err == nil {
+		// GitLab can keep stale push permissions when updating existing rules to
+		// "No one" (merge-only). Recreate the rule to enforce the access levels.
+		if pushAccessLevel == gitlab.NoPermissions {
+			if err := c.recreateProtectedBranch(project, branch, pushAccessLevel, mergeAccessLevel); err != nil {
+				return err
+			}
+			return nil
+		}
+
 		updateOpts := &gitlab.UpdateProtectedBranchOptions{
 			AllowedToPush:             replaceBranchPermissions(existing.PushAccessLevels, pushAccessLevel),
 			AllowedToMerge:            replaceBranchPermissions(existing.MergeAccessLevels, mergeAccessLevel),
@@ -147,6 +156,29 @@ func (c *Client) protectSingleBranch(
 			Str("branch", branch.Name).
 			Msg("cannot read protected branch")
 		return fmt.Errorf("error while trying to read protected branch %s: %w", branch.Name, err)
+	}
+
+	if err := c.recreateProtectedBranch(project, branch, pushAccessLevel, mergeAccessLevel); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) recreateProtectedBranch(
+	project *gitlab.Project,
+	branch config.BranchRule,
+	pushAccessLevel gitlab.AccessLevelValue,
+	mergeAccessLevel gitlab.AccessLevelValue,
+) error {
+	_, err := c.ProtectedBranches.UnprotectRepositoryBranches(project.ID, branch.Name)
+	if err != nil && !isProtectedBranchNotFoundError(err) {
+		log.Debug().Err(err).
+			Str("name", project.Name).
+			Str("toURL", project.SSHURLToRepo).
+			Str("branch", branch.Name).
+			Msg("cannot unprotect branch")
+		return fmt.Errorf("error while trying to unprotect branch %s: %w", branch.Name, err)
 	}
 
 	opts := &gitlab.ProtectRepositoryBranchesOptions{

--- a/gitlab/protect_contract_test.go
+++ b/gitlab/protect_contract_test.go
@@ -367,6 +367,45 @@ func TestProtectSingleBranch_Success(t *testing.T) {
 	}
 }
 
+func TestProtectSingleBranch_MergeOnly_RecreatesExistingRule(t *testing.T) {
+	deleteCalled := false
+	postCalled := false
+	patchCalled := false
+
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "protected_branches"):
+			_, _ = w.Write([]byte(`{"id":1,"name":"main","push_access_levels":[{"id":10,"access_level":40}],"merge_access_levels":[{"id":11,"access_level":40}],"unprotect_access_levels":[{"id":12,"access_level":40}]}`))
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "protected_branches"):
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "protected_branches"):
+			postCalled = true
+			_, _ = w.Write([]byte(`{"id":1,"name":"main"}`))
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "protected_branches"):
+			patchCalled = true
+			_, _ = w.Write([]byte(`{"id":1,"name":"main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	err := client.protectSingleBranch(project, config.BranchRule{Name: "main", MergeOnly: true}, gitlabapi.NoPermissions, gitlabapi.DeveloperPermissions)
+	if err != nil {
+		t.Fatalf("protectSingleBranch() error = %v", err)
+	}
+	if !deleteCalled {
+		t.Fatal("protectSingleBranch() did not unprotect existing branch before recreating merge-only rule")
+	}
+	if !postCalled {
+		t.Fatal("protectSingleBranch() did not create merge-only protected branch rule")
+	}
+	if patchCalled {
+		t.Fatal("protectSingleBranch() should not patch existing protected branch for merge-only rule")
+	}
+}
+
 func TestProtectSingleBranch_GetNotFound_ProtectStillCalled(t *testing.T) {
 	// Get returns 404 (branch not yet protected) -> protectSingleBranch creates the rule.
 	protectCalled := false

--- a/gitlab/protect_contract_test.go
+++ b/gitlab/protect_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
@@ -343,6 +343,448 @@ func TestProtectBranch_UpdateSendsAdditionalBranchProtectionFlags(t *testing.T) 
 	}
 	if patchBody["code_owner_approval_required"] != true {
 		t.Errorf("code_owner_approval_required = %#v, want true", patchBody["code_owner_approval_required"])
+	}
+}
+
+func TestProtectBranch_AppliesMergeRequestApprovals(t *testing.T) {
+	var createBody map[string]any
+	protectedMain := `{"id":10,"name":"main","push_access_levels":[{"id":10,"access_level":40}],"merge_access_levels":[{"id":11,"access_level":40}],"unprotect_access_levels":[{"id":12,"access_level":40}]}`
+
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups":
+			if r.URL.Query().Get("search") != "tutors" {
+				t.Fatalf("groups search query = %q, want tutors", r.URL.Query().Get("search"))
+			}
+			_, _ = w.Write([]byte(`[{"id":55,"full_path":"mpd/tutors"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches/main":
+			_, _ = w.Write([]byte(protectedMain))
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v4/projects/1/protected_branches/main":
+			_, _ = w.Write([]byte(`{"id":10,"name":"main"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatalf("json.Decode() error = %v", err)
+			}
+			_, _ = w.Write([]byte(`{"id":77,"name":"review-main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Branches: []config.BranchRule{{Name: "main", Protect: true}},
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:              "review-main",
+			Branches:          []string{"main"},
+			Usernames:         []string{"@me"},
+			Groups:            []string{"mpd/tutors"},
+			RequiredApprovals: 2,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.protectBranch(cfg, project, false); err != nil {
+		t.Fatalf("protectBranch() error = %v", err)
+	}
+
+	if createBody["name"] != "review-main" {
+		t.Fatalf("approval rule name = %#v, want review-main", createBody["name"])
+	}
+	if createBody["approvals_required"] != float64(2) {
+		t.Fatalf("approvals_required = %#v, want 2", createBody["approvals_required"])
+	}
+
+	usernames, ok := createBody["usernames"].([]any)
+	if !ok || len(usernames) != 1 || usernames[0] != "me" {
+		t.Fatalf("usernames = %#v, want [\"me\"]", createBody["usernames"])
+	}
+	groupIDs, ok := createBody["group_ids"].([]any)
+	if !ok || len(groupIDs) != 1 || groupIDs[0] != float64(55) {
+		t.Fatalf("group_ids = %#v, want [55]", createBody["group_ids"])
+	}
+	branchIDs, ok := createBody["protected_branch_ids"].([]any)
+	if !ok || len(branchIDs) != 1 || branchIDs[0] != float64(10) {
+		t.Fatalf("protected_branch_ids = %#v, want [10]", createBody["protected_branch_ids"])
+	}
+}
+
+func TestProtectBranch_AppliesMergeRequestApprovalSettings(t *testing.T) {
+	var body map[string]any
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approvals":
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("json.Decode() error = %v", err)
+			}
+			_, _ = w.Write([]byte(`{"merge_requests_author_approval":false}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	preventCreator := true
+	preventCommitters := true
+	preventEditing := true
+	reauth := true
+	whenCommitAdded := config.ApprovalRemoveCodeOwnerApprovalsIfFilesChanged
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{
+			ApprovalSettings: &config.MergeRequestApprovalSettings{
+				PreventApprovalByMergeRequestCreator:       &preventCreator,
+				PreventApprovalsByUsersWhoAddCommits:       &preventCommitters,
+				PreventEditingApprovalRulesInMergeRequests: &preventEditing,
+				RequireUserReauthenticationToApprove:       &reauth,
+				WhenCommitAdded:                            &whenCommitAdded,
+			},
+		},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.protectBranch(cfg, project, false); err != nil {
+		t.Fatalf("protectBranch() error = %v", err)
+	}
+
+	if body["merge_requests_author_approval"] != false {
+		t.Fatalf("merge_requests_author_approval = %#v, want false", body["merge_requests_author_approval"])
+	}
+	if body["merge_requests_disable_committers_approval"] != true {
+		t.Fatalf("merge_requests_disable_committers_approval = %#v, want true", body["merge_requests_disable_committers_approval"])
+	}
+	if body["disable_overriding_approvers_per_merge_request"] != true {
+		t.Fatalf("disable_overriding_approvers_per_merge_request = %#v, want true", body["disable_overriding_approvers_per_merge_request"])
+	}
+	if body["require_reauthentication_to_approve"] != true {
+		t.Fatalf("require_reauthentication_to_approve = %#v, want true", body["require_reauthentication_to_approve"])
+	}
+	if body["reset_approvals_on_push"] != false {
+		t.Fatalf("reset_approvals_on_push = %#v, want false", body["reset_approvals_on_push"])
+	}
+	if body["selective_code_owner_removals"] != true {
+		t.Fatalf("selective_code_owner_removals = %#v, want true", body["selective_code_owner_removals"])
+	}
+}
+
+func TestProtectBranch_ClearsApprovalRuleWhenNoApproversConfigured(t *testing.T) {
+	deleted := false
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[{"id":9,"name":"no-review"}]`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v4/projects/1/approval_rules/9":
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:              "no-review",
+			Branches:          []string{"main"},
+			RequiredApprovals: 0,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.protectBranch(cfg, project, false); err != nil {
+		t.Fatalf("protectBranch() error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("approval rule delete was not called")
+	}
+}
+
+func TestProtectBranch_SkipsApprovalRuleForUnprotectedBranch(t *testing.T) {
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			_, _ = w.Write([]byte(`{"id":77,"name":"main-review"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{
+			{
+				Name:              "main-review",
+				Branches:          []string{"main"},
+				Usernames:         []string{"me"},
+				RequiredApprovals: 1,
+			},
+			{
+				Name:              "missing-branch-review",
+				Branches:          []string{"blubber"},
+				Usernames:         []string{"me"},
+				RequiredApprovals: 1,
+			},
+		}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.protectBranch(cfg, project, false); err != nil {
+		t.Fatalf("protectBranch() error = %v", err)
+	}
+	if created != 1 {
+		t.Fatalf("created approval rules = %d, want 1", created)
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_MergesAnyApproverRulesAcrossBranches(t *testing.T) {
+	var createBody map[string]any
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"},{"id":11,"name":"blubber"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatalf("json.Decode() error = %v", err)
+			}
+			_, _ = w.Write([]byte(`{"id":77,"name":"main-review","rule_type":"any_approver"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{
+			{Name: "main-review", Branches: []string{"main"}, RequiredApprovals: 1},
+			{Name: "blubber-review", Branches: []string{"blubber"}, RequiredApprovals: 1},
+		}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRules(cfg, project); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRules() error = %v", err)
+	}
+	if created != 1 {
+		t.Fatalf("created approval rules = %d, want 1", created)
+	}
+	if createBody["rule_type"] != "any_approver" {
+		t.Fatalf("rule_type = %#v, want any_approver", createBody["rule_type"])
+	}
+	if createBody["approvals_required"] != float64(1) {
+		t.Fatalf("approvals_required = %#v, want 1", createBody["approvals_required"])
+	}
+	branchIDs, ok := createBody["protected_branch_ids"].([]any)
+	if !ok || len(branchIDs) != 2 || branchIDs[0] != float64(11) || branchIDs[1] != float64(10) {
+		t.Fatalf("protected_branch_ids = %#v, want [11 10]", createBody["protected_branch_ids"])
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_UpdatesExistingAnyApproverRule(t *testing.T) {
+	var updateBody map[string]any
+	updated := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"},{"id":11,"name":"blubber"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[{"id":9,"name":"Minimum required approvals","rule_type":"any_approver"}]`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v4/projects/1/approval_rules/9":
+			updated++
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Fatalf("json.Decode() error = %v", err)
+			}
+			_, _ = w.Write([]byte(`{"id":9,"name":"Minimum required approvals","rule_type":"any_approver"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{
+			{Name: "main-review", Branches: []string{"main"}, RequiredApprovals: 1},
+			{Name: "blubber-review", Branches: []string{"blubber"}, RequiredApprovals: 1},
+		}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRules(cfg, project); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRules() error = %v", err)
+	}
+	if updated != 1 {
+		t.Fatalf("updated approval rules = %d, want 1", updated)
+	}
+	if updateBody["approvals_required"] != float64(1) {
+		t.Fatalf("approvals_required = %#v, want 1", updateBody["approvals_required"])
+	}
+	branchIDs, ok := updateBody["protected_branch_ids"].([]any)
+	if !ok || len(branchIDs) != 2 || branchIDs[0] != float64(11) || branchIDs[1] != float64(10) {
+		t.Fatalf("protected_branch_ids = %#v, want [11 10]", updateBody["protected_branch_ids"])
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_RejectsMultipleAnyApproverApprovalCounts(t *testing.T) {
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"},{"id":11,"name":"blubber"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{
+			{Name: "main-review", Branches: []string{"main"}, RequiredApprovals: 1},
+			{Name: "blubber-review", Branches: []string{"blubber"}, RequiredApprovals: 2},
+		}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	err := client.applyMergeRequestApprovalRules(cfg, project)
+	if err == nil {
+		t.Fatal("applyMergeRequestApprovalRules() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "only one any-approver rule") {
+		t.Fatalf("error = %q, want any-approver guidance", err)
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_MultiMemberGroupsOnly_SkipsForStudentProjects(t *testing.T) {
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			_, _ = w.Write([]byte(`{"id":77,"name":"review-main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Per: config.PerStudent,
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:                  "review-main",
+			Branches:              []string{"main"},
+			Usernames:             []string{"me"},
+			MultiMemberGroupsOnly: true,
+			RequiredApprovals:     1,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRulesForMemberCount(cfg, project, 1); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRulesForMemberCount() error = %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("created approval rules = %d, want 0", created)
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_MultiMemberGroupsOnly_SkipsForSingleMemberGroup(t *testing.T) {
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			_, _ = w.Write([]byte(`{"id":77,"name":"review-main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Per: config.PerGroup,
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:                  "review-main",
+			Branches:              []string{"main"},
+			Usernames:             []string{"me"},
+			MultiMemberGroupsOnly: true,
+			RequiredApprovals:     1,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRulesForMemberCount(cfg, project, 1); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRulesForMemberCount() error = %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("created approval rules = %d, want 0", created)
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_MultiMemberGroupsOnly_AppliesForMultiMemberGroup(t *testing.T) {
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			_, _ = w.Write([]byte(`{"id":77,"name":"review-main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Per: config.PerGroup,
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:                  "review-main",
+			Branches:              []string{"main"},
+			Usernames:             []string{"me"},
+			MultiMemberGroupsOnly: true,
+			RequiredApprovals:     1,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRulesForMemberCount(cfg, project, 2); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRulesForMemberCount() error = %v", err)
+	}
+	if created != 1 {
+		t.Fatalf("created approval rules = %d, want 1", created)
+	}
+}
+
+func TestProtectBranch_EmailApproverNotSupported_ReturnsError(t *testing.T) {
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:              "main-review",
+			Branches:          []string{"main"},
+			Usernames:         []string{"me@example.org"},
+			RequiredApprovals: 1,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	err := client.protectBranch(cfg, project, false)
+	if err == nil {
+		t.Fatal("protectBranch() expected error for email approver, got nil")
+	}
+	if !strings.Contains(err.Error(), "email") || !strings.Contains(err.Error(), "use username") {
+		t.Fatalf("error = %q, want email guidance", err)
 	}
 }
 

--- a/gitlab/protect_contract_test.go
+++ b/gitlab/protect_contract_test.go
@@ -346,6 +346,448 @@ func TestProtectBranch_UpdateSendsAdditionalBranchProtectionFlags(t *testing.T) 
 	}
 }
 
+func TestProtectBranch_AppliesMergeRequestApprovals(t *testing.T) {
+	var createBody map[string]any
+	protectedMain := `{"id":10,"name":"main","push_access_levels":[{"id":10,"access_level":40}],"merge_access_levels":[{"id":11,"access_level":40}],"unprotect_access_levels":[{"id":12,"access_level":40}]}`
+
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups":
+			if r.URL.Query().Get("search") != "tutors" {
+				t.Fatalf("groups search query = %q, want tutors", r.URL.Query().Get("search"))
+			}
+			_, _ = w.Write([]byte(`[{"id":55,"full_path":"mpd/tutors"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches/main":
+			_, _ = w.Write([]byte(protectedMain))
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v4/projects/1/protected_branches/main":
+			_, _ = w.Write([]byte(`{"id":10,"name":"main"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatalf("json.Decode() error = %v", err)
+			}
+			_, _ = w.Write([]byte(`{"id":77,"name":"review-main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Branches: []config.BranchRule{{Name: "main", Protect: true}},
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:              "review-main",
+			Branches:          []string{"main"},
+			Usernames:         []string{"@me"},
+			Groups:            []string{"mpd/tutors"},
+			RequiredApprovals: 2,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.protectBranch(cfg, project, false); err != nil {
+		t.Fatalf("protectBranch() error = %v", err)
+	}
+
+	if createBody["name"] != "review-main" {
+		t.Fatalf("approval rule name = %#v, want review-main", createBody["name"])
+	}
+	if createBody["approvals_required"] != float64(2) {
+		t.Fatalf("approvals_required = %#v, want 2", createBody["approvals_required"])
+	}
+
+	usernames, ok := createBody["usernames"].([]any)
+	if !ok || len(usernames) != 1 || usernames[0] != "me" {
+		t.Fatalf("usernames = %#v, want [\"me\"]", createBody["usernames"])
+	}
+	groupIDs, ok := createBody["group_ids"].([]any)
+	if !ok || len(groupIDs) != 1 || groupIDs[0] != float64(55) {
+		t.Fatalf("group_ids = %#v, want [55]", createBody["group_ids"])
+	}
+	branchIDs, ok := createBody["protected_branch_ids"].([]any)
+	if !ok || len(branchIDs) != 1 || branchIDs[0] != float64(10) {
+		t.Fatalf("protected_branch_ids = %#v, want [10]", createBody["protected_branch_ids"])
+	}
+}
+
+func TestProtectBranch_AppliesMergeRequestApprovalSettings(t *testing.T) {
+	var body map[string]any
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approvals":
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("json.Decode() error = %v", err)
+			}
+			_, _ = w.Write([]byte(`{"merge_requests_author_approval":false}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	preventCreator := true
+	preventCommitters := true
+	preventEditing := true
+	reauth := true
+	whenCommitAdded := config.ApprovalRemoveCodeOwnerApprovalsIfFilesChanged
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{
+			ApprovalSettings: &config.MergeRequestApprovalSettings{
+				PreventApprovalByMergeRequestCreator:       &preventCreator,
+				PreventApprovalsByUsersWhoAddCommits:       &preventCommitters,
+				PreventEditingApprovalRulesInMergeRequests: &preventEditing,
+				RequireUserReauthenticationToApprove:       &reauth,
+				WhenCommitAdded:                            &whenCommitAdded,
+			},
+		},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.protectBranch(cfg, project, false); err != nil {
+		t.Fatalf("protectBranch() error = %v", err)
+	}
+
+	if body["merge_requests_author_approval"] != false {
+		t.Fatalf("merge_requests_author_approval = %#v, want false", body["merge_requests_author_approval"])
+	}
+	if body["merge_requests_disable_committers_approval"] != true {
+		t.Fatalf("merge_requests_disable_committers_approval = %#v, want true", body["merge_requests_disable_committers_approval"])
+	}
+	if body["disable_overriding_approvers_per_merge_request"] != true {
+		t.Fatalf("disable_overriding_approvers_per_merge_request = %#v, want true", body["disable_overriding_approvers_per_merge_request"])
+	}
+	if body["require_reauthentication_to_approve"] != true {
+		t.Fatalf("require_reauthentication_to_approve = %#v, want true", body["require_reauthentication_to_approve"])
+	}
+	if body["reset_approvals_on_push"] != false {
+		t.Fatalf("reset_approvals_on_push = %#v, want false", body["reset_approvals_on_push"])
+	}
+	if body["selective_code_owner_removals"] != true {
+		t.Fatalf("selective_code_owner_removals = %#v, want true", body["selective_code_owner_removals"])
+	}
+}
+
+func TestProtectBranch_ClearsApprovalRuleWhenNoApproversConfigured(t *testing.T) {
+	deleted := false
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[{"id":9,"name":"no-review"}]`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v4/projects/1/approval_rules/9":
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:              "no-review",
+			Branches:          []string{"main"},
+			RequiredApprovals: 0,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.protectBranch(cfg, project, false); err != nil {
+		t.Fatalf("protectBranch() error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("approval rule delete was not called")
+	}
+}
+
+func TestProtectBranch_SkipsApprovalRuleForUnprotectedBranch(t *testing.T) {
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			_, _ = w.Write([]byte(`{"id":77,"name":"main-review"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{
+			{
+				Name:              "main-review",
+				Branches:          []string{"main"},
+				Usernames:         []string{"me"},
+				RequiredApprovals: 1,
+			},
+			{
+				Name:              "missing-branch-review",
+				Branches:          []string{"blubber"},
+				Usernames:         []string{"me"},
+				RequiredApprovals: 1,
+			},
+		}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.protectBranch(cfg, project, false); err != nil {
+		t.Fatalf("protectBranch() error = %v", err)
+	}
+	if created != 1 {
+		t.Fatalf("created approval rules = %d, want 1", created)
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_MergesAnyApproverRulesAcrossBranches(t *testing.T) {
+	var createBody map[string]any
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"},{"id":11,"name":"blubber"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatalf("json.Decode() error = %v", err)
+			}
+			_, _ = w.Write([]byte(`{"id":77,"name":"main-review","rule_type":"any_approver"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{
+			{Name: "main-review", Branches: []string{"main"}, RequiredApprovals: 1},
+			{Name: "blubber-review", Branches: []string{"blubber"}, RequiredApprovals: 1},
+		}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRules(cfg, project); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRules() error = %v", err)
+	}
+	if created != 1 {
+		t.Fatalf("created approval rules = %d, want 1", created)
+	}
+	if createBody["rule_type"] != "any_approver" {
+		t.Fatalf("rule_type = %#v, want any_approver", createBody["rule_type"])
+	}
+	if createBody["approvals_required"] != float64(1) {
+		t.Fatalf("approvals_required = %#v, want 1", createBody["approvals_required"])
+	}
+	branchIDs, ok := createBody["protected_branch_ids"].([]any)
+	if !ok || len(branchIDs) != 2 || branchIDs[0] != float64(11) || branchIDs[1] != float64(10) {
+		t.Fatalf("protected_branch_ids = %#v, want [11 10]", createBody["protected_branch_ids"])
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_UpdatesExistingAnyApproverRule(t *testing.T) {
+	var updateBody map[string]any
+	updated := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"},{"id":11,"name":"blubber"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[{"id":9,"name":"Minimum required approvals","rule_type":"any_approver"}]`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v4/projects/1/approval_rules/9":
+			updated++
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Fatalf("json.Decode() error = %v", err)
+			}
+			_, _ = w.Write([]byte(`{"id":9,"name":"Minimum required approvals","rule_type":"any_approver"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{
+			{Name: "main-review", Branches: []string{"main"}, RequiredApprovals: 1},
+			{Name: "blubber-review", Branches: []string{"blubber"}, RequiredApprovals: 1},
+		}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRules(cfg, project); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRules() error = %v", err)
+	}
+	if updated != 1 {
+		t.Fatalf("updated approval rules = %d, want 1", updated)
+	}
+	if updateBody["approvals_required"] != float64(1) {
+		t.Fatalf("approvals_required = %#v, want 1", updateBody["approvals_required"])
+	}
+	branchIDs, ok := updateBody["protected_branch_ids"].([]any)
+	if !ok || len(branchIDs) != 2 || branchIDs[0] != float64(11) || branchIDs[1] != float64(10) {
+		t.Fatalf("protected_branch_ids = %#v, want [11 10]", updateBody["protected_branch_ids"])
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_RejectsMultipleAnyApproverApprovalCounts(t *testing.T) {
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"},{"id":11,"name":"blubber"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{
+			{Name: "main-review", Branches: []string{"main"}, RequiredApprovals: 1},
+			{Name: "blubber-review", Branches: []string{"blubber"}, RequiredApprovals: 2},
+		}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	err := client.applyMergeRequestApprovalRules(cfg, project)
+	if err == nil {
+		t.Fatal("applyMergeRequestApprovalRules() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "only one any-approver rule") {
+		t.Fatalf("error = %q, want any-approver guidance", err)
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_MultiMemberGroupsOnly_SkipsForStudentProjects(t *testing.T) {
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			_, _ = w.Write([]byte(`{"id":77,"name":"review-main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Per: config.PerStudent,
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:                  "review-main",
+			Branches:              []string{"main"},
+			Usernames:             []string{"me"},
+			MultiMemberGroupsOnly: true,
+			RequiredApprovals:     1,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRulesForMemberCount(cfg, project, 1); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRulesForMemberCount() error = %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("created approval rules = %d, want 0", created)
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_MultiMemberGroupsOnly_SkipsForSingleMemberGroup(t *testing.T) {
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			_, _ = w.Write([]byte(`{"id":77,"name":"review-main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Per: config.PerGroup,
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:                  "review-main",
+			Branches:              []string{"main"},
+			Usernames:             []string{"me"},
+			MultiMemberGroupsOnly: true,
+			RequiredApprovals:     1,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRulesForMemberCount(cfg, project, 1); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRulesForMemberCount() error = %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("created approval rules = %d, want 0", created)
+	}
+}
+
+func TestApplyMergeRequestApprovalRules_MultiMemberGroupsOnly_AppliesForMultiMemberGroup(t *testing.T) {
+	created := 0
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			created++
+			_, _ = w.Write([]byte(`{"id":77,"name":"review-main"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		Per: config.PerGroup,
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:                  "review-main",
+			Branches:              []string{"main"},
+			Usernames:             []string{"me"},
+			MultiMemberGroupsOnly: true,
+			RequiredApprovals:     1,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	if err := client.applyMergeRequestApprovalRulesForMemberCount(cfg, project, 2); err != nil {
+		t.Fatalf("applyMergeRequestApprovalRulesForMemberCount() error = %v", err)
+	}
+	if created != 1 {
+		t.Fatalf("created approval rules = %d, want 1", created)
+	}
+}
+
+func TestProtectBranch_EmailApproverNotSupported_ReturnsError(t *testing.T) {
+	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/protected_branches":
+			_, _ = w.Write([]byte(`[{"id":10,"name":"main"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/1/approval_rules":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	cfg := &config.AssignmentConfig{
+		MergeRequest: &config.MergeRequest{Approvals: []config.MergeRequestApprovalRule{{
+			Name:              "main-review",
+			Branches:          []string{"main"},
+			Usernames:         []string{"me@example.org"},
+			RequiredApprovals: 1,
+		}}},
+	}
+	project := &gitlabapi.Project{ID: 1, Name: "myrepo"}
+	err := client.protectBranch(cfg, project, false)
+	if err == nil {
+		t.Fatal("protectBranch() expected error for email approver, got nil")
+	}
+	if !strings.Contains(err.Error(), "email") || !strings.Contains(err.Error(), "use username") {
+		t.Fatalf("error = %q, want email guidance", err)
+	}
+}
+
 // ---- protectSingleBranch ----------------------------------------------------
 
 func TestProtectSingleBranch_Success(t *testing.T) {

--- a/gitlab/protect_contract_test.go
+++ b/gitlab/protect_contract_test.go
@@ -648,7 +648,7 @@ func TestApplyMergeRequestApprovalRules_RejectsMultipleAnyApproverApprovalCounts
 	if err == nil {
 		t.Fatal("applyMergeRequestApprovalRules() expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "only one any-approver rule") {
+	if !strings.Contains(err.Error(), "any-approver") {
 		t.Fatalf("error = %q, want any-approver guidance", err)
 	}
 }

--- a/gitlab/report.go
+++ b/gitlab/report.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/obcode/glabs/config"
-	r "github.com/obcode/glabs/gitlab/report"
+	"github.com/obcode/glabs/v2/config"
+	r "github.com/obcode/glabs/v2/gitlab/report"
 )
 
 func (c *Client) Report(assignmentCfg *config.AssignmentConfig, templateFile *string, output *string) {

--- a/gitlab/report_contract_test.go
+++ b/gitlab/report_contract_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 // makeFullReportHandler returns a handler that mocks all calls needed by report().

--- a/gitlab/report_helper.go
+++ b/gitlab/report_helper.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/gitlab/report"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/gitlab/report"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"

--- a/gitlab/report_helper_contract_test.go
+++ b/gitlab/report_helper_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/runtime_test.go
+++ b/gitlab/runtime_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/spf13/viper"
 )
 

--- a/gitlab/seeder.go
+++ b/gitlab/seeder.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	cfg "github.com/obcode/glabs/config"
-	g "github.com/obcode/glabs/git"
+	cfg "github.com/obcode/glabs/v2/config"
+	g "github.com/obcode/glabs/v2/git"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/setaccess.go
+++ b/gitlab/setaccess.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"

--- a/gitlab/setaccess_contract_test.go
+++ b/gitlab/setaccess_contract_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 // ---- Setaccess (top-level) --------------------------------------------------

--- a/gitlab/starterrepo.go
+++ b/gitlab/starterrepo.go
@@ -5,8 +5,8 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
-	cfg "github.com/obcode/glabs/config"
-	g "github.com/obcode/glabs/git"
+	cfg "github.com/obcode/glabs/v2/config"
+	g "github.com/obcode/glabs/v2/git"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/update.go
+++ b/gitlab/update.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/config"
-	"github.com/obcode/glabs/git"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v2/git"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"

--- a/gitlab/update_contract_test.go
+++ b/gitlab/update_contract_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 // ---- Update (top-level) -----------------------------------------------------

--- a/gitlab/users.go
+++ b/gitlab/users.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/users_contract_test.go
+++ b/gitlab/users_contract_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/obcode/glabs/config"
+	"github.com/obcode/glabs/v2/config"
 )
 
 // ---- getUser ----------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/obcode/glabs
+module github.com/obcode/glabs/v2
 
 go 1.26
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/obcode/glabs/v2/cmd"
 	"github.com/spf13/viper"
@@ -16,6 +17,11 @@ var (
 )
 
 func main() {
+	if version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+			version = info.Main.Version
+		}
+	}
 	viper.Set("Version", version)
 	viper.Set("Commit", commit)
 	viper.Set("Date", date)

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/obcode/glabs/cmd"
+	"github.com/obcode/glabs/v2/cmd"
 	"github.com/spf13/viper"
 )
 


### PR DESCRIPTION
- Added functionality to apply merge request approval rules based on member count.
- Introduced methods to handle approval settings for merge requests.
- Enhanced branch protection logic to consider approval rules.
- Updated tests to cover new approval rule functionalities and edge cases.
- Refactored existing branch protection methods to accommodate new logic.