### PR TITLE
test(config): pin resolved config with golden tests

### DIFF
--- a/config/golden_test.go
+++ b/config/golden_test.go
@@ -1,0 +1,267 @@
+package config
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// Golden tests pin the *current* resolved output of GetAssignmentConfig for a
+// set of course files, so that the upcoming rewrite of config loading (viper ->
+// typed source schema) can be proven behaviour-preserving.
+//
+// They deliberately freeze behaviour as it is today, bugs included. If a golden
+// looks wrong, that is a finding to fix in its own commit — not something to
+// quietly "correct" while regenerating, or the goldens stop being a net.
+//
+// Refresh with:  go test ./config/ -run TestGolden -update
+
+var updateGolden = flag.Bool("update", false, "update golden files")
+
+// goldenHost is fixed so the recorded URLs do not depend on any local config.
+const goldenHost = "https://gitlab.lrz.de"
+
+// reservedCourseKeys are the course-level keys that are not assignments.
+// viper lowercases all keys, so these are compared lowercase.
+var reservedCourseKeys = map[string]bool{
+	"coursepath":             true,
+	"semesterpath":           true,
+	"usecoursenameasprefix":  true,
+	"useemaildomainassuffix": true,
+	"students":               true,
+	"groups":                 true,
+}
+
+// goldenStudent records the resolved identity together with the names derived
+// from it. The derived names are the point: a change in case handling would not
+// show up in Email/Raw, but it silently renames the GitLab project.
+type goldenStudent struct {
+	Raw        string  `json:"raw"`
+	Email      *string `json:"email"`
+	Username   *string `json:"username"`
+	ID         *int    `json:"id"`
+	RepoSuffix string  `json:"repoSuffix"`
+	RepoName   string  `json:"repoName"`
+}
+
+type goldenGroup struct {
+	Name     string          `json:"name"`
+	RepoName string          `json:"repoName"`
+	Members  []goldenStudent `json:"members"`
+}
+
+// goldenSeeder replaces Seeder.SignKey (*openpgp.Entity), which has no stable
+// serialization, with a boolean.
+type goldenSeeder struct {
+	Command         string   `json:"command"`
+	Args            []string `json:"args"`
+	Name            string   `json:"name"`
+	EMail           string   `json:"email"`
+	HasSignKey      bool     `json:"hasSignKey"`
+	ToBranch        string   `json:"toBranch"`
+	ProtectToBranch bool     `json:"protectToBranch"`
+}
+
+type goldenAssignment struct {
+	Course                 string                     `json:"course"`
+	Name                   string                     `json:"name"`
+	UseCoursenameAsPrefix  bool                       `json:"useCoursenameAsPrefix"`
+	UseEmailDomainAsSuffix bool                       `json:"useEmailDomainAsSuffix"`
+	Path                   string                     `json:"path"`
+	URL                    string                     `json:"url"`
+	RepoBaseName           string                     `json:"repoBaseName"`
+	Per                    string                     `json:"per"`
+	Description            string                     `json:"description"`
+	ContainerRegistry      bool                       `json:"containerRegistry"`
+	AccessLevel            string                     `json:"accessLevel"`
+	AccessLevelValue       int                        `json:"accessLevelValue"`
+	MergeRequest           *MergeRequest              `json:"mergeRequest"`
+	Branches               []BranchRule               `json:"branches"`
+	Issues                 *IssueReplication          `json:"issues"`
+	Startercode            *Startercode               `json:"startercode"`
+	Clone                  *Clone                     `json:"clone"`
+	Release                *Release                   `json:"release"`
+	Seeder                 *goldenSeeder              `json:"seeder"`
+	DeferredBranches       map[string]*DeferredBranch `json:"deferredBranches"`
+	Students               []goldenStudent            `json:"students"`
+	Groups                 []goldenGroup              `json:"groups"`
+}
+
+func goldenView(cfg *AssignmentConfig) *goldenAssignment {
+	view := &goldenAssignment{
+		Course:                 cfg.Course,
+		Name:                   cfg.Name,
+		UseCoursenameAsPrefix:  cfg.UseCoursenameAsPrefix,
+		UseEmailDomainAsSuffix: cfg.UseEmailDomainAsSuffix,
+		Path:                   cfg.Path,
+		URL:                    cfg.URL,
+		RepoBaseName:           cfg.RepoBaseName(),
+		Per:                    string(cfg.Per),
+		Description:            cfg.Description,
+		ContainerRegistry:      cfg.ContainerRegistry,
+		AccessLevel:            cfg.AccessLevel.String(),
+		AccessLevelValue:       int(cfg.AccessLevel),
+		MergeRequest:           cfg.MergeRequest,
+		Branches:               cfg.Branches,
+		Issues:                 cfg.Issues,
+		Startercode:            cfg.Startercode,
+		Clone:                  cfg.Clone,
+		Release:                cfg.Release,
+		DeferredBranches:       cfg.DeferredBranches,
+	}
+
+	if cfg.Seeder != nil {
+		view.Seeder = &goldenSeeder{
+			Command:         cfg.Seeder.Command,
+			Args:            cfg.Seeder.Args,
+			Name:            cfg.Seeder.Name,
+			EMail:           cfg.Seeder.EMail,
+			HasSignKey:      cfg.Seeder.SignKey != nil,
+			ToBranch:        cfg.Seeder.ToBranch,
+			ProtectToBranch: cfg.Seeder.ProtectToBranch,
+		}
+	}
+
+	for _, student := range cfg.Students {
+		view.Students = append(view.Students, goldenStudentView(cfg, student))
+	}
+
+	for _, group := range cfg.Groups {
+		g := goldenGroup{Name: group.Name, RepoName: cfg.RepoNameForGroup(group)}
+		for _, member := range group.Members {
+			g.Members = append(g.Members, goldenStudentView(cfg, member))
+		}
+		view.Groups = append(view.Groups, g)
+	}
+
+	return view
+}
+
+func goldenStudentView(cfg *AssignmentConfig, student *Student) goldenStudent {
+	return goldenStudent{
+		Raw:        student.Raw,
+		Email:      student.Email,
+		Username:   student.Username,
+		ID:         student.Id,
+		RepoSuffix: cfg.RepoSuffix(student),
+		RepoName:   cfg.RepoNameForStudent(student),
+	}
+}
+
+// loadCourseFixture resets viper and loads a single course file, mimicking what
+// cmd/root.go initConfig() does for a course file. viper is global and
+// GetAssignmentConfig writes back to it while resolving `extends`
+// (config/inheritance.go:54), so every assignment gets a fresh load — otherwise
+// results would depend on resolution order.
+func loadCourseFixture(t *testing.T, path string) string {
+	t.Helper()
+
+	resetViper(t)
+	viper.SetConfigFile(path)
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("reading fixture %s: %v", path, err)
+	}
+	viper.Set("gitlab.host", goldenHost)
+
+	course := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	if !viper.IsSet(course) {
+		t.Fatalf("fixture %s has no top-level key %q — filename and course name must match", path, course)
+	}
+	return course
+}
+
+// concreteAssignments returns the assignments that can actually be operated on:
+// every course-level key that holds a map, minus the reserved course settings
+// and minus abstract bases.
+func concreteAssignments(t *testing.T, course string) []string {
+	t.Helper()
+
+	var names []string
+	for key, value := range viper.GetStringMap(course) {
+		if reservedCourseKeys[key] {
+			continue
+		}
+		if _, isMap := asStringMap(value); !isMap {
+			continue
+		}
+		if viper.GetBool(course + "." + key + "." + abstractKey) {
+			continue
+		}
+		names = append(names, key)
+	}
+	sort.Strings(names)
+
+	if len(names) == 0 {
+		t.Fatalf("course %q has no concrete assignments — fixture or discovery is broken", course)
+	}
+	return names
+}
+
+func courseFixtures(t *testing.T) []string {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join("testdata", "courses", "*.yaml"))
+	if err != nil {
+		t.Fatalf("globbing fixtures: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no course fixtures found — glob broken?")
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func TestGolden(t *testing.T) {
+	for _, path := range courseFixtures(t) {
+		course := loadCourseFixture(t, path)
+
+		for _, assignment := range concreteAssignments(t, course) {
+			t.Run(course+"/"+assignment, func(t *testing.T) {
+				// Reload per assignment: GetAssignmentConfig mutates viper.
+				loadCourseFixture(t, path)
+
+				cfg := GetAssignmentConfig(course, assignment)
+				if cfg == nil {
+					t.Fatalf("GetAssignmentConfig(%q, %q) returned nil", course, assignment)
+				}
+
+				got, err := json.MarshalIndent(goldenView(cfg), "", "  ")
+				if err != nil {
+					t.Fatalf("marshalling golden view: %v", err)
+				}
+				got = append(got, '\n')
+
+				assertGolden(t, filepath.Join("testdata", "golden", course+"."+assignment+".json"), got)
+			})
+		}
+	}
+}
+
+func assertGolden(t *testing.T, path string, got []byte) {
+	t.Helper()
+
+	if *updateGolden {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("creating golden dir: %v", err)
+		}
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("writing golden %s: %v", path, err)
+		}
+		return
+	}
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading golden %s: %v (run: go test ./config/ -run TestGolden -update)", path, err)
+	}
+
+	if string(got) != string(want) {
+		t.Errorf("resolved config differs from golden %s\n--- want\n%s\n--- got\n%s", path, want, got)
+	}
+}

--- a/config/testdata/courses/algdati.yaml
+++ b/config/testdata/courses/algdati.yaml
@@ -1,0 +1,198 @@
+algdati:
+  coursepath: algdati/semester
+  semesterpath: ob-25ws
+
+  blatt1:
+    assignmentpath: blatt-1
+    description: Blatt 1, Algorithmen und Datenstrukturen I, WS 25/26
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:algdati/startercode/startercodeBlatt1.git
+      fromBranch: template
+
+  blatt2-1:
+    assignmentpath: blatt-2-1
+    description: Blatt 2, Algorithmen und Datenstrukturen I, WS 25/26
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:algdati/startercode/startercodeBlatt2.git
+      fromBranch: template
+
+  blatt2-2:
+    assignmentpath: blatt-2-2
+    description: Blatt 2, Algorithmen und Datenstrukturen I, WS 25/26
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:algdati/startercode/startercodeBlatt2-2.git
+      fromBranch: template
+
+  blatt3:
+    assignmentpath: blatt-3
+    description: Blatt 3, Algorithmen und Datenstrukturen I, WS 25/26
+    per: group
+    startercode:
+      url: git@gitlab.lrz.de:algdati/startercode/startercodeBlatt3.git
+      fromBranch: template
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/algdati/25ws/blatt3
+      branch: develop
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+
+  blatt4:
+    assignmentpath: blatt-4
+    description: Blatt 4, Algorithmen und Datenstrukturen I, WS 25/26
+    per: group
+    startercode:
+      url: git@gitlab.lrz.de:algdati/startercode/startercodeblatt04.git
+      fromBranch: template
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/algdati/25ws/blatt4
+      branch: develop
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+
+  students:
+    - s161.t161@example.edu
+    - s217.t217@example.edu
+    - s068.t068@example.edu
+    - s016@example.edu
+    - s073.t073@example.edu
+    - s116.t116@example.edu
+    - s024.t024@example.edu
+    - s110.t110@example.edu
+    - s188.t188@example.edu
+    - s063.t063@example.edu
+    - s162.t162@example.edu
+    - s101.t101@example.edu
+    - s065.t065@example.edu
+    - s018.t018@example.edu
+    - s156.t156@example.edu
+    - s141@example.edu
+    - s149.t149@example.edu
+    - s095.t095@example.edu
+    - s181.t181@example.edu
+    - s179.t179@example.edu
+    - s093.t093@example.edu
+    - s124.t124@example.edu
+    - s015.t015@example.edu
+    - s177.t177@example.edu
+    - s046@example.edu
+    - s118.t118@example.edu
+    - s164.t164@example.edu
+    - s201.t201@example.edu
+    - s113.t113@example.edu
+    - s208.t208@example.edu
+    - s025.t025@example.edu
+    - s031.t031@example.edu
+    - s173.t173@example.edu
+    - s105.t105@example.edu
+    - s210.t210@example.edu
+    - s172.t172@example.edu
+    - s009@example.edu
+    - s193@example.edu
+    - s186.t186@example.edu
+    - s148.t148@example.edu
+    - s079.t079@example.edu
+    - s199.t199@example.edu
+    - s138.t138@example.edu
+    - s038.t038@example.edu
+    - s072.t072@example.edu
+    - s098.t098@example.edu
+    - s174.t174@example.edu
+    - s220@example.edu
+    - s187.t187@example.edu
+    - s014.t014@example.edu
+    - s007.t007@example.edu
+
+  groups:
+    grp00:
+      - s161.t161@example.edu
+      - s135.t135@example.edu
+    grp01:
+      - s110.t110@example.edu # Student 110
+      - s025.t025@example.edu # Student 025
+    grp02:
+      - s073.t073@example.edu # Student 073
+    grp03:
+      - s065.t065@example.edu # Student 065
+      - s186.t186@example.edu # Student 186
+    grp05:
+      - s181.t181@example.edu # Student 181
+      - s098.t098@example.edu # Student 098
+    grp06:
+      - s156.t156@example.edu # Student 156
+      - s208.t208@example.edu # Student 208
+    grp07:
+      - s031.t031@example.edu # Student 031
+      - s199.t199@example.edu # Student 199
+    grp08:
+      - s079.t079@example.edu # Student 079
+    grp10:
+      - s179.t179@example.edu # Student 179
+      - s201.t201@example.edu # Student 201
+    grp11:
+      - s095.t095@example.edu # Student 095
+      - s172.t172@example.edu # Student 172
+    grp12:
+      - s093.t093@example.edu # Student 093
+      - s148.t148@example.edu # Student 148
+    grp13:
+      - s124.t124@example.edu # Student 124
+      - s105.t105@example.edu # Student 105
+    grp14:
+      - s188.t188@example.edu # Student 188
+      - s072.t072@example.edu # Student 072
+    grp15:
+      - s193@example.edu # Student 193
+    grp16:
+      - s173.t173@example.edu # Student 173
+    grp18:
+      - s063.t063@example.edu # Student 063
+      - s138.t138@example.edu # Student 138
+    grp20:
+      - s217.t217@example.edu # Student 217
+    grp21:
+      - s210.t210@example.edu # Student 210
+    grp22:
+      - s220@example.edu # Student 220
+    grp23:
+      - s018.t018@example.edu # Student 018
+      - s174.t174@example.edu # Student 174
+    grp25:
+      - s015.t015@example.edu # Student 015
+      - s113.t113@example.edu # Student 113
+    grp31:
+      - s024.t024@example.edu # Student 024
+      - s164.t164@example.edu # Student 164
+    grp33:
+      - s068.t068@example.edu # Student 068
+      - s038.t038@example.edu # Student 038
+    grp34:
+      - s219.t219@example.edu # Student 219
+    grp35:
+      - s149.t149@example.edu # Student 149
+    grp36:
+      - s116.t116@example.edu # Student 116
+    grp37:
+      - s009@example.edu # Student 009
+    grp38:
+      - s101.t101@example.edu # Student 101
+      - s118.t118@example.edu # Student 118
+    grp39:
+      - s046@example.edu # Student 046
+    grp40:
+      - s141@example.edu # Student 141
+    grp41:
+      - s014.t014@example.edu
+      - s007.t007@example.edu
+    grp42:
+      - s023@example.edu # Student 023

--- a/config/testdata/courses/casecourse.yaml
+++ b/config/testdata/courses/casecourse.yaml
@@ -1,0 +1,74 @@
+# Synthetic fixture. The real course files are all lowercase throughout, so they
+# cannot detect a change in case handling. This one pins the exact behaviour on
+# the three axes where viper's case rules are load-bearing:
+#
+#   1. field names   -- viper is case-insensitive, `frombranch` == `fromBranch`
+#   2. map keys      -- viper LOWERCASES them, so `Grp01` becomes `grp01`; these
+#                       are data, not field names, and they end up in repo names
+#   3. list values   -- NOT touched by viper; they reach gitlabProjectPath as-is
+#
+# The golden records the derived repo names, because that is where a regression
+# would actually bite: a group silently renamed grp01 -> Grp01 is a *different*
+# GitLab project.
+casecourse:
+  coursepath: CaseCourse/Semester # gitlabGroupPath lowercases each segment
+  semesterpath: SS2026
+  useCoursenameAsPrefix: true
+  useEmailDomainAsSuffix: false
+
+  # Field names spelled all-lowercase and in legacy snake_case.
+  mixedfields:
+    assignmentpath: Blatt-01
+    description: Mixed-case field names
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:case/startercode.git
+      frombranch: template # lowercase spelling of fromBranch
+      tobranch: main # lowercase spelling of toBranch
+      templatemessage: Init # lowercase spelling of templateMessage
+    branches:
+      - name: main
+        mergeonly: true # lowercase spelling of mergeOnly
+        default: true
+      - name: startercode
+        protect: true
+        allow_force_push: true # snake_case alias of allowForcePush
+
+  # Upper-case map keys: deferredBranches names.
+  upperkeys:
+    assignmentpath: blatt-02
+    description: Upper-case map keys
+    per: group
+    startercode:
+      url: git@gitlab.lrz.de:case/startercode.git
+      fromBranch: template
+      toBranch: main
+    deferredBranches:
+      DevContainer:
+        url: git@gitlab.lrz.de:case/devcontainer.git
+        fromBranch: main
+        toBranch: DevContainer
+        orphan: true
+        orphanMessage: DevContainer snapshot
+
+  # Student identities that exercise both gitlabProjectPath branches: names that
+  # are already valid project paths survive verbatim (including their case),
+  # names containing an invalid char are parameterized (which also lowercases).
+  slugs:
+    assignmentpath: blatt-03
+    description: Project path slugification
+    per: student
+
+  students:
+    - plain@example.edu
+    - dotted.name@example.edu
+    - Upper.Case@example.edu # valid path -> kept verbatim, NOT lowercased
+    - plus+tag@example.edu # '+' invalid -> parameterized -> lowercased
+    - under_score@example.edu
+
+  groups:
+    Grp01: # viper lowercases the key -> grp01
+      - plain@example.edu
+      - Upper.Case@example.edu
+    grp02:
+      - dotted.name@example.edu

--- a/config/testdata/courses/fun.yaml
+++ b/config/testdata/courses/fun.yaml
@@ -1,0 +1,77 @@
+fun:
+  coursepath: fun/semester
+  semesterpath: ob-25ws
+
+  blatt1:
+    assignmentpath: blatt-1
+    description: Blatt 1, Funktionale Programmierung, WS 25/26
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fun/startercode/startercode01.git
+      fromBranch: 25ws-2
+    # accesslevel: guest
+
+  blatt2:
+    assignmentpath: blatt-2
+    description: Blatt 2, Funktionale Programmierung, WS 25/26
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fun/startercode/startercode02.git
+      fromBranch: 25ws
+    # accesslevel: guest
+
+  blatt3:
+    assignmentpath: blatt-3
+    description: Blatt 3, Funktionale Programmierung, WS 25/26
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fun/startercode/startercode03.git
+      fromBranch: 25ws
+
+  projekt:
+    assignmentpath: projekte
+    description: Projekt, Funktionale Programmierung, WS 25/26
+    per: group
+    startercode:
+      url: git@gitlab.lrz.de:fun/startercode/startercodeProjekt.git
+      fromBranch: main
+    clone:
+      localpath: /tmp/glabs/fun/25ws/projekte
+      branch: main
+      clone: true
+
+  students:
+    # Student 161
+    - s073.t073@example.edu
+    - s140.t140@example.edu
+    - s057@example.edu
+    - s082@example.edu
+    - s153.t153@example.edu
+    - s086.t086@example.edu
+    - s077.t077@example.edu
+    - s005@example.edu
+    - s104.t104@example.edu
+    - s159@example.edu
+    - s120.t120@example.edu
+    - s190@example.edu
+    - s087.t087@example.edu
+    - s115.t115@example.edu
+    - s058.t058@example.edu
+
+  groups:
+    grp00:
+      - s161.t161@example.edu
+    grp01:
+      - s086.t086@example.edu
+      - s058.t058@example.edu
+    grp02:
+      - s140.t140@example.edu
+      - s077.t077@example.edu
+      - s087.t087@example.edu
+    grp03:
+      - s057@example.edu
+      - s082@example.edu
+    grp04:
+      - s153.t153@example.edu
+      - s120.t120@example.edu
+      - s115.t115@example.edu

--- a/config/testdata/courses/fundc.yaml
+++ b/config/testdata/courses/fundc.yaml
@@ -1,0 +1,217 @@
+fundc:
+  coursepath: fundc/semester
+  semesterpath: ob-25ss
+
+  blatt02:
+    assignmentpath: blatt-02
+    description: Blatt 2, Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB02.git
+      fromBranch: 24ss-2
+    # accesslevel: guest
+
+  blatt03:
+    assignmentpath: blatt-03
+    description: Blatt 3, Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB03.git
+      fromBranch: 24ss
+    # accesslevel: guest
+
+  blatt04:
+    assignmentpath: blatt-04
+    description: Blatt 4 (Abgabe), Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB04.git
+      fromBranch: 24ss
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/fundc/24ss/blatt04
+      branch: develop
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+    accesslevel: guest
+
+  blatt05:
+    assignmentpath: blatt-05
+    description: Blatt 5, Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB05.git
+      fromBranch: 24ss
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/fundc/24ss/blatt05
+      branch: develop
+      clone: true
+    # accesslevel: guest
+
+  blatt06:
+    assignmentpath: blatt-06
+    description: Blatt 6, Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB06.git
+      fromBranch: 24ss
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/fundc/24ss/blatt06
+      branch: develop
+      clone: true
+    # accesslevel: guest
+
+  blatt07:
+    assignmentpath: blatt-07
+    description: Blatt 7 (Abgabe), Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB07.git
+      fromBranch: 24ss
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/fundc/24ss/blatt07
+      branch: develop
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+    accesslevel: guest
+
+  blatt08:
+    assignmentpath: blatt-08
+    description: Blatt 8, Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB08.git
+      fromBranch: 24ss
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/fundc/24ss/blatt08
+      branch: develop
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+    # accesslevel: guest
+
+  blatt09:
+    assignmentpath: blatt-09
+    description: Blatt 9, Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercode-blatt-09.git
+      fromBranch: 25ss # neuen Branch erzeugen!!!
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/fundc/24ss/blatt09
+      branch: develop
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+    # accesslevel: guest
+
+  blatt10:
+    assignmentpath: blatt-10
+    description: Blatt 10, Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB10.git
+      fromBranch: 25ss
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/fundc/25ss/blatt10
+      branch: develop
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+    # accesslevel: guest
+
+  blatt11:
+    assignmentpath: blatt-11
+    description: Blatt 11, Funktionale Programmierung, DC, SS 25
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:fundc/startercode/startercodeB11.git
+      fromBranch: 24ss
+      devBranch: develop
+      protectToBranch: true
+    clone:
+      localpath: /tmp/glabs/fundc/25ss/blatt11
+      branch: develop
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+    # accesslevel: guest
+
+  students:
+    - s161.t161@example.edu
+    - s001.t001@example.edu
+    - s112.t112@example.edu
+    - s006@example.edu
+    - s030.t030@example.edu
+    - s022.t022@example.edu
+    - s097.t097@example.edu
+    - s223@example.edu
+    - s222.t222@example.edu
+    - s064.t064@example.edu
+    - s080.t080@example.edu
+    - s008.t008@example.edu
+    - s017@example.edu
+    - s049.t049@example.edu
+    - s154.t154@example.edu
+    - s035.t035@example.edu
+    - s056@example.edu
+    - s011.t011@example.edu
+    - s150.t150@example.edu
+    - s122.t122@example.edu
+    - s033.t033@example.edu
+    - s040.t040@example.edu
+    - s106.t106@example.edu
+    - s123.t123@example.edu
+    - s196.t196@example.edu
+    - s127.t127@example.edu
+    - s134@example.edu
+    - s062.t062@example.edu
+    - s167.t167@example.edu
+    - s048.t048@example.edu
+    - s163@example.edu
+    - s090.t090@example.edu
+    - s060.t060@example.edu
+    - s119.t119@example.edu
+    - s108.t108@example.edu
+    - s175.t175@example.edu
+    - s043.t043@example.edu
+    - s041.t041@example.edu
+    - s203.t203@example.edu
+    - s125.t125@example.edu
+    - s111.t111@example.edu
+    - s050.t050@example.edu
+    - s091.t091@example.edu
+    - s160.t160@example.edu
+    - s204.t204@example.edu
+    - s026.t026@example.edu
+    - s027.t027@example.edu
+    - s211.t211@example.edu
+    - s212.t212@example.edu
+    - s010.t010@example.edu
+    - s052.t052@example.edu
+    - s032.t032@example.edu
+    - s117.t117@example.edu
+    - s214@example.edu
+    - s059@example.edu
+    - s094@example.edu

--- a/config/testdata/courses/legacy.yaml
+++ b/config/testdata/courses/legacy.yaml
@@ -1,0 +1,138 @@
+# Synthetic fixture pinning the legacy-key compatibility shims. Of these, only
+# `startercode.devBranch` / `protectToBranch` still appear in the real course
+# files (algdati, fundc); the rest are kept working for older configs and have
+# no live coverage at all.
+#
+# Note the subtle activation rules this fixture exists to pin down:
+#   - the startercode branch shims apply ONLY when `branches:` is absent
+#     (config/repo.go:98)
+#   - the startercode issue shims apply ONLY when `issues:` is absent entirely,
+#     not merely when replicateFromStartercode is false (config/repo.go:193)
+legacy:
+  coursepath: legacy/semester
+  semesterpath: ss2026
+  useCoursenameAsPrefix: true
+  useEmailDomainAsSuffix: false
+
+  # startercode.devBranch + protectToBranch + protectDevBranchMergeOnly,
+  # superseded by `branches:` but honoured here because `branches:` is absent.
+  devbranch:
+    assignmentpath: blatt-01
+    description: Legacy startercode branch keys
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:legacy/startercode.git
+      fromBranch: template
+      toBranch: main
+      devBranch: develop
+      protectToBranch: true
+      protectDevBranchMergeOnly: true
+      additionalBranches:
+        - extra
+
+  # Same legacy keys, but `branches:` is present and must win outright.
+  devbranchoverridden:
+    assignmentpath: blatt-01b
+    description: Legacy branch keys ignored because branches is set
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:legacy/startercode.git
+      fromBranch: template
+      toBranch: main
+      devBranch: develop
+      protectToBranch: true
+    branches:
+      - name: main
+        default: true
+
+  # startercode.replicateIssue + startercode.issueNumbers.
+  legacyissues:
+    assignmentpath: blatt-02
+    description: Legacy startercode issue keys
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:legacy/startercode.git
+      fromBranch: template
+      toBranch: main
+      replicateIssue: true
+      issueNumbers: [3, 4]
+
+  # `issues:` present but replication off -> the legacy shim must NOT kick in,
+  # even though startercode.replicateIssue says true.
+  legacyissuesshadowed:
+    assignmentpath: blatt-02b
+    description: Legacy issue keys shadowed by an explicit issues block
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:legacy/startercode.git
+      fromBranch: template
+      toBranch: main
+      replicateIssue: true
+      issueNumbers: [3, 4]
+    issues:
+      replicateFromStartercode: false
+
+  # approvals as a bare list (the pre-{settings, rules} form), plus both
+  # aliases of requiredApprovals.
+  #
+  # BUG, frozen on purpose: only `required_approvals` actually works. viper
+  # lowercases keys, so `approvalsRequired` arrives as `approvalsrequired`,
+  # which the alias table in config/assignment.go:443 compares against the
+  # camelCase spelling and therefore never matches. The rule silently ends up
+  # with RequiredApprovals 0 — i.e. no approval required at all. Latent today:
+  # no real course file uses the alias. Do not "fix" this by regenerating the
+  # golden; fix it in its own commit after the schema rewrite.
+  approvalslist:
+    assignmentpath: blatt-03
+    description: Legacy approvals list form
+    per: group
+    startercode:
+      url: git@gitlab.lrz.de:legacy/startercode.git
+      fromBranch: template
+      toBranch: main
+    mergeRequest:
+      mergeMethod: ff
+      squashOption: always
+      approvals:
+        - name: review
+          branch: main
+          required_approvals: 2 # snake_case alias -> works (already lowercase)
+          usernames: [obcode]
+        - name: second
+          branches: [main, startercode]
+          approvalsRequired: 1 # camelCase alias -> silently ignored, yields 0
+          groups: [tutors]
+          multiMemberGroupsOnly: true
+        - name: canonical
+          branches: [main]
+          requiredApprovals: 3 # canonical spelling -> works
+          usernames: [obcode]
+
+  # Normalization edge cases: a rule without branches is dropped entirely, a
+  # negative requiredApprovals is clamped to 0, whitespace is trimmed.
+  approvalsnormalized:
+    assignmentpath: blatt-04
+    description: Approvals normalization
+    per: group
+    startercode:
+      url: git@gitlab.lrz.de:legacy/startercode.git
+      fromBranch: template
+      toBranch: main
+    mergeRequest:
+      approvals:
+        rules:
+          - name: dropped-no-branches
+            requiredApprovals: 1
+          - name: "  padded  "
+            branches: ["  main  ", "", main] # trimmed, empties and dupes removed
+            requiredApprovals: -5 # clamped to 0
+            usernames: ["  obcode  ", ""]
+
+  students:
+    - a@example.edu
+    - b.two@example.edu
+
+  groups:
+    grp01:
+      - a@example.edu
+      - b.two@example.edu

--- a/config/testdata/courses/mpd.yaml
+++ b/config/testdata/courses/mpd.yaml
@@ -1,0 +1,263 @@
+mpd:
+  coursepath: mpd/semester
+  semesterpath: ob-26ss
+  useCoursenameAsPrefix: true
+  useEmailDomainAsSuffix: false
+
+  # Basis-Konfiguration, von der alle Assignments erben (extends: defaults).
+  # `abstract: true` macht dies zu einer reinen Basis: `glabs generate mpd
+  # defaults` (oder protect/clone/…) wird hart abgelehnt.
+  defaults:
+    abstract: true
+    per: student
+    mergeRequest:
+      mergeMethod: semi_linear
+      squashOption: never
+      pipeline: true
+      skippedPipelinesAreSuccessful: true
+      allThreadsMustBeResolved: true
+      statusChecksMustSucceed: true
+    branches:
+      - name: main
+        mergeOnly: true
+    issues:
+      replicateFromStartercode: true
+      issueNumbers: [1]
+
+  # ---------------------------------------------------------------------------
+  # Frühe Blätter (Template-Familie): startercode aus Branch `template`,
+  # keine deferredBranches. blatt02–05 erben sequenziell und ändern nur
+  # url + description.
+  # ---------------------------------------------------------------------------
+  blatt01:
+    extends: defaults
+    assignmentpath: blatt-01
+    description: Blatt 1, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/startercode/blatt-01.git
+      fromBranch: template
+      toBranch: main
+
+  blatt02:
+    extends: blatt01
+    assignmentpath: blatt-02
+    description: Blatt 2, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/startercode/blatt-02.git
+
+  blatt03:
+    extends: blatt02
+    assignmentpath: blatt-03
+    description: Blatt 3, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/startercode/blatt-03.git
+
+  blatt04:
+    extends: blatt03
+    assignmentpath: blatt-04
+    description: Blatt 4, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/startercode/blatt-04.git
+
+  blatt05:
+    extends: blatt04
+    assignmentpath: blatt-05
+    description: Blatt 5, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/startercode/blatt-05.git
+
+  # ---------------------------------------------------------------------------
+  # blatt06: startercode aus Branch `startercode` als Template, mit
+  # Lösungs-Branch und lokalem clone. Eigenständig (kein passender Vorgänger).
+  # ---------------------------------------------------------------------------
+  blatt06:
+    extends: defaults
+    assignmentpath: blatt-06
+    description: Blatt 6, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/startercode/blatt-06.git
+      fromBranch: startercode
+      template: true
+      templateMessage: Initial Commit
+    deferredBranches:
+      #   devcontainer:
+      #     url: git@gitlab.lrz.de:mpd/devcontainer.git
+      #     fromBranch: main
+      #     toBranch: devcontainer
+      solution:
+        # url: git@gitlab.lrz.de:mpd/startercode/blatt-06.git
+        fromBranch: main
+        toBranch: solution
+        orphan: true
+        orphanMessage: Lösungsvorschlag [skip ci]
+    clone:
+      localpath: /tmp/glabs/mpd/26ss/blatt1
+      clone: true
+
+  # ---------------------------------------------------------------------------
+  # blatt07 + mockexam: devcontainer + (nicht-orphan) Lösungs-Branch,
+  # Issues inkl. Child-Tasks. mockexam erbt von blatt07.
+  # ---------------------------------------------------------------------------
+  # glabs generate mpd blatt07
+  # glabs protect mpd blatt07
+  # glabs push mpd blatt07 devcontainer
+  blatt07:
+    extends: defaults
+    assignmentpath: blatt-07
+    description: Blatt 7, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/startercode/blatt-07.git
+      fromBranch: startercode
+      # template: true
+      # templateMessage: Initial Commit
+    issues:
+      issueNumbers: [2]
+      includeChildTasks: true
+    deferredBranches:
+      devcontainer:
+        url: git@gitlab.lrz.de:mpd/devcontainer.git
+        fromBranch: main
+        toBranch: devcontainer
+        orphan: true
+        orphanMessage: "publish: devcontainer [skip ci]"
+      solution:
+        # url: git@gitlab.lrz.de:mpd/startercode/blatt-07.git
+        fromBranch: solution
+        # toBranch: solution
+        orphan: false
+        # orphanMessage: Lösungsvorschlag
+
+  # glabs generate mpd mockexam
+  # glabs protect mpd mockexam
+  # glabs push mpd mockexam devcontainer
+  # glabs push mpd mockexam solution
+  mockexam:
+    extends: blatt07
+    assignmentpath: mockexam
+    description: Probeprüfung, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/labs/mockexam.git
+    issues:
+      issueNumbers: [1]
+
+  # ---------------------------------------------------------------------------
+  # Moderne Familie (blatt08 → blatt09 → blatt10): Template aus `startercode`,
+  # devcontainer + orphan-Lösungs-Branch, Issues inkl. Child-Tasks.
+  # blatt09/10 ändern nur url (+ tag) + description.
+  # ---------------------------------------------------------------------------
+  # glabs generate mpd blatt08
+  # glabs protect mpd blatt08
+  # glabs push mpd blatt08 devcontainer
+  # glabs push mpd blatt08 solution
+  blatt08:
+    extends: defaults
+    assignmentpath: blatt-08
+    description: Blatt 8, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/labs/blatt-08.git
+      fromBranch: startercode
+      template: true
+      templateMessage: "Startercode [skip ci]"
+    issues:
+      includeChildTasks: true
+    deferredBranches:
+      devcontainer:
+        url: git@gitlab.lrz.de:mpd/devcontainer.git
+        fromBranch: main
+        toBranch: devcontainer
+        orphan: true
+        orphanMessage: "DevContainer [skip ci]"
+      solution:
+        # url: git@gitlab.lrz.de:mpd/labs/blatt-08.git
+        fromBranch: solution
+        # toBranch: solution
+        orphan: true
+        orphanMessage: "Lösungsvorschlag [skip ci]"
+
+  # glabs generate mpd blatt09
+  # glabs protect mpd blatt09
+  # glabs push mpd blatt09 devcontainer
+  # glabs push mpd blatt09 solution
+  blatt09:
+    extends: blatt08
+    assignmentpath: blatt-09
+    description: Blatt 9, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/labs/blatt-09.git
+      tag: startercode
+
+  # glabs generate mpd blatt10
+  # glabs protect mpd blatt10
+  # glabs push mpd blatt10 devcontainer
+  # glabs push mpd blatt10 solution
+  blatt10:
+    extends: blatt09
+    assignmentpath: blatt-10
+    description: Blatt 10, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/labs/blatt-10.git
+
+  # glabs generate mpd blatt11
+  # glabs protect mpd blatt11
+  # glabs push mpd blatt11 devcontainer
+  # glabs push mpd blatt11 solution
+  blatt11:
+    extends: blatt10
+    assignmentpath: blatt-11
+    description: Blatt 11, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/labs/blatt-11.git
+
+  # glabs generate mpd blatt12
+  # glabs protect mpd blatt12
+  # glabs push mpd blatt12 devcontainer
+  # glabs push mpd blatt12 solution
+  blatt12:
+    extends: blatt11
+    assignmentpath: blatt-12
+    description: Blatt 12, Moderne Programmierkonzepte und Datenstrukturen
+    startercode:
+      url: git@gitlab.lrz.de:mpd/labs/blatt-12.git
+
+  students:
+    - s161.t161@example.edu
+    - s069.t069@example.edu
+    - s168.t168@example.edu
+    - s171.t171@example.edu
+    - s076.t076@example.edu
+    - s002.t002@example.edu
+    - s176.t176@example.edu
+    - s170.t170@example.edu
+    - s221.t221@example.edu
+    - s157.t157@example.edu
+    - s202.t202@example.edu
+    - s139.t139@example.edu
+    - s180.t180@example.edu
+    - s051.t051@example.edu
+    - s042.t042@example.edu
+    - s183.t183@example.edu
+    - s099.t099@example.edu
+    - s146.t146@example.edu
+    - s147.t147@example.edu
+    - s102.t102@example.edu
+    - s121.t121@example.edu
+    - s061.t061@example.edu
+    - s216.t216@example.edu
+    - s145@example.edu
+    - s158.t158@example.edu
+    - s130.t130@example.edu
+    - s195.t195@example.edu
+    - s037.t037@example.edu
+    - s218.t218@example.edu
+    - s131.t131@example.edu
+    - s020.t020@example.edu
+    - s178.t178@example.edu
+    - s192.t192@example.edu
+    - s100.t100@example.edu
+    - s012.t012@example.edu
+    - s197.t197@example.edu
+    - s126.t126@example.edu
+    - s028.t028@example.edu
+    - s182.t182@example.edu
+    - s074.t074@example.edu
+    - s213.t213@example.edu

--- a/config/testdata/courses/vss.yaml
+++ b/config/testdata/courses/vss.yaml
@@ -1,0 +1,304 @@
+vss:
+  coursepath: vss/semester
+  semesterpath: ob-26ss
+  useCoursenameAsPrefix: true
+  useEmailDomainAsSuffix: false
+
+  # collaborative-working-with-gitlab:
+  #   assignmentpath: supplementary-material
+  #   description: "Explorative Methods and Data Visualization - Illustration of how to use GitLab for collaborative projects."
+  #   per: group
+  #   startercode:
+  #     url: git@gitlab.lrz.de:vss/startercode/startercodeB0.git
+  #     fromBranch: main
+  #   branches:
+  #     - name: main
+  #       mergeOnly: true
+  #   issues:
+  #     replicateFromStartercode: true
+  #     issueNumbers: [1, 2, 3]
+
+  blatt0:
+    assignmentpath: blatt-0
+    description: Blatt 0, Verteilte Softwaresysteme, SS 26
+    per: student
+    startercode:
+      url: git@gitlab.lrz.de:vss/startercode/startercodeB0.git
+      fromBranch: template
+      toBranch: main
+    branches:
+      - name: main
+        default: true
+      - name: startercode
+        protect: true
+    clone:
+      localpath: /tmp/glabs/vss/26ss/blatt0
+      branch: develop
+      clone: true
+
+# glabs report vss blatt1 --html -o vss-blatt1.html
+  blatt1:
+    assignmentpath: blatt-1
+    description: Blatt 1, Verteilte Softwaresysteme, SS 26
+    per: group
+    containerRegistry: true
+    startercode:
+      url: git@gitlab.lrz.de:vss/startercode/startercodeB1.git
+      fromBranch: template
+      toBranch: main
+    branches:
+      - name: main
+        mergeOnly: true
+        default: true
+      - name: startercode
+        protect: true
+    issues:
+      replicateFromStartercode: true
+      issueNumbers: [1]
+    mergeRequest:
+      mergeMethod: semi_linear
+      squashOption: never
+      pipeline: true
+      skippedPipelinesAreSuccessful: false
+      allThreadsMustBeResolved: true
+      statusChecksMustSucceed: true
+    clone:
+      localpath: /tmp/glabs/vss/26ss/blatt1
+      branch: develop
+      clone: true
+    # accesslevel: guest
+    release:
+      mergeRequest:
+        pipeline: true
+
+  blatt2:
+    assignmentpath: blatt-2
+    description: Blatt 2, Verteilte Softwaresysteme, SS 26
+    per: group
+    containerRegistry: true
+    startercode:
+      url: git@gitlab.lrz.de:vss/startercode/startercodeB2.git
+      fromBranch: template
+      toBranch: main
+    branches:
+      - name: main
+        mergeOnly: true
+        default: true
+      - name: startercode
+        protect: true
+    issues:
+      replicateFromStartercode: true
+      issueNumbers: [1]
+    mergeRequest:
+      mergeMethod: semi_linear
+      squashOption: never
+      pipeline: true
+      skippedPipelinesAreSuccessful: false
+      statusChecksMustSucceed: true
+      allThreadsMustBeResolved: true
+      approvals:
+        settings:
+          preventApprovalByMergeRequestCreator: true
+          preventApprovalsByUsersWhoAddCommits: false
+          preventEditingApprovalRulesInMergeRequests: true
+          requireUserReauthenticationToApprove: false
+          whenCommitAdded: removeAllApprovals
+        rules:
+          - name: review
+            branches:
+              - main
+              - startercode
+            requiredApprovals: 1
+            multiMemberGroupsOnly: true
+          - name: submission
+            branch: startercode
+            usernames:
+              - obcode
+            requiredApprovals: 1
+    clone:
+      localpath: /tmp/glabs/vss/26ss/blatt2
+      branch: main
+      clone: true
+    # accesslevel: guest
+    release:
+      mergeRequest:
+        pipeline: true
+        dockerImages:
+          - service/customer
+          - service/order
+          - service/payment
+          - service/shipment
+          - service/stock
+          - service/supplier
+
+  students:
+    - s161.t161@example.edu
+    - s013@example.edu
+    - s054@example.edu
+    - s191.t191@example.edu
+    - s053.t053@example.edu
+    - s021@example.edu
+    - s073.t073@example.edu
+    - s209.t209@example.edu
+    - s152.t152@example.edu
+    - s081@example.edu
+    - s206.t206@example.edu
+    - s194.t194@example.edu
+    - s198.t198@example.edu
+    - s215.t215@example.edu
+    - s039.t039@example.edu
+    - s067.t067@example.edu
+    - s019.t019@example.edu
+    - s088.t088@example.edu
+    - s045.t045@example.edu
+    - s089.t089@example.edu
+    - s036.t036@example.edu
+    - s066@example.edu
+    - s085.t085@example.edu
+    - s155.t155@example.edu
+    - s109.t109@example.edu
+    - s205.t205@example.edu
+    - s070.t070@example.edu
+    - s047.t047@example.edu
+    - s084@example.edu
+    - s143.t143@example.edu
+    - s189.t189@example.edu
+    - s136.t136@example.edu
+    - s142@example.edu
+    - s200.t200@example.edu
+    - s107@example.edu
+    - s185.t185@example.edu
+    - s207.t207@example.edu
+    - s078.t078@example.edu
+    - s151@example.edu
+    - s132.t132@example.edu
+    - s004.t004@example.edu
+    - s166@example.edu
+    - s075.t075@example.edu
+    - s169@example.edu
+    - s044.t044@example.edu
+    - s184.t184@example.edu
+    - s114.t114@example.edu
+    - s137.t137@example.edu
+    - s003.t003@example.edu
+    - s190@example.edu
+    - s034.t034@example.edu
+    - s055.t055@example.edu
+    - s133.t133@example.edu
+    - s029.t029@example.edu
+    - s165.t165@example.edu
+    - s144.t144@example.edu
+    - s096.t096@example.edu
+    - s128.t128@example.edu
+    - s071.t071@example.edu
+    - s083.t083@example.edu
+    - s103@example.edu
+    - s092.t092@example.edu
+    - s129.t129@example.edu
+
+  groups:
+    grp00:
+      - s161.t161@example.edu
+
+    grp01:
+      - s081@example.edu # Student 081
+      - s036.t036@example.edu # Student 036
+    grp02:
+      - s070.t070@example.edu # Student 070
+      - s132.t132@example.edu # Student 132
+    grp03:
+      - s089.t089@example.edu # Student 089
+      - s165.t165@example.edu # Student 165
+    grp04:
+      - s198.t198@example.edu # Student 198
+      - s114.t114@example.edu # Student 114
+    grp05:
+      - s019.t019@example.edu # Student 019
+      - s107@example.edu # Student 107
+    grp06:
+      - s054@example.edu # Student 054
+      - s129.t129@example.edu # Student 129
+    grp07:
+      - s013@example.edu # Student 013
+      - s083.t083@example.edu # Student 083
+    grp08:
+      - s067.t067@example.edu # Student 067
+      - s066@example.edu # Student 066
+    grp09:
+      - s152.t152@example.edu # Student 152
+      - s166@example.edu # Student 166
+    grp10:
+      - s143.t143@example.edu # Student 143
+      - s029.t029@example.edu # Student 029
+    grp11:
+      - s189.t189@example.edu # Student 189
+      - s103@example.edu # Student 103
+    grp12:
+      - s215.t215@example.edu # Student 215
+      - s004.t004@example.edu # Student 004
+    grp13:
+      - s191.t191@example.edu # Student 191
+      - s184.t184@example.edu # Student 184
+    grp14:
+      - s137.t137@example.edu # Student 137
+    grp15:
+      - s085.t085@example.edu # Student 085
+      - s185.t185@example.edu # Student 185
+    grp16:
+      - s207.t207@example.edu # Student 207
+    grp17:
+      - s206.t206@example.edu # Student 206
+      - s169@example.edu # Student 169
+    grp18:
+      - s088.t088@example.edu # Student 088
+    grp19:
+      - s078.t078@example.edu # Student 078
+    grp20:
+      - s039.t039@example.edu # Student 039
+      - s155.t155@example.edu # Student 155
+    grp21:
+      - s136.t136@example.edu # Student 136
+      - s142@example.edu # Student 142
+    grp22:
+      - s190@example.edu # Student 190
+    grp23:
+      - s055.t055@example.edu # Student 055
+    grp24:
+      - s053.t053@example.edu # Student 053
+    grp25:
+      - s200.t200@example.edu # Student 200
+    grp26:
+      - s003.t003@example.edu # Student 003
+    grp27:
+      - s021@example.edu # Student 021
+    grp28:
+      - s096.t096@example.edu # Student 096
+      - s128.t128@example.edu # Student 128
+    grp29:
+      - s034.t034@example.edu # Student 034
+    grp30:
+      - s133.t133@example.edu # Student 133
+      - s092.t092@example.edu # Student 092
+    grp32:
+      - s151@example.edu # Student 151
+    grp33:
+      - s194.t194@example.edu # Student 194
+    grp35:
+      - s109.t109@example.edu # Student 109
+      - s084@example.edu # Student 084
+    grp36:
+      - s044.t044@example.edu # Student 044
+    grp37:
+      - s073.t073@example.edu # Student 073
+    grp38:
+      - s071.t071@example.edu # Student 071
+    grp39:
+      - s075.t075@example.edu # Student 075
+    grp40:
+      - s205.t205@example.edu # Student 205
+    grp41:
+      - s047.t047@example.edu # Student 047
+    grp42:
+      - s209.t209@example.edu # Student 209
+    grp43:
+      - s144.t144@example.edu # Student 144

--- a/config/testdata/golden/algdati.blatt1.json
+++ b/config/testdata/golden/algdati.blatt1.json
@@ -1,0 +1,467 @@
+{
+  "course": "algdati",
+  "name": "blatt1",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "algdati/semester/ob-25ws/blatt-1",
+  "url": "https://gitlab.lrz.de/algdati/semester/ob-25ws/blatt-1",
+  "repoBaseName": "blatt1",
+  "per": "student",
+  "description": "Blatt 1, Algorithmen und Datenstrukturen I, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:algdati/startercode/startercodeBlatt1.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s007.t007@example.edu",
+      "email": "s007.t007@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s007.t007_at_example.edu",
+      "repoName": "blatt1-s007.t007_at_example.edu"
+    },
+    {
+      "raw": "s009@example.edu",
+      "email": "s009@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s009_at_example.edu",
+      "repoName": "blatt1-s009_at_example.edu"
+    },
+    {
+      "raw": "s014.t014@example.edu",
+      "email": "s014.t014@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s014.t014_at_example.edu",
+      "repoName": "blatt1-s014.t014_at_example.edu"
+    },
+    {
+      "raw": "s015.t015@example.edu",
+      "email": "s015.t015@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s015.t015_at_example.edu",
+      "repoName": "blatt1-s015.t015_at_example.edu"
+    },
+    {
+      "raw": "s016@example.edu",
+      "email": "s016@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s016_at_example.edu",
+      "repoName": "blatt1-s016_at_example.edu"
+    },
+    {
+      "raw": "s018.t018@example.edu",
+      "email": "s018.t018@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s018.t018_at_example.edu",
+      "repoName": "blatt1-s018.t018_at_example.edu"
+    },
+    {
+      "raw": "s024.t024@example.edu",
+      "email": "s024.t024@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s024.t024_at_example.edu",
+      "repoName": "blatt1-s024.t024_at_example.edu"
+    },
+    {
+      "raw": "s025.t025@example.edu",
+      "email": "s025.t025@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s025.t025_at_example.edu",
+      "repoName": "blatt1-s025.t025_at_example.edu"
+    },
+    {
+      "raw": "s031.t031@example.edu",
+      "email": "s031.t031@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s031.t031_at_example.edu",
+      "repoName": "blatt1-s031.t031_at_example.edu"
+    },
+    {
+      "raw": "s038.t038@example.edu",
+      "email": "s038.t038@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s038.t038_at_example.edu",
+      "repoName": "blatt1-s038.t038_at_example.edu"
+    },
+    {
+      "raw": "s046@example.edu",
+      "email": "s046@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s046_at_example.edu",
+      "repoName": "blatt1-s046_at_example.edu"
+    },
+    {
+      "raw": "s063.t063@example.edu",
+      "email": "s063.t063@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s063.t063_at_example.edu",
+      "repoName": "blatt1-s063.t063_at_example.edu"
+    },
+    {
+      "raw": "s065.t065@example.edu",
+      "email": "s065.t065@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s065.t065_at_example.edu",
+      "repoName": "blatt1-s065.t065_at_example.edu"
+    },
+    {
+      "raw": "s068.t068@example.edu",
+      "email": "s068.t068@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s068.t068_at_example.edu",
+      "repoName": "blatt1-s068.t068_at_example.edu"
+    },
+    {
+      "raw": "s072.t072@example.edu",
+      "email": "s072.t072@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s072.t072_at_example.edu",
+      "repoName": "blatt1-s072.t072_at_example.edu"
+    },
+    {
+      "raw": "s073.t073@example.edu",
+      "email": "s073.t073@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s073.t073_at_example.edu",
+      "repoName": "blatt1-s073.t073_at_example.edu"
+    },
+    {
+      "raw": "s079.t079@example.edu",
+      "email": "s079.t079@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s079.t079_at_example.edu",
+      "repoName": "blatt1-s079.t079_at_example.edu"
+    },
+    {
+      "raw": "s093.t093@example.edu",
+      "email": "s093.t093@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s093.t093_at_example.edu",
+      "repoName": "blatt1-s093.t093_at_example.edu"
+    },
+    {
+      "raw": "s095.t095@example.edu",
+      "email": "s095.t095@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s095.t095_at_example.edu",
+      "repoName": "blatt1-s095.t095_at_example.edu"
+    },
+    {
+      "raw": "s098.t098@example.edu",
+      "email": "s098.t098@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s098.t098_at_example.edu",
+      "repoName": "blatt1-s098.t098_at_example.edu"
+    },
+    {
+      "raw": "s101.t101@example.edu",
+      "email": "s101.t101@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s101.t101_at_example.edu",
+      "repoName": "blatt1-s101.t101_at_example.edu"
+    },
+    {
+      "raw": "s105.t105@example.edu",
+      "email": "s105.t105@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s105.t105_at_example.edu",
+      "repoName": "blatt1-s105.t105_at_example.edu"
+    },
+    {
+      "raw": "s110.t110@example.edu",
+      "email": "s110.t110@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s110.t110_at_example.edu",
+      "repoName": "blatt1-s110.t110_at_example.edu"
+    },
+    {
+      "raw": "s113.t113@example.edu",
+      "email": "s113.t113@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s113.t113_at_example.edu",
+      "repoName": "blatt1-s113.t113_at_example.edu"
+    },
+    {
+      "raw": "s116.t116@example.edu",
+      "email": "s116.t116@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s116.t116_at_example.edu",
+      "repoName": "blatt1-s116.t116_at_example.edu"
+    },
+    {
+      "raw": "s118.t118@example.edu",
+      "email": "s118.t118@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s118.t118_at_example.edu",
+      "repoName": "blatt1-s118.t118_at_example.edu"
+    },
+    {
+      "raw": "s124.t124@example.edu",
+      "email": "s124.t124@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s124.t124_at_example.edu",
+      "repoName": "blatt1-s124.t124_at_example.edu"
+    },
+    {
+      "raw": "s138.t138@example.edu",
+      "email": "s138.t138@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s138.t138_at_example.edu",
+      "repoName": "blatt1-s138.t138_at_example.edu"
+    },
+    {
+      "raw": "s141@example.edu",
+      "email": "s141@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s141_at_example.edu",
+      "repoName": "blatt1-s141_at_example.edu"
+    },
+    {
+      "raw": "s148.t148@example.edu",
+      "email": "s148.t148@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s148.t148_at_example.edu",
+      "repoName": "blatt1-s148.t148_at_example.edu"
+    },
+    {
+      "raw": "s149.t149@example.edu",
+      "email": "s149.t149@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s149.t149_at_example.edu",
+      "repoName": "blatt1-s149.t149_at_example.edu"
+    },
+    {
+      "raw": "s156.t156@example.edu",
+      "email": "s156.t156@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s156.t156_at_example.edu",
+      "repoName": "blatt1-s156.t156_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt1-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s162.t162@example.edu",
+      "email": "s162.t162@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s162.t162_at_example.edu",
+      "repoName": "blatt1-s162.t162_at_example.edu"
+    },
+    {
+      "raw": "s164.t164@example.edu",
+      "email": "s164.t164@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s164.t164_at_example.edu",
+      "repoName": "blatt1-s164.t164_at_example.edu"
+    },
+    {
+      "raw": "s172.t172@example.edu",
+      "email": "s172.t172@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s172.t172_at_example.edu",
+      "repoName": "blatt1-s172.t172_at_example.edu"
+    },
+    {
+      "raw": "s173.t173@example.edu",
+      "email": "s173.t173@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s173.t173_at_example.edu",
+      "repoName": "blatt1-s173.t173_at_example.edu"
+    },
+    {
+      "raw": "s174.t174@example.edu",
+      "email": "s174.t174@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s174.t174_at_example.edu",
+      "repoName": "blatt1-s174.t174_at_example.edu"
+    },
+    {
+      "raw": "s177.t177@example.edu",
+      "email": "s177.t177@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s177.t177_at_example.edu",
+      "repoName": "blatt1-s177.t177_at_example.edu"
+    },
+    {
+      "raw": "s179.t179@example.edu",
+      "email": "s179.t179@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s179.t179_at_example.edu",
+      "repoName": "blatt1-s179.t179_at_example.edu"
+    },
+    {
+      "raw": "s181.t181@example.edu",
+      "email": "s181.t181@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s181.t181_at_example.edu",
+      "repoName": "blatt1-s181.t181_at_example.edu"
+    },
+    {
+      "raw": "s186.t186@example.edu",
+      "email": "s186.t186@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s186.t186_at_example.edu",
+      "repoName": "blatt1-s186.t186_at_example.edu"
+    },
+    {
+      "raw": "s187.t187@example.edu",
+      "email": "s187.t187@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s187.t187_at_example.edu",
+      "repoName": "blatt1-s187.t187_at_example.edu"
+    },
+    {
+      "raw": "s188.t188@example.edu",
+      "email": "s188.t188@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s188.t188_at_example.edu",
+      "repoName": "blatt1-s188.t188_at_example.edu"
+    },
+    {
+      "raw": "s193@example.edu",
+      "email": "s193@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s193_at_example.edu",
+      "repoName": "blatt1-s193_at_example.edu"
+    },
+    {
+      "raw": "s199.t199@example.edu",
+      "email": "s199.t199@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s199.t199_at_example.edu",
+      "repoName": "blatt1-s199.t199_at_example.edu"
+    },
+    {
+      "raw": "s201.t201@example.edu",
+      "email": "s201.t201@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s201.t201_at_example.edu",
+      "repoName": "blatt1-s201.t201_at_example.edu"
+    },
+    {
+      "raw": "s208.t208@example.edu",
+      "email": "s208.t208@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s208.t208_at_example.edu",
+      "repoName": "blatt1-s208.t208_at_example.edu"
+    },
+    {
+      "raw": "s210.t210@example.edu",
+      "email": "s210.t210@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s210.t210_at_example.edu",
+      "repoName": "blatt1-s210.t210_at_example.edu"
+    },
+    {
+      "raw": "s217.t217@example.edu",
+      "email": "s217.t217@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s217.t217_at_example.edu",
+      "repoName": "blatt1-s217.t217_at_example.edu"
+    },
+    {
+      "raw": "s220@example.edu",
+      "email": "s220@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s220_at_example.edu",
+      "repoName": "blatt1-s220_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/algdati.blatt2-1.json
+++ b/config/testdata/golden/algdati.blatt2-1.json
@@ -1,0 +1,467 @@
+{
+  "course": "algdati",
+  "name": "blatt2-1",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "algdati/semester/ob-25ws/blatt-2-1",
+  "url": "https://gitlab.lrz.de/algdati/semester/ob-25ws/blatt-2-1",
+  "repoBaseName": "blatt2-1",
+  "per": "student",
+  "description": "Blatt 2, Algorithmen und Datenstrukturen I, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:algdati/startercode/startercodeBlatt2.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s007.t007@example.edu",
+      "email": "s007.t007@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s007.t007_at_example.edu",
+      "repoName": "blatt2-1-s007.t007_at_example.edu"
+    },
+    {
+      "raw": "s009@example.edu",
+      "email": "s009@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s009_at_example.edu",
+      "repoName": "blatt2-1-s009_at_example.edu"
+    },
+    {
+      "raw": "s014.t014@example.edu",
+      "email": "s014.t014@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s014.t014_at_example.edu",
+      "repoName": "blatt2-1-s014.t014_at_example.edu"
+    },
+    {
+      "raw": "s015.t015@example.edu",
+      "email": "s015.t015@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s015.t015_at_example.edu",
+      "repoName": "blatt2-1-s015.t015_at_example.edu"
+    },
+    {
+      "raw": "s016@example.edu",
+      "email": "s016@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s016_at_example.edu",
+      "repoName": "blatt2-1-s016_at_example.edu"
+    },
+    {
+      "raw": "s018.t018@example.edu",
+      "email": "s018.t018@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s018.t018_at_example.edu",
+      "repoName": "blatt2-1-s018.t018_at_example.edu"
+    },
+    {
+      "raw": "s024.t024@example.edu",
+      "email": "s024.t024@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s024.t024_at_example.edu",
+      "repoName": "blatt2-1-s024.t024_at_example.edu"
+    },
+    {
+      "raw": "s025.t025@example.edu",
+      "email": "s025.t025@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s025.t025_at_example.edu",
+      "repoName": "blatt2-1-s025.t025_at_example.edu"
+    },
+    {
+      "raw": "s031.t031@example.edu",
+      "email": "s031.t031@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s031.t031_at_example.edu",
+      "repoName": "blatt2-1-s031.t031_at_example.edu"
+    },
+    {
+      "raw": "s038.t038@example.edu",
+      "email": "s038.t038@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s038.t038_at_example.edu",
+      "repoName": "blatt2-1-s038.t038_at_example.edu"
+    },
+    {
+      "raw": "s046@example.edu",
+      "email": "s046@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s046_at_example.edu",
+      "repoName": "blatt2-1-s046_at_example.edu"
+    },
+    {
+      "raw": "s063.t063@example.edu",
+      "email": "s063.t063@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s063.t063_at_example.edu",
+      "repoName": "blatt2-1-s063.t063_at_example.edu"
+    },
+    {
+      "raw": "s065.t065@example.edu",
+      "email": "s065.t065@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s065.t065_at_example.edu",
+      "repoName": "blatt2-1-s065.t065_at_example.edu"
+    },
+    {
+      "raw": "s068.t068@example.edu",
+      "email": "s068.t068@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s068.t068_at_example.edu",
+      "repoName": "blatt2-1-s068.t068_at_example.edu"
+    },
+    {
+      "raw": "s072.t072@example.edu",
+      "email": "s072.t072@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s072.t072_at_example.edu",
+      "repoName": "blatt2-1-s072.t072_at_example.edu"
+    },
+    {
+      "raw": "s073.t073@example.edu",
+      "email": "s073.t073@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s073.t073_at_example.edu",
+      "repoName": "blatt2-1-s073.t073_at_example.edu"
+    },
+    {
+      "raw": "s079.t079@example.edu",
+      "email": "s079.t079@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s079.t079_at_example.edu",
+      "repoName": "blatt2-1-s079.t079_at_example.edu"
+    },
+    {
+      "raw": "s093.t093@example.edu",
+      "email": "s093.t093@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s093.t093_at_example.edu",
+      "repoName": "blatt2-1-s093.t093_at_example.edu"
+    },
+    {
+      "raw": "s095.t095@example.edu",
+      "email": "s095.t095@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s095.t095_at_example.edu",
+      "repoName": "blatt2-1-s095.t095_at_example.edu"
+    },
+    {
+      "raw": "s098.t098@example.edu",
+      "email": "s098.t098@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s098.t098_at_example.edu",
+      "repoName": "blatt2-1-s098.t098_at_example.edu"
+    },
+    {
+      "raw": "s101.t101@example.edu",
+      "email": "s101.t101@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s101.t101_at_example.edu",
+      "repoName": "blatt2-1-s101.t101_at_example.edu"
+    },
+    {
+      "raw": "s105.t105@example.edu",
+      "email": "s105.t105@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s105.t105_at_example.edu",
+      "repoName": "blatt2-1-s105.t105_at_example.edu"
+    },
+    {
+      "raw": "s110.t110@example.edu",
+      "email": "s110.t110@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s110.t110_at_example.edu",
+      "repoName": "blatt2-1-s110.t110_at_example.edu"
+    },
+    {
+      "raw": "s113.t113@example.edu",
+      "email": "s113.t113@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s113.t113_at_example.edu",
+      "repoName": "blatt2-1-s113.t113_at_example.edu"
+    },
+    {
+      "raw": "s116.t116@example.edu",
+      "email": "s116.t116@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s116.t116_at_example.edu",
+      "repoName": "blatt2-1-s116.t116_at_example.edu"
+    },
+    {
+      "raw": "s118.t118@example.edu",
+      "email": "s118.t118@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s118.t118_at_example.edu",
+      "repoName": "blatt2-1-s118.t118_at_example.edu"
+    },
+    {
+      "raw": "s124.t124@example.edu",
+      "email": "s124.t124@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s124.t124_at_example.edu",
+      "repoName": "blatt2-1-s124.t124_at_example.edu"
+    },
+    {
+      "raw": "s138.t138@example.edu",
+      "email": "s138.t138@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s138.t138_at_example.edu",
+      "repoName": "blatt2-1-s138.t138_at_example.edu"
+    },
+    {
+      "raw": "s141@example.edu",
+      "email": "s141@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s141_at_example.edu",
+      "repoName": "blatt2-1-s141_at_example.edu"
+    },
+    {
+      "raw": "s148.t148@example.edu",
+      "email": "s148.t148@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s148.t148_at_example.edu",
+      "repoName": "blatt2-1-s148.t148_at_example.edu"
+    },
+    {
+      "raw": "s149.t149@example.edu",
+      "email": "s149.t149@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s149.t149_at_example.edu",
+      "repoName": "blatt2-1-s149.t149_at_example.edu"
+    },
+    {
+      "raw": "s156.t156@example.edu",
+      "email": "s156.t156@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s156.t156_at_example.edu",
+      "repoName": "blatt2-1-s156.t156_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt2-1-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s162.t162@example.edu",
+      "email": "s162.t162@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s162.t162_at_example.edu",
+      "repoName": "blatt2-1-s162.t162_at_example.edu"
+    },
+    {
+      "raw": "s164.t164@example.edu",
+      "email": "s164.t164@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s164.t164_at_example.edu",
+      "repoName": "blatt2-1-s164.t164_at_example.edu"
+    },
+    {
+      "raw": "s172.t172@example.edu",
+      "email": "s172.t172@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s172.t172_at_example.edu",
+      "repoName": "blatt2-1-s172.t172_at_example.edu"
+    },
+    {
+      "raw": "s173.t173@example.edu",
+      "email": "s173.t173@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s173.t173_at_example.edu",
+      "repoName": "blatt2-1-s173.t173_at_example.edu"
+    },
+    {
+      "raw": "s174.t174@example.edu",
+      "email": "s174.t174@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s174.t174_at_example.edu",
+      "repoName": "blatt2-1-s174.t174_at_example.edu"
+    },
+    {
+      "raw": "s177.t177@example.edu",
+      "email": "s177.t177@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s177.t177_at_example.edu",
+      "repoName": "blatt2-1-s177.t177_at_example.edu"
+    },
+    {
+      "raw": "s179.t179@example.edu",
+      "email": "s179.t179@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s179.t179_at_example.edu",
+      "repoName": "blatt2-1-s179.t179_at_example.edu"
+    },
+    {
+      "raw": "s181.t181@example.edu",
+      "email": "s181.t181@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s181.t181_at_example.edu",
+      "repoName": "blatt2-1-s181.t181_at_example.edu"
+    },
+    {
+      "raw": "s186.t186@example.edu",
+      "email": "s186.t186@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s186.t186_at_example.edu",
+      "repoName": "blatt2-1-s186.t186_at_example.edu"
+    },
+    {
+      "raw": "s187.t187@example.edu",
+      "email": "s187.t187@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s187.t187_at_example.edu",
+      "repoName": "blatt2-1-s187.t187_at_example.edu"
+    },
+    {
+      "raw": "s188.t188@example.edu",
+      "email": "s188.t188@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s188.t188_at_example.edu",
+      "repoName": "blatt2-1-s188.t188_at_example.edu"
+    },
+    {
+      "raw": "s193@example.edu",
+      "email": "s193@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s193_at_example.edu",
+      "repoName": "blatt2-1-s193_at_example.edu"
+    },
+    {
+      "raw": "s199.t199@example.edu",
+      "email": "s199.t199@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s199.t199_at_example.edu",
+      "repoName": "blatt2-1-s199.t199_at_example.edu"
+    },
+    {
+      "raw": "s201.t201@example.edu",
+      "email": "s201.t201@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s201.t201_at_example.edu",
+      "repoName": "blatt2-1-s201.t201_at_example.edu"
+    },
+    {
+      "raw": "s208.t208@example.edu",
+      "email": "s208.t208@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s208.t208_at_example.edu",
+      "repoName": "blatt2-1-s208.t208_at_example.edu"
+    },
+    {
+      "raw": "s210.t210@example.edu",
+      "email": "s210.t210@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s210.t210_at_example.edu",
+      "repoName": "blatt2-1-s210.t210_at_example.edu"
+    },
+    {
+      "raw": "s217.t217@example.edu",
+      "email": "s217.t217@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s217.t217_at_example.edu",
+      "repoName": "blatt2-1-s217.t217_at_example.edu"
+    },
+    {
+      "raw": "s220@example.edu",
+      "email": "s220@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s220_at_example.edu",
+      "repoName": "blatt2-1-s220_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/algdati.blatt2-2.json
+++ b/config/testdata/golden/algdati.blatt2-2.json
@@ -1,0 +1,467 @@
+{
+  "course": "algdati",
+  "name": "blatt2-2",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "algdati/semester/ob-25ws/blatt-2-2",
+  "url": "https://gitlab.lrz.de/algdati/semester/ob-25ws/blatt-2-2",
+  "repoBaseName": "blatt2-2",
+  "per": "student",
+  "description": "Blatt 2, Algorithmen und Datenstrukturen I, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:algdati/startercode/startercodeBlatt2-2.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s007.t007@example.edu",
+      "email": "s007.t007@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s007.t007_at_example.edu",
+      "repoName": "blatt2-2-s007.t007_at_example.edu"
+    },
+    {
+      "raw": "s009@example.edu",
+      "email": "s009@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s009_at_example.edu",
+      "repoName": "blatt2-2-s009_at_example.edu"
+    },
+    {
+      "raw": "s014.t014@example.edu",
+      "email": "s014.t014@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s014.t014_at_example.edu",
+      "repoName": "blatt2-2-s014.t014_at_example.edu"
+    },
+    {
+      "raw": "s015.t015@example.edu",
+      "email": "s015.t015@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s015.t015_at_example.edu",
+      "repoName": "blatt2-2-s015.t015_at_example.edu"
+    },
+    {
+      "raw": "s016@example.edu",
+      "email": "s016@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s016_at_example.edu",
+      "repoName": "blatt2-2-s016_at_example.edu"
+    },
+    {
+      "raw": "s018.t018@example.edu",
+      "email": "s018.t018@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s018.t018_at_example.edu",
+      "repoName": "blatt2-2-s018.t018_at_example.edu"
+    },
+    {
+      "raw": "s024.t024@example.edu",
+      "email": "s024.t024@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s024.t024_at_example.edu",
+      "repoName": "blatt2-2-s024.t024_at_example.edu"
+    },
+    {
+      "raw": "s025.t025@example.edu",
+      "email": "s025.t025@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s025.t025_at_example.edu",
+      "repoName": "blatt2-2-s025.t025_at_example.edu"
+    },
+    {
+      "raw": "s031.t031@example.edu",
+      "email": "s031.t031@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s031.t031_at_example.edu",
+      "repoName": "blatt2-2-s031.t031_at_example.edu"
+    },
+    {
+      "raw": "s038.t038@example.edu",
+      "email": "s038.t038@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s038.t038_at_example.edu",
+      "repoName": "blatt2-2-s038.t038_at_example.edu"
+    },
+    {
+      "raw": "s046@example.edu",
+      "email": "s046@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s046_at_example.edu",
+      "repoName": "blatt2-2-s046_at_example.edu"
+    },
+    {
+      "raw": "s063.t063@example.edu",
+      "email": "s063.t063@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s063.t063_at_example.edu",
+      "repoName": "blatt2-2-s063.t063_at_example.edu"
+    },
+    {
+      "raw": "s065.t065@example.edu",
+      "email": "s065.t065@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s065.t065_at_example.edu",
+      "repoName": "blatt2-2-s065.t065_at_example.edu"
+    },
+    {
+      "raw": "s068.t068@example.edu",
+      "email": "s068.t068@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s068.t068_at_example.edu",
+      "repoName": "blatt2-2-s068.t068_at_example.edu"
+    },
+    {
+      "raw": "s072.t072@example.edu",
+      "email": "s072.t072@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s072.t072_at_example.edu",
+      "repoName": "blatt2-2-s072.t072_at_example.edu"
+    },
+    {
+      "raw": "s073.t073@example.edu",
+      "email": "s073.t073@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s073.t073_at_example.edu",
+      "repoName": "blatt2-2-s073.t073_at_example.edu"
+    },
+    {
+      "raw": "s079.t079@example.edu",
+      "email": "s079.t079@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s079.t079_at_example.edu",
+      "repoName": "blatt2-2-s079.t079_at_example.edu"
+    },
+    {
+      "raw": "s093.t093@example.edu",
+      "email": "s093.t093@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s093.t093_at_example.edu",
+      "repoName": "blatt2-2-s093.t093_at_example.edu"
+    },
+    {
+      "raw": "s095.t095@example.edu",
+      "email": "s095.t095@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s095.t095_at_example.edu",
+      "repoName": "blatt2-2-s095.t095_at_example.edu"
+    },
+    {
+      "raw": "s098.t098@example.edu",
+      "email": "s098.t098@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s098.t098_at_example.edu",
+      "repoName": "blatt2-2-s098.t098_at_example.edu"
+    },
+    {
+      "raw": "s101.t101@example.edu",
+      "email": "s101.t101@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s101.t101_at_example.edu",
+      "repoName": "blatt2-2-s101.t101_at_example.edu"
+    },
+    {
+      "raw": "s105.t105@example.edu",
+      "email": "s105.t105@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s105.t105_at_example.edu",
+      "repoName": "blatt2-2-s105.t105_at_example.edu"
+    },
+    {
+      "raw": "s110.t110@example.edu",
+      "email": "s110.t110@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s110.t110_at_example.edu",
+      "repoName": "blatt2-2-s110.t110_at_example.edu"
+    },
+    {
+      "raw": "s113.t113@example.edu",
+      "email": "s113.t113@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s113.t113_at_example.edu",
+      "repoName": "blatt2-2-s113.t113_at_example.edu"
+    },
+    {
+      "raw": "s116.t116@example.edu",
+      "email": "s116.t116@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s116.t116_at_example.edu",
+      "repoName": "blatt2-2-s116.t116_at_example.edu"
+    },
+    {
+      "raw": "s118.t118@example.edu",
+      "email": "s118.t118@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s118.t118_at_example.edu",
+      "repoName": "blatt2-2-s118.t118_at_example.edu"
+    },
+    {
+      "raw": "s124.t124@example.edu",
+      "email": "s124.t124@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s124.t124_at_example.edu",
+      "repoName": "blatt2-2-s124.t124_at_example.edu"
+    },
+    {
+      "raw": "s138.t138@example.edu",
+      "email": "s138.t138@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s138.t138_at_example.edu",
+      "repoName": "blatt2-2-s138.t138_at_example.edu"
+    },
+    {
+      "raw": "s141@example.edu",
+      "email": "s141@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s141_at_example.edu",
+      "repoName": "blatt2-2-s141_at_example.edu"
+    },
+    {
+      "raw": "s148.t148@example.edu",
+      "email": "s148.t148@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s148.t148_at_example.edu",
+      "repoName": "blatt2-2-s148.t148_at_example.edu"
+    },
+    {
+      "raw": "s149.t149@example.edu",
+      "email": "s149.t149@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s149.t149_at_example.edu",
+      "repoName": "blatt2-2-s149.t149_at_example.edu"
+    },
+    {
+      "raw": "s156.t156@example.edu",
+      "email": "s156.t156@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s156.t156_at_example.edu",
+      "repoName": "blatt2-2-s156.t156_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt2-2-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s162.t162@example.edu",
+      "email": "s162.t162@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s162.t162_at_example.edu",
+      "repoName": "blatt2-2-s162.t162_at_example.edu"
+    },
+    {
+      "raw": "s164.t164@example.edu",
+      "email": "s164.t164@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s164.t164_at_example.edu",
+      "repoName": "blatt2-2-s164.t164_at_example.edu"
+    },
+    {
+      "raw": "s172.t172@example.edu",
+      "email": "s172.t172@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s172.t172_at_example.edu",
+      "repoName": "blatt2-2-s172.t172_at_example.edu"
+    },
+    {
+      "raw": "s173.t173@example.edu",
+      "email": "s173.t173@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s173.t173_at_example.edu",
+      "repoName": "blatt2-2-s173.t173_at_example.edu"
+    },
+    {
+      "raw": "s174.t174@example.edu",
+      "email": "s174.t174@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s174.t174_at_example.edu",
+      "repoName": "blatt2-2-s174.t174_at_example.edu"
+    },
+    {
+      "raw": "s177.t177@example.edu",
+      "email": "s177.t177@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s177.t177_at_example.edu",
+      "repoName": "blatt2-2-s177.t177_at_example.edu"
+    },
+    {
+      "raw": "s179.t179@example.edu",
+      "email": "s179.t179@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s179.t179_at_example.edu",
+      "repoName": "blatt2-2-s179.t179_at_example.edu"
+    },
+    {
+      "raw": "s181.t181@example.edu",
+      "email": "s181.t181@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s181.t181_at_example.edu",
+      "repoName": "blatt2-2-s181.t181_at_example.edu"
+    },
+    {
+      "raw": "s186.t186@example.edu",
+      "email": "s186.t186@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s186.t186_at_example.edu",
+      "repoName": "blatt2-2-s186.t186_at_example.edu"
+    },
+    {
+      "raw": "s187.t187@example.edu",
+      "email": "s187.t187@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s187.t187_at_example.edu",
+      "repoName": "blatt2-2-s187.t187_at_example.edu"
+    },
+    {
+      "raw": "s188.t188@example.edu",
+      "email": "s188.t188@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s188.t188_at_example.edu",
+      "repoName": "blatt2-2-s188.t188_at_example.edu"
+    },
+    {
+      "raw": "s193@example.edu",
+      "email": "s193@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s193_at_example.edu",
+      "repoName": "blatt2-2-s193_at_example.edu"
+    },
+    {
+      "raw": "s199.t199@example.edu",
+      "email": "s199.t199@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s199.t199_at_example.edu",
+      "repoName": "blatt2-2-s199.t199_at_example.edu"
+    },
+    {
+      "raw": "s201.t201@example.edu",
+      "email": "s201.t201@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s201.t201_at_example.edu",
+      "repoName": "blatt2-2-s201.t201_at_example.edu"
+    },
+    {
+      "raw": "s208.t208@example.edu",
+      "email": "s208.t208@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s208.t208_at_example.edu",
+      "repoName": "blatt2-2-s208.t208_at_example.edu"
+    },
+    {
+      "raw": "s210.t210@example.edu",
+      "email": "s210.t210@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s210.t210_at_example.edu",
+      "repoName": "blatt2-2-s210.t210_at_example.edu"
+    },
+    {
+      "raw": "s217.t217@example.edu",
+      "email": "s217.t217@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s217.t217_at_example.edu",
+      "repoName": "blatt2-2-s217.t217_at_example.edu"
+    },
+    {
+      "raw": "s220@example.edu",
+      "email": "s220@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s220_at_example.edu",
+      "repoName": "blatt2-2-s220_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/algdati.blatt3.json
+++ b/config/testdata/golden/algdati.blatt3.json
@@ -1,0 +1,666 @@
+{
+  "course": "algdati",
+  "name": "blatt3",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "algdati/semester/ob-25ws/blatt-3",
+  "url": "https://gitlab.lrz.de/algdati/semester/ob-25ws/blatt-3",
+  "repoBaseName": "blatt3",
+  "per": "group",
+  "description": "Blatt 3, Algorithmen und Datenstrukturen I, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:algdati/startercode/startercodeBlatt3.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/algdati/25ws/blatt3",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": null,
+  "groups": [
+    {
+      "name": "grp00",
+      "repoName": "blatt3-grp00",
+      "members": [
+        {
+          "raw": "s135.t135@example.edu",
+          "email": "s135.t135@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s135.t135_at_example.edu",
+          "repoName": "blatt3-s135.t135_at_example.edu"
+        },
+        {
+          "raw": "s161.t161@example.edu",
+          "email": "s161.t161@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s161.t161_at_example.edu",
+          "repoName": "blatt3-s161.t161_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp01",
+      "repoName": "blatt3-grp01",
+      "members": [
+        {
+          "raw": "s025.t025@example.edu",
+          "email": "s025.t025@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s025.t025_at_example.edu",
+          "repoName": "blatt3-s025.t025_at_example.edu"
+        },
+        {
+          "raw": "s110.t110@example.edu",
+          "email": "s110.t110@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s110.t110_at_example.edu",
+          "repoName": "blatt3-s110.t110_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp02",
+      "repoName": "blatt3-grp02",
+      "members": [
+        {
+          "raw": "s073.t073@example.edu",
+          "email": "s073.t073@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s073.t073_at_example.edu",
+          "repoName": "blatt3-s073.t073_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp03",
+      "repoName": "blatt3-grp03",
+      "members": [
+        {
+          "raw": "s065.t065@example.edu",
+          "email": "s065.t065@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s065.t065_at_example.edu",
+          "repoName": "blatt3-s065.t065_at_example.edu"
+        },
+        {
+          "raw": "s186.t186@example.edu",
+          "email": "s186.t186@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s186.t186_at_example.edu",
+          "repoName": "blatt3-s186.t186_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp05",
+      "repoName": "blatt3-grp05",
+      "members": [
+        {
+          "raw": "s098.t098@example.edu",
+          "email": "s098.t098@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s098.t098_at_example.edu",
+          "repoName": "blatt3-s098.t098_at_example.edu"
+        },
+        {
+          "raw": "s181.t181@example.edu",
+          "email": "s181.t181@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s181.t181_at_example.edu",
+          "repoName": "blatt3-s181.t181_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp06",
+      "repoName": "blatt3-grp06",
+      "members": [
+        {
+          "raw": "s156.t156@example.edu",
+          "email": "s156.t156@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s156.t156_at_example.edu",
+          "repoName": "blatt3-s156.t156_at_example.edu"
+        },
+        {
+          "raw": "s208.t208@example.edu",
+          "email": "s208.t208@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s208.t208_at_example.edu",
+          "repoName": "blatt3-s208.t208_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp07",
+      "repoName": "blatt3-grp07",
+      "members": [
+        {
+          "raw": "s031.t031@example.edu",
+          "email": "s031.t031@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s031.t031_at_example.edu",
+          "repoName": "blatt3-s031.t031_at_example.edu"
+        },
+        {
+          "raw": "s199.t199@example.edu",
+          "email": "s199.t199@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s199.t199_at_example.edu",
+          "repoName": "blatt3-s199.t199_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp08",
+      "repoName": "blatt3-grp08",
+      "members": [
+        {
+          "raw": "s079.t079@example.edu",
+          "email": "s079.t079@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s079.t079_at_example.edu",
+          "repoName": "blatt3-s079.t079_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp10",
+      "repoName": "blatt3-grp10",
+      "members": [
+        {
+          "raw": "s179.t179@example.edu",
+          "email": "s179.t179@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s179.t179_at_example.edu",
+          "repoName": "blatt3-s179.t179_at_example.edu"
+        },
+        {
+          "raw": "s201.t201@example.edu",
+          "email": "s201.t201@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s201.t201_at_example.edu",
+          "repoName": "blatt3-s201.t201_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp11",
+      "repoName": "blatt3-grp11",
+      "members": [
+        {
+          "raw": "s095.t095@example.edu",
+          "email": "s095.t095@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s095.t095_at_example.edu",
+          "repoName": "blatt3-s095.t095_at_example.edu"
+        },
+        {
+          "raw": "s172.t172@example.edu",
+          "email": "s172.t172@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s172.t172_at_example.edu",
+          "repoName": "blatt3-s172.t172_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp12",
+      "repoName": "blatt3-grp12",
+      "members": [
+        {
+          "raw": "s093.t093@example.edu",
+          "email": "s093.t093@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s093.t093_at_example.edu",
+          "repoName": "blatt3-s093.t093_at_example.edu"
+        },
+        {
+          "raw": "s148.t148@example.edu",
+          "email": "s148.t148@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s148.t148_at_example.edu",
+          "repoName": "blatt3-s148.t148_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp13",
+      "repoName": "blatt3-grp13",
+      "members": [
+        {
+          "raw": "s105.t105@example.edu",
+          "email": "s105.t105@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s105.t105_at_example.edu",
+          "repoName": "blatt3-s105.t105_at_example.edu"
+        },
+        {
+          "raw": "s124.t124@example.edu",
+          "email": "s124.t124@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s124.t124_at_example.edu",
+          "repoName": "blatt3-s124.t124_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp14",
+      "repoName": "blatt3-grp14",
+      "members": [
+        {
+          "raw": "s072.t072@example.edu",
+          "email": "s072.t072@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s072.t072_at_example.edu",
+          "repoName": "blatt3-s072.t072_at_example.edu"
+        },
+        {
+          "raw": "s188.t188@example.edu",
+          "email": "s188.t188@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s188.t188_at_example.edu",
+          "repoName": "blatt3-s188.t188_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp15",
+      "repoName": "blatt3-grp15",
+      "members": [
+        {
+          "raw": "s193@example.edu",
+          "email": "s193@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s193_at_example.edu",
+          "repoName": "blatt3-s193_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp16",
+      "repoName": "blatt3-grp16",
+      "members": [
+        {
+          "raw": "s173.t173@example.edu",
+          "email": "s173.t173@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s173.t173_at_example.edu",
+          "repoName": "blatt3-s173.t173_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp18",
+      "repoName": "blatt3-grp18",
+      "members": [
+        {
+          "raw": "s063.t063@example.edu",
+          "email": "s063.t063@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s063.t063_at_example.edu",
+          "repoName": "blatt3-s063.t063_at_example.edu"
+        },
+        {
+          "raw": "s138.t138@example.edu",
+          "email": "s138.t138@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s138.t138_at_example.edu",
+          "repoName": "blatt3-s138.t138_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp20",
+      "repoName": "blatt3-grp20",
+      "members": [
+        {
+          "raw": "s217.t217@example.edu",
+          "email": "s217.t217@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s217.t217_at_example.edu",
+          "repoName": "blatt3-s217.t217_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp21",
+      "repoName": "blatt3-grp21",
+      "members": [
+        {
+          "raw": "s210.t210@example.edu",
+          "email": "s210.t210@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s210.t210_at_example.edu",
+          "repoName": "blatt3-s210.t210_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp22",
+      "repoName": "blatt3-grp22",
+      "members": [
+        {
+          "raw": "s220@example.edu",
+          "email": "s220@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s220_at_example.edu",
+          "repoName": "blatt3-s220_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp23",
+      "repoName": "blatt3-grp23",
+      "members": [
+        {
+          "raw": "s018.t018@example.edu",
+          "email": "s018.t018@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s018.t018_at_example.edu",
+          "repoName": "blatt3-s018.t018_at_example.edu"
+        },
+        {
+          "raw": "s174.t174@example.edu",
+          "email": "s174.t174@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s174.t174_at_example.edu",
+          "repoName": "blatt3-s174.t174_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp25",
+      "repoName": "blatt3-grp25",
+      "members": [
+        {
+          "raw": "s015.t015@example.edu",
+          "email": "s015.t015@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s015.t015_at_example.edu",
+          "repoName": "blatt3-s015.t015_at_example.edu"
+        },
+        {
+          "raw": "s113.t113@example.edu",
+          "email": "s113.t113@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s113.t113_at_example.edu",
+          "repoName": "blatt3-s113.t113_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp31",
+      "repoName": "blatt3-grp31",
+      "members": [
+        {
+          "raw": "s024.t024@example.edu",
+          "email": "s024.t024@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s024.t024_at_example.edu",
+          "repoName": "blatt3-s024.t024_at_example.edu"
+        },
+        {
+          "raw": "s164.t164@example.edu",
+          "email": "s164.t164@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s164.t164_at_example.edu",
+          "repoName": "blatt3-s164.t164_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp33",
+      "repoName": "blatt3-grp33",
+      "members": [
+        {
+          "raw": "s038.t038@example.edu",
+          "email": "s038.t038@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s038.t038_at_example.edu",
+          "repoName": "blatt3-s038.t038_at_example.edu"
+        },
+        {
+          "raw": "s068.t068@example.edu",
+          "email": "s068.t068@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s068.t068_at_example.edu",
+          "repoName": "blatt3-s068.t068_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp34",
+      "repoName": "blatt3-grp34",
+      "members": [
+        {
+          "raw": "s219.t219@example.edu",
+          "email": "s219.t219@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s219.t219_at_example.edu",
+          "repoName": "blatt3-s219.t219_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp35",
+      "repoName": "blatt3-grp35",
+      "members": [
+        {
+          "raw": "s149.t149@example.edu",
+          "email": "s149.t149@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s149.t149_at_example.edu",
+          "repoName": "blatt3-s149.t149_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp36",
+      "repoName": "blatt3-grp36",
+      "members": [
+        {
+          "raw": "s116.t116@example.edu",
+          "email": "s116.t116@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s116.t116_at_example.edu",
+          "repoName": "blatt3-s116.t116_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp37",
+      "repoName": "blatt3-grp37",
+      "members": [
+        {
+          "raw": "s009@example.edu",
+          "email": "s009@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s009_at_example.edu",
+          "repoName": "blatt3-s009_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp38",
+      "repoName": "blatt3-grp38",
+      "members": [
+        {
+          "raw": "s101.t101@example.edu",
+          "email": "s101.t101@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s101.t101_at_example.edu",
+          "repoName": "blatt3-s101.t101_at_example.edu"
+        },
+        {
+          "raw": "s118.t118@example.edu",
+          "email": "s118.t118@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s118.t118_at_example.edu",
+          "repoName": "blatt3-s118.t118_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp39",
+      "repoName": "blatt3-grp39",
+      "members": [
+        {
+          "raw": "s046@example.edu",
+          "email": "s046@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s046_at_example.edu",
+          "repoName": "blatt3-s046_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp40",
+      "repoName": "blatt3-grp40",
+      "members": [
+        {
+          "raw": "s141@example.edu",
+          "email": "s141@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s141_at_example.edu",
+          "repoName": "blatt3-s141_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp41",
+      "repoName": "blatt3-grp41",
+      "members": [
+        {
+          "raw": "s007.t007@example.edu",
+          "email": "s007.t007@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s007.t007_at_example.edu",
+          "repoName": "blatt3-s007.t007_at_example.edu"
+        },
+        {
+          "raw": "s014.t014@example.edu",
+          "email": "s014.t014@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s014.t014_at_example.edu",
+          "repoName": "blatt3-s014.t014_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp42",
+      "repoName": "blatt3-grp42",
+      "members": [
+        {
+          "raw": "s023@example.edu",
+          "email": "s023@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s023_at_example.edu",
+          "repoName": "blatt3-s023_at_example.edu"
+        }
+      ]
+    }
+  ]
+}

--- a/config/testdata/golden/algdati.blatt4.json
+++ b/config/testdata/golden/algdati.blatt4.json
@@ -1,0 +1,666 @@
+{
+  "course": "algdati",
+  "name": "blatt4",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "algdati/semester/ob-25ws/blatt-4",
+  "url": "https://gitlab.lrz.de/algdati/semester/ob-25ws/blatt-4",
+  "repoBaseName": "blatt4",
+  "per": "group",
+  "description": "Blatt 4, Algorithmen und Datenstrukturen I, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:algdati/startercode/startercodeblatt04.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/algdati/25ws/blatt4",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": null,
+  "groups": [
+    {
+      "name": "grp00",
+      "repoName": "blatt4-grp00",
+      "members": [
+        {
+          "raw": "s135.t135@example.edu",
+          "email": "s135.t135@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s135.t135_at_example.edu",
+          "repoName": "blatt4-s135.t135_at_example.edu"
+        },
+        {
+          "raw": "s161.t161@example.edu",
+          "email": "s161.t161@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s161.t161_at_example.edu",
+          "repoName": "blatt4-s161.t161_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp01",
+      "repoName": "blatt4-grp01",
+      "members": [
+        {
+          "raw": "s025.t025@example.edu",
+          "email": "s025.t025@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s025.t025_at_example.edu",
+          "repoName": "blatt4-s025.t025_at_example.edu"
+        },
+        {
+          "raw": "s110.t110@example.edu",
+          "email": "s110.t110@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s110.t110_at_example.edu",
+          "repoName": "blatt4-s110.t110_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp02",
+      "repoName": "blatt4-grp02",
+      "members": [
+        {
+          "raw": "s073.t073@example.edu",
+          "email": "s073.t073@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s073.t073_at_example.edu",
+          "repoName": "blatt4-s073.t073_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp03",
+      "repoName": "blatt4-grp03",
+      "members": [
+        {
+          "raw": "s065.t065@example.edu",
+          "email": "s065.t065@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s065.t065_at_example.edu",
+          "repoName": "blatt4-s065.t065_at_example.edu"
+        },
+        {
+          "raw": "s186.t186@example.edu",
+          "email": "s186.t186@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s186.t186_at_example.edu",
+          "repoName": "blatt4-s186.t186_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp05",
+      "repoName": "blatt4-grp05",
+      "members": [
+        {
+          "raw": "s098.t098@example.edu",
+          "email": "s098.t098@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s098.t098_at_example.edu",
+          "repoName": "blatt4-s098.t098_at_example.edu"
+        },
+        {
+          "raw": "s181.t181@example.edu",
+          "email": "s181.t181@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s181.t181_at_example.edu",
+          "repoName": "blatt4-s181.t181_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp06",
+      "repoName": "blatt4-grp06",
+      "members": [
+        {
+          "raw": "s156.t156@example.edu",
+          "email": "s156.t156@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s156.t156_at_example.edu",
+          "repoName": "blatt4-s156.t156_at_example.edu"
+        },
+        {
+          "raw": "s208.t208@example.edu",
+          "email": "s208.t208@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s208.t208_at_example.edu",
+          "repoName": "blatt4-s208.t208_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp07",
+      "repoName": "blatt4-grp07",
+      "members": [
+        {
+          "raw": "s031.t031@example.edu",
+          "email": "s031.t031@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s031.t031_at_example.edu",
+          "repoName": "blatt4-s031.t031_at_example.edu"
+        },
+        {
+          "raw": "s199.t199@example.edu",
+          "email": "s199.t199@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s199.t199_at_example.edu",
+          "repoName": "blatt4-s199.t199_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp08",
+      "repoName": "blatt4-grp08",
+      "members": [
+        {
+          "raw": "s079.t079@example.edu",
+          "email": "s079.t079@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s079.t079_at_example.edu",
+          "repoName": "blatt4-s079.t079_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp10",
+      "repoName": "blatt4-grp10",
+      "members": [
+        {
+          "raw": "s179.t179@example.edu",
+          "email": "s179.t179@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s179.t179_at_example.edu",
+          "repoName": "blatt4-s179.t179_at_example.edu"
+        },
+        {
+          "raw": "s201.t201@example.edu",
+          "email": "s201.t201@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s201.t201_at_example.edu",
+          "repoName": "blatt4-s201.t201_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp11",
+      "repoName": "blatt4-grp11",
+      "members": [
+        {
+          "raw": "s095.t095@example.edu",
+          "email": "s095.t095@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s095.t095_at_example.edu",
+          "repoName": "blatt4-s095.t095_at_example.edu"
+        },
+        {
+          "raw": "s172.t172@example.edu",
+          "email": "s172.t172@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s172.t172_at_example.edu",
+          "repoName": "blatt4-s172.t172_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp12",
+      "repoName": "blatt4-grp12",
+      "members": [
+        {
+          "raw": "s093.t093@example.edu",
+          "email": "s093.t093@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s093.t093_at_example.edu",
+          "repoName": "blatt4-s093.t093_at_example.edu"
+        },
+        {
+          "raw": "s148.t148@example.edu",
+          "email": "s148.t148@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s148.t148_at_example.edu",
+          "repoName": "blatt4-s148.t148_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp13",
+      "repoName": "blatt4-grp13",
+      "members": [
+        {
+          "raw": "s105.t105@example.edu",
+          "email": "s105.t105@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s105.t105_at_example.edu",
+          "repoName": "blatt4-s105.t105_at_example.edu"
+        },
+        {
+          "raw": "s124.t124@example.edu",
+          "email": "s124.t124@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s124.t124_at_example.edu",
+          "repoName": "blatt4-s124.t124_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp14",
+      "repoName": "blatt4-grp14",
+      "members": [
+        {
+          "raw": "s072.t072@example.edu",
+          "email": "s072.t072@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s072.t072_at_example.edu",
+          "repoName": "blatt4-s072.t072_at_example.edu"
+        },
+        {
+          "raw": "s188.t188@example.edu",
+          "email": "s188.t188@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s188.t188_at_example.edu",
+          "repoName": "blatt4-s188.t188_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp15",
+      "repoName": "blatt4-grp15",
+      "members": [
+        {
+          "raw": "s193@example.edu",
+          "email": "s193@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s193_at_example.edu",
+          "repoName": "blatt4-s193_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp16",
+      "repoName": "blatt4-grp16",
+      "members": [
+        {
+          "raw": "s173.t173@example.edu",
+          "email": "s173.t173@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s173.t173_at_example.edu",
+          "repoName": "blatt4-s173.t173_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp18",
+      "repoName": "blatt4-grp18",
+      "members": [
+        {
+          "raw": "s063.t063@example.edu",
+          "email": "s063.t063@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s063.t063_at_example.edu",
+          "repoName": "blatt4-s063.t063_at_example.edu"
+        },
+        {
+          "raw": "s138.t138@example.edu",
+          "email": "s138.t138@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s138.t138_at_example.edu",
+          "repoName": "blatt4-s138.t138_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp20",
+      "repoName": "blatt4-grp20",
+      "members": [
+        {
+          "raw": "s217.t217@example.edu",
+          "email": "s217.t217@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s217.t217_at_example.edu",
+          "repoName": "blatt4-s217.t217_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp21",
+      "repoName": "blatt4-grp21",
+      "members": [
+        {
+          "raw": "s210.t210@example.edu",
+          "email": "s210.t210@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s210.t210_at_example.edu",
+          "repoName": "blatt4-s210.t210_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp22",
+      "repoName": "blatt4-grp22",
+      "members": [
+        {
+          "raw": "s220@example.edu",
+          "email": "s220@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s220_at_example.edu",
+          "repoName": "blatt4-s220_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp23",
+      "repoName": "blatt4-grp23",
+      "members": [
+        {
+          "raw": "s018.t018@example.edu",
+          "email": "s018.t018@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s018.t018_at_example.edu",
+          "repoName": "blatt4-s018.t018_at_example.edu"
+        },
+        {
+          "raw": "s174.t174@example.edu",
+          "email": "s174.t174@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s174.t174_at_example.edu",
+          "repoName": "blatt4-s174.t174_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp25",
+      "repoName": "blatt4-grp25",
+      "members": [
+        {
+          "raw": "s015.t015@example.edu",
+          "email": "s015.t015@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s015.t015_at_example.edu",
+          "repoName": "blatt4-s015.t015_at_example.edu"
+        },
+        {
+          "raw": "s113.t113@example.edu",
+          "email": "s113.t113@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s113.t113_at_example.edu",
+          "repoName": "blatt4-s113.t113_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp31",
+      "repoName": "blatt4-grp31",
+      "members": [
+        {
+          "raw": "s024.t024@example.edu",
+          "email": "s024.t024@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s024.t024_at_example.edu",
+          "repoName": "blatt4-s024.t024_at_example.edu"
+        },
+        {
+          "raw": "s164.t164@example.edu",
+          "email": "s164.t164@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s164.t164_at_example.edu",
+          "repoName": "blatt4-s164.t164_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp33",
+      "repoName": "blatt4-grp33",
+      "members": [
+        {
+          "raw": "s038.t038@example.edu",
+          "email": "s038.t038@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s038.t038_at_example.edu",
+          "repoName": "blatt4-s038.t038_at_example.edu"
+        },
+        {
+          "raw": "s068.t068@example.edu",
+          "email": "s068.t068@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s068.t068_at_example.edu",
+          "repoName": "blatt4-s068.t068_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp34",
+      "repoName": "blatt4-grp34",
+      "members": [
+        {
+          "raw": "s219.t219@example.edu",
+          "email": "s219.t219@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s219.t219_at_example.edu",
+          "repoName": "blatt4-s219.t219_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp35",
+      "repoName": "blatt4-grp35",
+      "members": [
+        {
+          "raw": "s149.t149@example.edu",
+          "email": "s149.t149@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s149.t149_at_example.edu",
+          "repoName": "blatt4-s149.t149_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp36",
+      "repoName": "blatt4-grp36",
+      "members": [
+        {
+          "raw": "s116.t116@example.edu",
+          "email": "s116.t116@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s116.t116_at_example.edu",
+          "repoName": "blatt4-s116.t116_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp37",
+      "repoName": "blatt4-grp37",
+      "members": [
+        {
+          "raw": "s009@example.edu",
+          "email": "s009@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s009_at_example.edu",
+          "repoName": "blatt4-s009_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp38",
+      "repoName": "blatt4-grp38",
+      "members": [
+        {
+          "raw": "s101.t101@example.edu",
+          "email": "s101.t101@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s101.t101_at_example.edu",
+          "repoName": "blatt4-s101.t101_at_example.edu"
+        },
+        {
+          "raw": "s118.t118@example.edu",
+          "email": "s118.t118@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s118.t118_at_example.edu",
+          "repoName": "blatt4-s118.t118_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp39",
+      "repoName": "blatt4-grp39",
+      "members": [
+        {
+          "raw": "s046@example.edu",
+          "email": "s046@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s046_at_example.edu",
+          "repoName": "blatt4-s046_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp40",
+      "repoName": "blatt4-grp40",
+      "members": [
+        {
+          "raw": "s141@example.edu",
+          "email": "s141@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s141_at_example.edu",
+          "repoName": "blatt4-s141_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp41",
+      "repoName": "blatt4-grp41",
+      "members": [
+        {
+          "raw": "s007.t007@example.edu",
+          "email": "s007.t007@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s007.t007_at_example.edu",
+          "repoName": "blatt4-s007.t007_at_example.edu"
+        },
+        {
+          "raw": "s014.t014@example.edu",
+          "email": "s014.t014@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s014.t014_at_example.edu",
+          "repoName": "blatt4-s014.t014_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp42",
+      "repoName": "blatt4-grp42",
+      "members": [
+        {
+          "raw": "s023@example.edu",
+          "email": "s023@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s023_at_example.edu",
+          "repoName": "blatt4-s023_at_example.edu"
+        }
+      ]
+    }
+  ]
+}

--- a/config/testdata/golden/casecourse.mixedfields.json
+++ b/config/testdata/golden/casecourse.mixedfields.json
@@ -1,0 +1,107 @@
+{
+  "course": "casecourse",
+  "name": "mixedfields",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "casecourse/semester/ss2026/blatt-01",
+  "url": "https://gitlab.lrz.de/casecourse/semester/ss2026/blatt-01",
+  "repoBaseName": "casecourse-mixedfields",
+  "per": "student",
+  "description": "Mixed-case field names",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "startercode",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": false,
+      "AllowForcePush": true,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:case/startercode.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Init",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "Upper.Case@example.edu",
+      "email": "Upper.Case@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "Upper.Case",
+      "repoName": "casecourse-mixedfields-Upper.Case"
+    },
+    {
+      "raw": "dotted.name@example.edu",
+      "email": "dotted.name@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "dotted.name",
+      "repoName": "casecourse-mixedfields-dotted.name"
+    },
+    {
+      "raw": "plain@example.edu",
+      "email": "plain@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "plain",
+      "repoName": "casecourse-mixedfields-plain"
+    },
+    {
+      "raw": "plus+tag@example.edu",
+      "email": "plus+tag@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "plus+tag",
+      "repoName": "casecourse-mixedfields-plus-tag"
+    },
+    {
+      "raw": "under_score@example.edu",
+      "email": "under_score@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "under_score",
+      "repoName": "casecourse-mixedfields-under_score"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/casecourse.slugs.json
+++ b/config/testdata/golden/casecourse.slugs.json
@@ -1,0 +1,82 @@
+{
+  "course": "casecourse",
+  "name": "slugs",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "casecourse/semester/ss2026/blatt-03",
+  "url": "https://gitlab.lrz.de/casecourse/semester/ss2026/blatt-03",
+  "repoBaseName": "casecourse-slugs",
+  "per": "student",
+  "description": "Project path slugification",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": null,
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "Upper.Case@example.edu",
+      "email": "Upper.Case@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "Upper.Case",
+      "repoName": "casecourse-slugs-Upper.Case"
+    },
+    {
+      "raw": "dotted.name@example.edu",
+      "email": "dotted.name@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "dotted.name",
+      "repoName": "casecourse-slugs-dotted.name"
+    },
+    {
+      "raw": "plain@example.edu",
+      "email": "plain@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "plain",
+      "repoName": "casecourse-slugs-plain"
+    },
+    {
+      "raw": "plus+tag@example.edu",
+      "email": "plus+tag@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "plus+tag",
+      "repoName": "casecourse-slugs-plus-tag"
+    },
+    {
+      "raw": "under_score@example.edu",
+      "email": "under_score@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "under_score",
+      "repoName": "casecourse-slugs-under_score"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/casecourse.upperkeys.json
+++ b/config/testdata/golden/casecourse.upperkeys.json
@@ -1,0 +1,103 @@
+{
+  "course": "casecourse",
+  "name": "upperkeys",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "casecourse/semester/ss2026/blatt-02",
+  "url": "https://gitlab.lrz.de/casecourse/semester/ss2026/blatt-02",
+  "repoBaseName": "casecourse-upperkeys",
+  "per": "group",
+  "description": "Upper-case map keys",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:case/startercode.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "devcontainer": {
+      "URL": "git@gitlab.lrz.de:case/devcontainer.git",
+      "FromBranch": "main",
+      "ToBranch": "DevContainer",
+      "Orphan": true,
+      "OrphanMessage": "DevContainer snapshot"
+    }
+  },
+  "students": null,
+  "groups": [
+    {
+      "name": "grp01",
+      "repoName": "casecourse-upperkeys-grp01",
+      "members": [
+        {
+          "raw": "Upper.Case@example.edu",
+          "email": "Upper.Case@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "Upper.Case",
+          "repoName": "casecourse-upperkeys-Upper.Case"
+        },
+        {
+          "raw": "plain@example.edu",
+          "email": "plain@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "plain",
+          "repoName": "casecourse-upperkeys-plain"
+        }
+      ]
+    },
+    {
+      "name": "grp02",
+      "repoName": "casecourse-upperkeys-grp02",
+      "members": [
+        {
+          "raw": "dotted.name@example.edu",
+          "email": "dotted.name@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "dotted.name",
+          "repoName": "casecourse-upperkeys-dotted.name"
+        }
+      ]
+    }
+  ]
+}

--- a/config/testdata/golden/fun.blatt1.json
+++ b/config/testdata/golden/fun.blatt1.json
@@ -1,0 +1,179 @@
+{
+  "course": "fun",
+  "name": "blatt1",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fun/semester/ob-25ws/blatt-1",
+  "url": "https://gitlab.lrz.de/fun/semester/ob-25ws/blatt-1",
+  "repoBaseName": "blatt1",
+  "per": "student",
+  "description": "Blatt 1, Funktionale Programmierung, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fun/startercode/startercode01.git",
+    "FromBranch": "25ws-2",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s005@example.edu",
+      "email": "s005@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s005_at_example.edu",
+      "repoName": "blatt1-s005_at_example.edu"
+    },
+    {
+      "raw": "s057@example.edu",
+      "email": "s057@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s057_at_example.edu",
+      "repoName": "blatt1-s057_at_example.edu"
+    },
+    {
+      "raw": "s058.t058@example.edu",
+      "email": "s058.t058@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s058.t058_at_example.edu",
+      "repoName": "blatt1-s058.t058_at_example.edu"
+    },
+    {
+      "raw": "s073.t073@example.edu",
+      "email": "s073.t073@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s073.t073_at_example.edu",
+      "repoName": "blatt1-s073.t073_at_example.edu"
+    },
+    {
+      "raw": "s077.t077@example.edu",
+      "email": "s077.t077@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s077.t077_at_example.edu",
+      "repoName": "blatt1-s077.t077_at_example.edu"
+    },
+    {
+      "raw": "s082@example.edu",
+      "email": "s082@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s082_at_example.edu",
+      "repoName": "blatt1-s082_at_example.edu"
+    },
+    {
+      "raw": "s086.t086@example.edu",
+      "email": "s086.t086@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s086.t086_at_example.edu",
+      "repoName": "blatt1-s086.t086_at_example.edu"
+    },
+    {
+      "raw": "s087.t087@example.edu",
+      "email": "s087.t087@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s087.t087_at_example.edu",
+      "repoName": "blatt1-s087.t087_at_example.edu"
+    },
+    {
+      "raw": "s104.t104@example.edu",
+      "email": "s104.t104@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s104.t104_at_example.edu",
+      "repoName": "blatt1-s104.t104_at_example.edu"
+    },
+    {
+      "raw": "s115.t115@example.edu",
+      "email": "s115.t115@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s115.t115_at_example.edu",
+      "repoName": "blatt1-s115.t115_at_example.edu"
+    },
+    {
+      "raw": "s120.t120@example.edu",
+      "email": "s120.t120@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s120.t120_at_example.edu",
+      "repoName": "blatt1-s120.t120_at_example.edu"
+    },
+    {
+      "raw": "s140.t140@example.edu",
+      "email": "s140.t140@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s140.t140_at_example.edu",
+      "repoName": "blatt1-s140.t140_at_example.edu"
+    },
+    {
+      "raw": "s153.t153@example.edu",
+      "email": "s153.t153@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s153.t153_at_example.edu",
+      "repoName": "blatt1-s153.t153_at_example.edu"
+    },
+    {
+      "raw": "s159@example.edu",
+      "email": "s159@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s159_at_example.edu",
+      "repoName": "blatt1-s159_at_example.edu"
+    },
+    {
+      "raw": "s190@example.edu",
+      "email": "s190@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s190_at_example.edu",
+      "repoName": "blatt1-s190_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fun.blatt2.json
+++ b/config/testdata/golden/fun.blatt2.json
@@ -1,0 +1,179 @@
+{
+  "course": "fun",
+  "name": "blatt2",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fun/semester/ob-25ws/blatt-2",
+  "url": "https://gitlab.lrz.de/fun/semester/ob-25ws/blatt-2",
+  "repoBaseName": "blatt2",
+  "per": "student",
+  "description": "Blatt 2, Funktionale Programmierung, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fun/startercode/startercode02.git",
+    "FromBranch": "25ws",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s005@example.edu",
+      "email": "s005@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s005_at_example.edu",
+      "repoName": "blatt2-s005_at_example.edu"
+    },
+    {
+      "raw": "s057@example.edu",
+      "email": "s057@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s057_at_example.edu",
+      "repoName": "blatt2-s057_at_example.edu"
+    },
+    {
+      "raw": "s058.t058@example.edu",
+      "email": "s058.t058@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s058.t058_at_example.edu",
+      "repoName": "blatt2-s058.t058_at_example.edu"
+    },
+    {
+      "raw": "s073.t073@example.edu",
+      "email": "s073.t073@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s073.t073_at_example.edu",
+      "repoName": "blatt2-s073.t073_at_example.edu"
+    },
+    {
+      "raw": "s077.t077@example.edu",
+      "email": "s077.t077@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s077.t077_at_example.edu",
+      "repoName": "blatt2-s077.t077_at_example.edu"
+    },
+    {
+      "raw": "s082@example.edu",
+      "email": "s082@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s082_at_example.edu",
+      "repoName": "blatt2-s082_at_example.edu"
+    },
+    {
+      "raw": "s086.t086@example.edu",
+      "email": "s086.t086@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s086.t086_at_example.edu",
+      "repoName": "blatt2-s086.t086_at_example.edu"
+    },
+    {
+      "raw": "s087.t087@example.edu",
+      "email": "s087.t087@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s087.t087_at_example.edu",
+      "repoName": "blatt2-s087.t087_at_example.edu"
+    },
+    {
+      "raw": "s104.t104@example.edu",
+      "email": "s104.t104@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s104.t104_at_example.edu",
+      "repoName": "blatt2-s104.t104_at_example.edu"
+    },
+    {
+      "raw": "s115.t115@example.edu",
+      "email": "s115.t115@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s115.t115_at_example.edu",
+      "repoName": "blatt2-s115.t115_at_example.edu"
+    },
+    {
+      "raw": "s120.t120@example.edu",
+      "email": "s120.t120@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s120.t120_at_example.edu",
+      "repoName": "blatt2-s120.t120_at_example.edu"
+    },
+    {
+      "raw": "s140.t140@example.edu",
+      "email": "s140.t140@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s140.t140_at_example.edu",
+      "repoName": "blatt2-s140.t140_at_example.edu"
+    },
+    {
+      "raw": "s153.t153@example.edu",
+      "email": "s153.t153@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s153.t153_at_example.edu",
+      "repoName": "blatt2-s153.t153_at_example.edu"
+    },
+    {
+      "raw": "s159@example.edu",
+      "email": "s159@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s159_at_example.edu",
+      "repoName": "blatt2-s159_at_example.edu"
+    },
+    {
+      "raw": "s190@example.edu",
+      "email": "s190@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s190_at_example.edu",
+      "repoName": "blatt2-s190_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fun.blatt3.json
+++ b/config/testdata/golden/fun.blatt3.json
@@ -1,0 +1,179 @@
+{
+  "course": "fun",
+  "name": "blatt3",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fun/semester/ob-25ws/blatt-3",
+  "url": "https://gitlab.lrz.de/fun/semester/ob-25ws/blatt-3",
+  "repoBaseName": "blatt3",
+  "per": "student",
+  "description": "Blatt 3, Funktionale Programmierung, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fun/startercode/startercode03.git",
+    "FromBranch": "25ws",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s005@example.edu",
+      "email": "s005@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s005_at_example.edu",
+      "repoName": "blatt3-s005_at_example.edu"
+    },
+    {
+      "raw": "s057@example.edu",
+      "email": "s057@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s057_at_example.edu",
+      "repoName": "blatt3-s057_at_example.edu"
+    },
+    {
+      "raw": "s058.t058@example.edu",
+      "email": "s058.t058@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s058.t058_at_example.edu",
+      "repoName": "blatt3-s058.t058_at_example.edu"
+    },
+    {
+      "raw": "s073.t073@example.edu",
+      "email": "s073.t073@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s073.t073_at_example.edu",
+      "repoName": "blatt3-s073.t073_at_example.edu"
+    },
+    {
+      "raw": "s077.t077@example.edu",
+      "email": "s077.t077@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s077.t077_at_example.edu",
+      "repoName": "blatt3-s077.t077_at_example.edu"
+    },
+    {
+      "raw": "s082@example.edu",
+      "email": "s082@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s082_at_example.edu",
+      "repoName": "blatt3-s082_at_example.edu"
+    },
+    {
+      "raw": "s086.t086@example.edu",
+      "email": "s086.t086@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s086.t086_at_example.edu",
+      "repoName": "blatt3-s086.t086_at_example.edu"
+    },
+    {
+      "raw": "s087.t087@example.edu",
+      "email": "s087.t087@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s087.t087_at_example.edu",
+      "repoName": "blatt3-s087.t087_at_example.edu"
+    },
+    {
+      "raw": "s104.t104@example.edu",
+      "email": "s104.t104@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s104.t104_at_example.edu",
+      "repoName": "blatt3-s104.t104_at_example.edu"
+    },
+    {
+      "raw": "s115.t115@example.edu",
+      "email": "s115.t115@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s115.t115_at_example.edu",
+      "repoName": "blatt3-s115.t115_at_example.edu"
+    },
+    {
+      "raw": "s120.t120@example.edu",
+      "email": "s120.t120@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s120.t120_at_example.edu",
+      "repoName": "blatt3-s120.t120_at_example.edu"
+    },
+    {
+      "raw": "s140.t140@example.edu",
+      "email": "s140.t140@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s140.t140_at_example.edu",
+      "repoName": "blatt3-s140.t140_at_example.edu"
+    },
+    {
+      "raw": "s153.t153@example.edu",
+      "email": "s153.t153@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s153.t153_at_example.edu",
+      "repoName": "blatt3-s153.t153_at_example.edu"
+    },
+    {
+      "raw": "s159@example.edu",
+      "email": "s159@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s159_at_example.edu",
+      "repoName": "blatt3-s159_at_example.edu"
+    },
+    {
+      "raw": "s190@example.edu",
+      "email": "s190@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s190_at_example.edu",
+      "repoName": "blatt3-s190_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fun.projekt.json
+++ b/config/testdata/golden/fun.projekt.json
@@ -1,0 +1,177 @@
+{
+  "course": "fun",
+  "name": "projekt",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fun/semester/ob-25ws/projekte",
+  "url": "https://gitlab.lrz.de/fun/semester/ob-25ws/projekte",
+  "repoBaseName": "projekt",
+  "per": "group",
+  "description": "Projekt, Funktionale Programmierung, WS 25/26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fun/startercode/startercodeProjekt.git",
+    "FromBranch": "main",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fun/25ws/projekte",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": null,
+  "groups": [
+    {
+      "name": "grp00",
+      "repoName": "projekt-grp00",
+      "members": [
+        {
+          "raw": "s161.t161@example.edu",
+          "email": "s161.t161@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s161.t161_at_example.edu",
+          "repoName": "projekt-s161.t161_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp01",
+      "repoName": "projekt-grp01",
+      "members": [
+        {
+          "raw": "s058.t058@example.edu",
+          "email": "s058.t058@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s058.t058_at_example.edu",
+          "repoName": "projekt-s058.t058_at_example.edu"
+        },
+        {
+          "raw": "s086.t086@example.edu",
+          "email": "s086.t086@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s086.t086_at_example.edu",
+          "repoName": "projekt-s086.t086_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp02",
+      "repoName": "projekt-grp02",
+      "members": [
+        {
+          "raw": "s077.t077@example.edu",
+          "email": "s077.t077@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s077.t077_at_example.edu",
+          "repoName": "projekt-s077.t077_at_example.edu"
+        },
+        {
+          "raw": "s087.t087@example.edu",
+          "email": "s087.t087@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s087.t087_at_example.edu",
+          "repoName": "projekt-s087.t087_at_example.edu"
+        },
+        {
+          "raw": "s140.t140@example.edu",
+          "email": "s140.t140@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s140.t140_at_example.edu",
+          "repoName": "projekt-s140.t140_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp03",
+      "repoName": "projekt-grp03",
+      "members": [
+        {
+          "raw": "s057@example.edu",
+          "email": "s057@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s057_at_example.edu",
+          "repoName": "projekt-s057_at_example.edu"
+        },
+        {
+          "raw": "s082@example.edu",
+          "email": "s082@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s082_at_example.edu",
+          "repoName": "projekt-s082_at_example.edu"
+        }
+      ]
+    },
+    {
+      "name": "grp04",
+      "repoName": "projekt-grp04",
+      "members": [
+        {
+          "raw": "s115.t115@example.edu",
+          "email": "s115.t115@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s115.t115_at_example.edu",
+          "repoName": "projekt-s115.t115_at_example.edu"
+        },
+        {
+          "raw": "s120.t120@example.edu",
+          "email": "s120.t120@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s120.t120_at_example.edu",
+          "repoName": "projekt-s120.t120_at_example.edu"
+        },
+        {
+          "raw": "s153.t153@example.edu",
+          "email": "s153.t153@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s153.t153_at_example.edu",
+          "repoName": "projekt-s153.t153_at_example.edu"
+        }
+      ]
+    }
+  ]
+}

--- a/config/testdata/golden/fundc.blatt02.json
+++ b/config/testdata/golden/fundc.blatt02.json
@@ -1,0 +1,507 @@
+{
+  "course": "fundc",
+  "name": "blatt02",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-02",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-02",
+  "repoBaseName": "blatt02",
+  "per": "student",
+  "description": "Blatt 2, Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB02.git",
+    "FromBranch": "24ss-2",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt02-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt02-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt02-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt02-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt02-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt02-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt02-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt02-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt02-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt02-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt02-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt02-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt02-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt02-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt02-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt02-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt02-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt02-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt02-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt02-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt02-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt02-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt02-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt02-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt02-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt02-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt02-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt02-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt02-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt02-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt02-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt02-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt02-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt02-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt02-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt02-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt02-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt02-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt02-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt02-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt02-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt02-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt02-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt02-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt02-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt02-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt02-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt02-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt02-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt02-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt02-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt02-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt02-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt02-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt02-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt02-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt03.json
+++ b/config/testdata/golden/fundc.blatt03.json
@@ -1,0 +1,507 @@
+{
+  "course": "fundc",
+  "name": "blatt03",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-03",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-03",
+  "repoBaseName": "blatt03",
+  "per": "student",
+  "description": "Blatt 3, Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB03.git",
+    "FromBranch": "24ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt03-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt03-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt03-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt03-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt03-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt03-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt03-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt03-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt03-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt03-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt03-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt03-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt03-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt03-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt03-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt03-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt03-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt03-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt03-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt03-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt03-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt03-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt03-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt03-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt03-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt03-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt03-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt03-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt03-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt03-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt03-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt03-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt03-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt03-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt03-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt03-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt03-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt03-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt03-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt03-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt03-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt03-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt03-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt03-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt03-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt03-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt03-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt03-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt03-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt03-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt03-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt03-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt03-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt03-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt03-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt03-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt04.json
+++ b/config/testdata/golden/fundc.blatt04.json
@@ -1,0 +1,522 @@
+{
+  "course": "fundc",
+  "name": "blatt04",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-04",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-04",
+  "repoBaseName": "blatt04",
+  "per": "student",
+  "description": "Blatt 4 (Abgabe), Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "guest",
+  "accessLevelValue": 10,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB04.git",
+    "FromBranch": "24ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fundc/24ss/blatt04",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt04-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt04-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt04-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt04-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt04-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt04-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt04-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt04-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt04-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt04-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt04-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt04-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt04-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt04-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt04-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt04-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt04-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt04-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt04-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt04-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt04-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt04-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt04-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt04-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt04-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt04-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt04-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt04-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt04-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt04-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt04-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt04-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt04-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt04-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt04-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt04-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt04-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt04-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt04-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt04-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt04-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt04-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt04-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt04-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt04-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt04-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt04-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt04-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt04-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt04-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt04-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt04-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt04-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt04-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt04-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt04-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt05.json
+++ b/config/testdata/golden/fundc.blatt05.json
@@ -1,0 +1,515 @@
+{
+  "course": "fundc",
+  "name": "blatt05",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-05",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-05",
+  "repoBaseName": "blatt05",
+  "per": "student",
+  "description": "Blatt 5, Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB05.git",
+    "FromBranch": "24ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fundc/24ss/blatt05",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt05-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt05-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt05-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt05-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt05-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt05-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt05-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt05-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt05-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt05-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt05-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt05-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt05-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt05-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt05-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt05-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt05-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt05-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt05-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt05-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt05-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt05-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt05-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt05-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt05-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt05-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt05-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt05-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt05-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt05-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt05-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt05-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt05-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt05-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt05-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt05-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt05-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt05-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt05-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt05-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt05-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt05-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt05-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt05-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt05-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt05-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt05-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt05-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt05-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt05-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt05-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt05-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt05-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt05-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt05-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt05-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt06.json
+++ b/config/testdata/golden/fundc.blatt06.json
@@ -1,0 +1,515 @@
+{
+  "course": "fundc",
+  "name": "blatt06",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-06",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-06",
+  "repoBaseName": "blatt06",
+  "per": "student",
+  "description": "Blatt 6, Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB06.git",
+    "FromBranch": "24ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fundc/24ss/blatt06",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt06-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt06-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt06-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt06-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt06-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt06-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt06-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt06-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt06-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt06-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt06-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt06-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt06-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt06-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt06-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt06-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt06-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt06-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt06-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt06-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt06-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt06-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt06-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt06-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt06-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt06-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt06-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt06-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt06-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt06-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt06-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt06-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt06-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt06-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt06-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt06-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt06-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt06-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt06-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt06-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt06-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt06-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt06-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt06-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt06-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt06-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt06-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt06-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt06-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt06-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt06-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt06-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt06-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt06-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt06-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt06-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt07.json
+++ b/config/testdata/golden/fundc.blatt07.json
@@ -1,0 +1,522 @@
+{
+  "course": "fundc",
+  "name": "blatt07",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-07",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-07",
+  "repoBaseName": "blatt07",
+  "per": "student",
+  "description": "Blatt 7 (Abgabe), Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "guest",
+  "accessLevelValue": 10,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB07.git",
+    "FromBranch": "24ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fundc/24ss/blatt07",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt07-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt07-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt07-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt07-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt07-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt07-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt07-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt07-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt07-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt07-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt07-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt07-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt07-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt07-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt07-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt07-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt07-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt07-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt07-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt07-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt07-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt07-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt07-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt07-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt07-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt07-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt07-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt07-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt07-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt07-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt07-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt07-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt07-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt07-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt07-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt07-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt07-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt07-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt07-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt07-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt07-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt07-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt07-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt07-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt07-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt07-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt07-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt07-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt07-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt07-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt07-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt07-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt07-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt07-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt07-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt07-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt08.json
+++ b/config/testdata/golden/fundc.blatt08.json
@@ -1,0 +1,522 @@
+{
+  "course": "fundc",
+  "name": "blatt08",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-08",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-08",
+  "repoBaseName": "blatt08",
+  "per": "student",
+  "description": "Blatt 8, Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB08.git",
+    "FromBranch": "24ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fundc/24ss/blatt08",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt08-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt08-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt08-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt08-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt08-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt08-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt08-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt08-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt08-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt08-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt08-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt08-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt08-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt08-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt08-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt08-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt08-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt08-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt08-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt08-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt08-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt08-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt08-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt08-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt08-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt08-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt08-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt08-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt08-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt08-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt08-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt08-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt08-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt08-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt08-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt08-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt08-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt08-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt08-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt08-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt08-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt08-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt08-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt08-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt08-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt08-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt08-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt08-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt08-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt08-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt08-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt08-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt08-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt08-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt08-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt08-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt09.json
+++ b/config/testdata/golden/fundc.blatt09.json
@@ -1,0 +1,522 @@
+{
+  "course": "fundc",
+  "name": "blatt09",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-09",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-09",
+  "repoBaseName": "blatt09",
+  "per": "student",
+  "description": "Blatt 9, Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercode-blatt-09.git",
+    "FromBranch": "25ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fundc/24ss/blatt09",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt09-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt09-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt09-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt09-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt09-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt09-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt09-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt09-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt09-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt09-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt09-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt09-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt09-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt09-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt09-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt09-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt09-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt09-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt09-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt09-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt09-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt09-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt09-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt09-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt09-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt09-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt09-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt09-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt09-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt09-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt09-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt09-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt09-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt09-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt09-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt09-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt09-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt09-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt09-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt09-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt09-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt09-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt09-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt09-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt09-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt09-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt09-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt09-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt09-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt09-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt09-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt09-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt09-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt09-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt09-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt09-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt10.json
+++ b/config/testdata/golden/fundc.blatt10.json
@@ -1,0 +1,522 @@
+{
+  "course": "fundc",
+  "name": "blatt10",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-10",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-10",
+  "repoBaseName": "blatt10",
+  "per": "student",
+  "description": "Blatt 10, Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB10.git",
+    "FromBranch": "25ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fundc/25ss/blatt10",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt10-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt10-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt10-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt10-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt10-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt10-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt10-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt10-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt10-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt10-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt10-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt10-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt10-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt10-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt10-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt10-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt10-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt10-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt10-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt10-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt10-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt10-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt10-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt10-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt10-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt10-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt10-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt10-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt10-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt10-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt10-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt10-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt10-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt10-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt10-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt10-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt10-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt10-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt10-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt10-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt10-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt10-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt10-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt10-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt10-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt10-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt10-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt10-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt10-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt10-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt10-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt10-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt10-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt10-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt10-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt10-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/fundc.blatt11.json
+++ b/config/testdata/golden/fundc.blatt11.json
@@ -1,0 +1,522 @@
+{
+  "course": "fundc",
+  "name": "blatt11",
+  "useCoursenameAsPrefix": false,
+  "useEmailDomainAsSuffix": true,
+  "path": "fundc/semester/ob-25ss/blatt-11",
+  "url": "https://gitlab.lrz.de/fundc/semester/ob-25ss/blatt-11",
+  "repoBaseName": "blatt11",
+  "per": "student",
+  "description": "Blatt 11, Funktionale Programmierung, DC, SS 25",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:fundc/startercode/startercodeB11.git",
+    "FromBranch": "24ss",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/fundc/25ss/blatt11",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s001.t001@example.edu",
+      "email": "s001.t001@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s001.t001_at_example.edu",
+      "repoName": "blatt11-s001.t001_at_example.edu"
+    },
+    {
+      "raw": "s006@example.edu",
+      "email": "s006@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s006_at_example.edu",
+      "repoName": "blatt11-s006_at_example.edu"
+    },
+    {
+      "raw": "s008.t008@example.edu",
+      "email": "s008.t008@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s008.t008_at_example.edu",
+      "repoName": "blatt11-s008.t008_at_example.edu"
+    },
+    {
+      "raw": "s010.t010@example.edu",
+      "email": "s010.t010@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s010.t010_at_example.edu",
+      "repoName": "blatt11-s010.t010_at_example.edu"
+    },
+    {
+      "raw": "s011.t011@example.edu",
+      "email": "s011.t011@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s011.t011_at_example.edu",
+      "repoName": "blatt11-s011.t011_at_example.edu"
+    },
+    {
+      "raw": "s017@example.edu",
+      "email": "s017@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s017_at_example.edu",
+      "repoName": "blatt11-s017_at_example.edu"
+    },
+    {
+      "raw": "s022.t022@example.edu",
+      "email": "s022.t022@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s022.t022_at_example.edu",
+      "repoName": "blatt11-s022.t022_at_example.edu"
+    },
+    {
+      "raw": "s026.t026@example.edu",
+      "email": "s026.t026@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s026.t026_at_example.edu",
+      "repoName": "blatt11-s026.t026_at_example.edu"
+    },
+    {
+      "raw": "s027.t027@example.edu",
+      "email": "s027.t027@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s027.t027_at_example.edu",
+      "repoName": "blatt11-s027.t027_at_example.edu"
+    },
+    {
+      "raw": "s030.t030@example.edu",
+      "email": "s030.t030@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s030.t030_at_example.edu",
+      "repoName": "blatt11-s030.t030_at_example.edu"
+    },
+    {
+      "raw": "s032.t032@example.edu",
+      "email": "s032.t032@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s032.t032_at_example.edu",
+      "repoName": "blatt11-s032.t032_at_example.edu"
+    },
+    {
+      "raw": "s033.t033@example.edu",
+      "email": "s033.t033@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s033.t033_at_example.edu",
+      "repoName": "blatt11-s033.t033_at_example.edu"
+    },
+    {
+      "raw": "s035.t035@example.edu",
+      "email": "s035.t035@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s035.t035_at_example.edu",
+      "repoName": "blatt11-s035.t035_at_example.edu"
+    },
+    {
+      "raw": "s040.t040@example.edu",
+      "email": "s040.t040@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s040.t040_at_example.edu",
+      "repoName": "blatt11-s040.t040_at_example.edu"
+    },
+    {
+      "raw": "s041.t041@example.edu",
+      "email": "s041.t041@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s041.t041_at_example.edu",
+      "repoName": "blatt11-s041.t041_at_example.edu"
+    },
+    {
+      "raw": "s043.t043@example.edu",
+      "email": "s043.t043@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s043.t043_at_example.edu",
+      "repoName": "blatt11-s043.t043_at_example.edu"
+    },
+    {
+      "raw": "s048.t048@example.edu",
+      "email": "s048.t048@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s048.t048_at_example.edu",
+      "repoName": "blatt11-s048.t048_at_example.edu"
+    },
+    {
+      "raw": "s049.t049@example.edu",
+      "email": "s049.t049@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s049.t049_at_example.edu",
+      "repoName": "blatt11-s049.t049_at_example.edu"
+    },
+    {
+      "raw": "s050.t050@example.edu",
+      "email": "s050.t050@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s050.t050_at_example.edu",
+      "repoName": "blatt11-s050.t050_at_example.edu"
+    },
+    {
+      "raw": "s052.t052@example.edu",
+      "email": "s052.t052@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s052.t052_at_example.edu",
+      "repoName": "blatt11-s052.t052_at_example.edu"
+    },
+    {
+      "raw": "s056@example.edu",
+      "email": "s056@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s056_at_example.edu",
+      "repoName": "blatt11-s056_at_example.edu"
+    },
+    {
+      "raw": "s059@example.edu",
+      "email": "s059@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s059_at_example.edu",
+      "repoName": "blatt11-s059_at_example.edu"
+    },
+    {
+      "raw": "s060.t060@example.edu",
+      "email": "s060.t060@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s060.t060_at_example.edu",
+      "repoName": "blatt11-s060.t060_at_example.edu"
+    },
+    {
+      "raw": "s062.t062@example.edu",
+      "email": "s062.t062@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s062.t062_at_example.edu",
+      "repoName": "blatt11-s062.t062_at_example.edu"
+    },
+    {
+      "raw": "s064.t064@example.edu",
+      "email": "s064.t064@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s064.t064_at_example.edu",
+      "repoName": "blatt11-s064.t064_at_example.edu"
+    },
+    {
+      "raw": "s080.t080@example.edu",
+      "email": "s080.t080@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s080.t080_at_example.edu",
+      "repoName": "blatt11-s080.t080_at_example.edu"
+    },
+    {
+      "raw": "s090.t090@example.edu",
+      "email": "s090.t090@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s090.t090_at_example.edu",
+      "repoName": "blatt11-s090.t090_at_example.edu"
+    },
+    {
+      "raw": "s091.t091@example.edu",
+      "email": "s091.t091@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s091.t091_at_example.edu",
+      "repoName": "blatt11-s091.t091_at_example.edu"
+    },
+    {
+      "raw": "s094@example.edu",
+      "email": "s094@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s094_at_example.edu",
+      "repoName": "blatt11-s094_at_example.edu"
+    },
+    {
+      "raw": "s097.t097@example.edu",
+      "email": "s097.t097@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s097.t097_at_example.edu",
+      "repoName": "blatt11-s097.t097_at_example.edu"
+    },
+    {
+      "raw": "s106.t106@example.edu",
+      "email": "s106.t106@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s106.t106_at_example.edu",
+      "repoName": "blatt11-s106.t106_at_example.edu"
+    },
+    {
+      "raw": "s108.t108@example.edu",
+      "email": "s108.t108@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s108.t108_at_example.edu",
+      "repoName": "blatt11-s108.t108_at_example.edu"
+    },
+    {
+      "raw": "s111.t111@example.edu",
+      "email": "s111.t111@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s111.t111_at_example.edu",
+      "repoName": "blatt11-s111.t111_at_example.edu"
+    },
+    {
+      "raw": "s112.t112@example.edu",
+      "email": "s112.t112@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s112.t112_at_example.edu",
+      "repoName": "blatt11-s112.t112_at_example.edu"
+    },
+    {
+      "raw": "s117.t117@example.edu",
+      "email": "s117.t117@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s117.t117_at_example.edu",
+      "repoName": "blatt11-s117.t117_at_example.edu"
+    },
+    {
+      "raw": "s119.t119@example.edu",
+      "email": "s119.t119@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s119.t119_at_example.edu",
+      "repoName": "blatt11-s119.t119_at_example.edu"
+    },
+    {
+      "raw": "s122.t122@example.edu",
+      "email": "s122.t122@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s122.t122_at_example.edu",
+      "repoName": "blatt11-s122.t122_at_example.edu"
+    },
+    {
+      "raw": "s123.t123@example.edu",
+      "email": "s123.t123@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s123.t123_at_example.edu",
+      "repoName": "blatt11-s123.t123_at_example.edu"
+    },
+    {
+      "raw": "s125.t125@example.edu",
+      "email": "s125.t125@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s125.t125_at_example.edu",
+      "repoName": "blatt11-s125.t125_at_example.edu"
+    },
+    {
+      "raw": "s127.t127@example.edu",
+      "email": "s127.t127@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s127.t127_at_example.edu",
+      "repoName": "blatt11-s127.t127_at_example.edu"
+    },
+    {
+      "raw": "s134@example.edu",
+      "email": "s134@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s134_at_example.edu",
+      "repoName": "blatt11-s134_at_example.edu"
+    },
+    {
+      "raw": "s150.t150@example.edu",
+      "email": "s150.t150@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s150.t150_at_example.edu",
+      "repoName": "blatt11-s150.t150_at_example.edu"
+    },
+    {
+      "raw": "s154.t154@example.edu",
+      "email": "s154.t154@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s154.t154_at_example.edu",
+      "repoName": "blatt11-s154.t154_at_example.edu"
+    },
+    {
+      "raw": "s160.t160@example.edu",
+      "email": "s160.t160@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s160.t160_at_example.edu",
+      "repoName": "blatt11-s160.t160_at_example.edu"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161_at_example.edu",
+      "repoName": "blatt11-s161.t161_at_example.edu"
+    },
+    {
+      "raw": "s163@example.edu",
+      "email": "s163@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s163_at_example.edu",
+      "repoName": "blatt11-s163_at_example.edu"
+    },
+    {
+      "raw": "s167.t167@example.edu",
+      "email": "s167.t167@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s167.t167_at_example.edu",
+      "repoName": "blatt11-s167.t167_at_example.edu"
+    },
+    {
+      "raw": "s175.t175@example.edu",
+      "email": "s175.t175@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s175.t175_at_example.edu",
+      "repoName": "blatt11-s175.t175_at_example.edu"
+    },
+    {
+      "raw": "s196.t196@example.edu",
+      "email": "s196.t196@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s196.t196_at_example.edu",
+      "repoName": "blatt11-s196.t196_at_example.edu"
+    },
+    {
+      "raw": "s203.t203@example.edu",
+      "email": "s203.t203@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s203.t203_at_example.edu",
+      "repoName": "blatt11-s203.t203_at_example.edu"
+    },
+    {
+      "raw": "s204.t204@example.edu",
+      "email": "s204.t204@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s204.t204_at_example.edu",
+      "repoName": "blatt11-s204.t204_at_example.edu"
+    },
+    {
+      "raw": "s211.t211@example.edu",
+      "email": "s211.t211@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s211.t211_at_example.edu",
+      "repoName": "blatt11-s211.t211_at_example.edu"
+    },
+    {
+      "raw": "s212.t212@example.edu",
+      "email": "s212.t212@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s212.t212_at_example.edu",
+      "repoName": "blatt11-s212.t212_at_example.edu"
+    },
+    {
+      "raw": "s214@example.edu",
+      "email": "s214@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s214_at_example.edu",
+      "repoName": "blatt11-s214_at_example.edu"
+    },
+    {
+      "raw": "s222.t222@example.edu",
+      "email": "s222.t222@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s222.t222_at_example.edu",
+      "repoName": "blatt11-s222.t222_at_example.edu"
+    },
+    {
+      "raw": "s223@example.edu",
+      "email": "s223@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s223_at_example.edu",
+      "repoName": "blatt11-s223_at_example.edu"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/legacy.approvalslist.json
+++ b/config/testdata/golden/legacy.approvalslist.json
@@ -1,0 +1,122 @@
+{
+  "course": "legacy",
+  "name": "approvalslist",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "legacy/semester/ss2026/blatt-03",
+  "url": "https://gitlab.lrz.de/legacy/semester/ss2026/blatt-03",
+  "repoBaseName": "legacy-approvalslist",
+  "per": "group",
+  "description": "Legacy approvals list form",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "ff",
+    "SquashOption": "always",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": [
+      {
+        "Name": "review",
+        "Branch": "",
+        "Branches": [
+          "main"
+        ],
+        "Usernames": [
+          "obcode"
+        ],
+        "Groups": [],
+        "MultiMemberGroupsOnly": false,
+        "RequiredApprovals": 2
+      },
+      {
+        "Name": "second",
+        "Branch": "",
+        "Branches": [
+          "main",
+          "startercode"
+        ],
+        "Usernames": [],
+        "Groups": [
+          "tutors"
+        ],
+        "MultiMemberGroupsOnly": true,
+        "RequiredApprovals": 0
+      },
+      {
+        "Name": "canonical",
+        "Branch": "",
+        "Branches": [
+          "main"
+        ],
+        "Usernames": [
+          "obcode"
+        ],
+        "Groups": [],
+        "MultiMemberGroupsOnly": false,
+        "RequiredApprovals": 3
+      }
+    ],
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:legacy/startercode.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": null,
+  "groups": [
+    {
+      "name": "grp01",
+      "repoName": "legacy-approvalslist-grp01",
+      "members": [
+        {
+          "raw": "a@example.edu",
+          "email": "a@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "a",
+          "repoName": "legacy-approvalslist-a"
+        },
+        {
+          "raw": "b.two@example.edu",
+          "email": "b.two@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "b.two",
+          "repoName": "legacy-approvalslist-b.two"
+        }
+      ]
+    }
+  ]
+}

--- a/config/testdata/golden/legacy.approvalsnormalized.json
+++ b/config/testdata/golden/legacy.approvalsnormalized.json
@@ -1,0 +1,95 @@
+{
+  "course": "legacy",
+  "name": "approvalsnormalized",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "legacy/semester/ss2026/blatt-04",
+  "url": "https://gitlab.lrz.de/legacy/semester/ss2026/blatt-04",
+  "repoBaseName": "legacy-approvalsnormalized",
+  "per": "group",
+  "description": "Approvals normalization",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": [
+      {
+        "Name": "padded",
+        "Branch": "",
+        "Branches": [
+          "main"
+        ],
+        "Usernames": [
+          "obcode"
+        ],
+        "Groups": [],
+        "MultiMemberGroupsOnly": false,
+        "RequiredApprovals": 0
+      }
+    ],
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:legacy/startercode.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": null,
+  "groups": [
+    {
+      "name": "grp01",
+      "repoName": "legacy-approvalsnormalized-grp01",
+      "members": [
+        {
+          "raw": "a@example.edu",
+          "email": "a@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "a",
+          "repoName": "legacy-approvalsnormalized-a"
+        },
+        {
+          "raw": "b.two@example.edu",
+          "email": "b.two@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "b.two",
+          "repoName": "legacy-approvalsnormalized-b.two"
+        }
+      ]
+    }
+  ]
+}

--- a/config/testdata/golden/legacy.devbranch.json
+++ b/config/testdata/golden/legacy.devbranch.json
@@ -1,0 +1,93 @@
+{
+  "course": "legacy",
+  "name": "devbranch",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "legacy/semester/ss2026/blatt-01",
+  "url": "https://gitlab.lrz.de/legacy/semester/ss2026/blatt-01",
+  "repoBaseName": "legacy-devbranch",
+  "per": "student",
+  "description": "Legacy startercode branch keys",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "develop",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "extra",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": false,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:legacy/startercode.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": [
+      "extra"
+    ]
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "a@example.edu",
+      "email": "a@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "a",
+      "repoName": "legacy-devbranch-a"
+    },
+    {
+      "raw": "b.two@example.edu",
+      "email": "b.two@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "b.two",
+      "repoName": "legacy-devbranch-b.two"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/legacy.devbranchoverridden.json
+++ b/config/testdata/golden/legacy.devbranchoverridden.json
@@ -1,0 +1,75 @@
+{
+  "course": "legacy",
+  "name": "devbranchoverridden",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "legacy/semester/ss2026/blatt-01b",
+  "url": "https://gitlab.lrz.de/legacy/semester/ss2026/blatt-01b",
+  "repoBaseName": "legacy-devbranchoverridden",
+  "per": "student",
+  "description": "Legacy branch keys ignored because branches is set",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:legacy/startercode.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "a@example.edu",
+      "email": "a@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "a",
+      "repoName": "legacy-devbranchoverridden-a"
+    },
+    {
+      "raw": "b.two@example.edu",
+      "email": "b.two@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "b.two",
+      "repoName": "legacy-devbranchoverridden-b.two"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/legacy.legacyissues.json
+++ b/config/testdata/golden/legacy.legacyissues.json
@@ -1,0 +1,78 @@
+{
+  "course": "legacy",
+  "name": "legacyissues",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "legacy/semester/ss2026/blatt-02",
+  "url": "https://gitlab.lrz.de/legacy/semester/ss2026/blatt-02",
+  "repoBaseName": "legacy-legacyissues",
+  "per": "student",
+  "description": "Legacy startercode issue keys",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      3,
+      4
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:legacy/startercode.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "a@example.edu",
+      "email": "a@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "a",
+      "repoName": "legacy-legacyissues-a"
+    },
+    {
+      "raw": "b.two@example.edu",
+      "email": "b.two@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "b.two",
+      "repoName": "legacy-legacyissues-b.two"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/legacy.legacyissuesshadowed.json
+++ b/config/testdata/golden/legacy.legacyissuesshadowed.json
@@ -1,0 +1,75 @@
+{
+  "course": "legacy",
+  "name": "legacyissuesshadowed",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "legacy/semester/ss2026/blatt-02b",
+  "url": "https://gitlab.lrz.de/legacy/semester/ss2026/blatt-02b",
+  "repoBaseName": "legacy-legacyissuesshadowed",
+  "per": "student",
+  "description": "Legacy issue keys shadowed by an explicit issues block",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:legacy/startercode.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "a@example.edu",
+      "email": "a@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "a",
+      "repoName": "legacy-legacyissuesshadowed-a"
+    },
+    {
+      "raw": "b.two@example.edu",
+      "email": "b.two@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "b.two",
+      "repoName": "legacy-legacyissuesshadowed-b.two"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt01.json
+++ b/config/testdata/golden/mpd.blatt01.json
@@ -1,0 +1,389 @@
+{
+  "course": "mpd",
+  "name": "blatt01",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-01",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-01",
+  "repoBaseName": "mpd-blatt01",
+  "per": "student",
+  "description": "Blatt 1, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-01.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt01-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt01-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt01-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt01-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt01-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt01-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt01-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt01-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt01-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt01-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt01-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt01-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt01-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt01-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt01-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt01-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt01-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt01-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt01-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt01-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt01-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt01-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt01-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt01-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt01-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt01-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt01-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt01-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt01-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt01-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt01-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt01-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt01-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt01-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt01-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt01-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt01-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt01-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt01-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt01-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt01-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt02.json
+++ b/config/testdata/golden/mpd.blatt02.json
@@ -1,0 +1,389 @@
+{
+  "course": "mpd",
+  "name": "blatt02",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-02",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-02",
+  "repoBaseName": "mpd-blatt02",
+  "per": "student",
+  "description": "Blatt 2, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-02.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt02-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt02-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt02-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt02-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt02-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt02-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt02-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt02-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt02-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt02-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt02-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt02-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt02-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt02-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt02-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt02-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt02-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt02-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt02-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt02-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt02-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt02-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt02-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt02-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt02-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt02-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt02-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt02-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt02-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt02-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt02-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt02-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt02-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt02-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt02-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt02-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt02-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt02-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt02-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt02-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt02-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt03.json
+++ b/config/testdata/golden/mpd.blatt03.json
@@ -1,0 +1,389 @@
+{
+  "course": "mpd",
+  "name": "blatt03",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-03",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-03",
+  "repoBaseName": "mpd-blatt03",
+  "per": "student",
+  "description": "Blatt 3, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-03.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt03-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt03-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt03-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt03-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt03-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt03-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt03-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt03-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt03-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt03-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt03-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt03-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt03-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt03-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt03-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt03-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt03-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt03-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt03-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt03-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt03-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt03-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt03-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt03-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt03-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt03-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt03-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt03-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt03-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt03-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt03-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt03-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt03-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt03-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt03-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt03-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt03-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt03-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt03-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt03-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt03-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt04.json
+++ b/config/testdata/golden/mpd.blatt04.json
@@ -1,0 +1,389 @@
+{
+  "course": "mpd",
+  "name": "blatt04",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-04",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-04",
+  "repoBaseName": "mpd-blatt04",
+  "per": "student",
+  "description": "Blatt 4, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-04.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt04-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt04-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt04-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt04-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt04-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt04-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt04-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt04-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt04-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt04-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt04-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt04-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt04-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt04-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt04-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt04-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt04-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt04-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt04-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt04-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt04-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt04-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt04-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt04-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt04-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt04-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt04-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt04-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt04-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt04-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt04-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt04-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt04-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt04-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt04-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt04-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt04-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt04-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt04-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt04-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt04-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt05.json
+++ b/config/testdata/golden/mpd.blatt05.json
@@ -1,0 +1,389 @@
+{
+  "course": "mpd",
+  "name": "blatt05",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-05",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-05",
+  "repoBaseName": "mpd-blatt05",
+  "per": "student",
+  "description": "Blatt 5, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-05.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt05-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt05-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt05-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt05-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt05-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt05-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt05-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt05-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt05-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt05-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt05-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt05-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt05-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt05-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt05-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt05-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt05-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt05-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt05-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt05-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt05-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt05-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt05-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt05-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt05-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt05-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt05-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt05-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt05-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt05-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt05-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt05-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt05-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt05-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt05-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt05-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt05-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt05-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt05-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt05-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt05-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt06.json
+++ b/config/testdata/golden/mpd.blatt06.json
@@ -1,0 +1,397 @@
+{
+  "course": "mpd",
+  "name": "blatt06",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-06",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-06",
+  "repoBaseName": "mpd-blatt06",
+  "per": "student",
+  "description": "Blatt 6, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-06.git",
+    "FromBranch": "startercode",
+    "Tag": "",
+    "Template": true,
+    "TemplateMessage": "Initial Commit",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/mpd/26ss/blatt1",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "solution": {
+      "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-06.git",
+      "FromBranch": "main",
+      "ToBranch": "solution",
+      "Orphan": true,
+      "OrphanMessage": "Lösungsvorschlag [skip ci]"
+    }
+  },
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt06-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt06-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt06-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt06-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt06-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt06-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt06-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt06-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt06-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt06-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt06-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt06-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt06-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt06-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt06-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt06-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt06-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt06-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt06-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt06-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt06-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt06-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt06-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt06-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt06-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt06-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt06-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt06-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt06-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt06-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt06-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt06-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt06-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt06-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt06-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt06-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt06-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt06-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt06-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt06-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt06-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt07.json
+++ b/config/testdata/golden/mpd.blatt07.json
@@ -1,0 +1,404 @@
+{
+  "course": "mpd",
+  "name": "blatt07",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-07",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-07",
+  "repoBaseName": "mpd-blatt07",
+  "per": "student",
+  "description": "Blatt 7, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      2
+    ],
+    "IncludeChildTasks": true
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-07.git",
+    "FromBranch": "startercode",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "devcontainer": {
+      "URL": "git@gitlab.lrz.de:mpd/devcontainer.git",
+      "FromBranch": "main",
+      "ToBranch": "devcontainer",
+      "Orphan": true,
+      "OrphanMessage": "publish: devcontainer [skip ci]"
+    },
+    "solution": {
+      "URL": "git@gitlab.lrz.de:mpd/startercode/blatt-07.git",
+      "FromBranch": "solution",
+      "ToBranch": "solution",
+      "Orphan": false,
+      "OrphanMessage": "Snapshot of solution"
+    }
+  },
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt07-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt07-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt07-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt07-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt07-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt07-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt07-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt07-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt07-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt07-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt07-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt07-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt07-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt07-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt07-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt07-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt07-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt07-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt07-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt07-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt07-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt07-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt07-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt07-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt07-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt07-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt07-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt07-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt07-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt07-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt07-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt07-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt07-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt07-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt07-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt07-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt07-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt07-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt07-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt07-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt07-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt08.json
+++ b/config/testdata/golden/mpd.blatt08.json
@@ -1,0 +1,404 @@
+{
+  "course": "mpd",
+  "name": "blatt08",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-08",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-08",
+  "repoBaseName": "mpd-blatt08",
+  "per": "student",
+  "description": "Blatt 8, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": true
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/labs/blatt-08.git",
+    "FromBranch": "startercode",
+    "Tag": "",
+    "Template": true,
+    "TemplateMessage": "Startercode [skip ci]",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "devcontainer": {
+      "URL": "git@gitlab.lrz.de:mpd/devcontainer.git",
+      "FromBranch": "main",
+      "ToBranch": "devcontainer",
+      "Orphan": true,
+      "OrphanMessage": "DevContainer [skip ci]"
+    },
+    "solution": {
+      "URL": "git@gitlab.lrz.de:mpd/labs/blatt-08.git",
+      "FromBranch": "solution",
+      "ToBranch": "solution",
+      "Orphan": true,
+      "OrphanMessage": "Lösungsvorschlag [skip ci]"
+    }
+  },
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt08-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt08-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt08-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt08-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt08-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt08-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt08-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt08-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt08-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt08-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt08-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt08-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt08-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt08-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt08-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt08-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt08-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt08-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt08-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt08-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt08-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt08-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt08-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt08-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt08-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt08-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt08-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt08-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt08-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt08-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt08-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt08-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt08-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt08-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt08-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt08-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt08-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt08-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt08-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt08-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt08-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt09.json
+++ b/config/testdata/golden/mpd.blatt09.json
@@ -1,0 +1,404 @@
+{
+  "course": "mpd",
+  "name": "blatt09",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-09",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-09",
+  "repoBaseName": "mpd-blatt09",
+  "per": "student",
+  "description": "Blatt 9, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": true
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/labs/blatt-09.git",
+    "FromBranch": "startercode",
+    "Tag": "startercode",
+    "Template": true,
+    "TemplateMessage": "Startercode [skip ci]",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "devcontainer": {
+      "URL": "git@gitlab.lrz.de:mpd/devcontainer.git",
+      "FromBranch": "main",
+      "ToBranch": "devcontainer",
+      "Orphan": true,
+      "OrphanMessage": "DevContainer [skip ci]"
+    },
+    "solution": {
+      "URL": "git@gitlab.lrz.de:mpd/labs/blatt-09.git",
+      "FromBranch": "solution",
+      "ToBranch": "solution",
+      "Orphan": true,
+      "OrphanMessage": "Lösungsvorschlag [skip ci]"
+    }
+  },
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt09-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt09-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt09-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt09-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt09-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt09-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt09-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt09-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt09-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt09-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt09-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt09-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt09-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt09-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt09-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt09-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt09-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt09-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt09-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt09-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt09-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt09-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt09-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt09-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt09-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt09-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt09-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt09-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt09-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt09-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt09-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt09-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt09-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt09-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt09-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt09-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt09-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt09-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt09-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt09-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt09-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt10.json
+++ b/config/testdata/golden/mpd.blatt10.json
@@ -1,0 +1,404 @@
+{
+  "course": "mpd",
+  "name": "blatt10",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-10",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-10",
+  "repoBaseName": "mpd-blatt10",
+  "per": "student",
+  "description": "Blatt 10, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": true
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/labs/blatt-10.git",
+    "FromBranch": "startercode",
+    "Tag": "startercode",
+    "Template": true,
+    "TemplateMessage": "Startercode [skip ci]",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "devcontainer": {
+      "URL": "git@gitlab.lrz.de:mpd/devcontainer.git",
+      "FromBranch": "main",
+      "ToBranch": "devcontainer",
+      "Orphan": true,
+      "OrphanMessage": "DevContainer [skip ci]"
+    },
+    "solution": {
+      "URL": "git@gitlab.lrz.de:mpd/labs/blatt-10.git",
+      "FromBranch": "solution",
+      "ToBranch": "solution",
+      "Orphan": true,
+      "OrphanMessage": "Lösungsvorschlag [skip ci]"
+    }
+  },
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt10-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt10-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt10-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt10-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt10-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt10-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt10-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt10-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt10-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt10-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt10-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt10-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt10-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt10-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt10-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt10-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt10-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt10-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt10-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt10-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt10-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt10-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt10-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt10-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt10-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt10-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt10-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt10-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt10-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt10-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt10-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt10-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt10-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt10-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt10-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt10-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt10-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt10-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt10-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt10-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt10-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt11.json
+++ b/config/testdata/golden/mpd.blatt11.json
@@ -1,0 +1,404 @@
+{
+  "course": "mpd",
+  "name": "blatt11",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-11",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-11",
+  "repoBaseName": "mpd-blatt11",
+  "per": "student",
+  "description": "Blatt 11, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": true
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/labs/blatt-11.git",
+    "FromBranch": "startercode",
+    "Tag": "startercode",
+    "Template": true,
+    "TemplateMessage": "Startercode [skip ci]",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "devcontainer": {
+      "URL": "git@gitlab.lrz.de:mpd/devcontainer.git",
+      "FromBranch": "main",
+      "ToBranch": "devcontainer",
+      "Orphan": true,
+      "OrphanMessage": "DevContainer [skip ci]"
+    },
+    "solution": {
+      "URL": "git@gitlab.lrz.de:mpd/labs/blatt-11.git",
+      "FromBranch": "solution",
+      "ToBranch": "solution",
+      "Orphan": true,
+      "OrphanMessage": "Lösungsvorschlag [skip ci]"
+    }
+  },
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt11-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt11-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt11-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt11-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt11-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt11-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt11-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt11-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt11-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt11-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt11-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt11-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt11-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt11-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt11-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt11-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt11-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt11-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt11-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt11-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt11-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt11-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt11-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt11-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt11-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt11-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt11-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt11-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt11-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt11-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt11-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt11-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt11-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt11-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt11-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt11-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt11-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt11-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt11-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt11-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt11-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.blatt12.json
+++ b/config/testdata/golden/mpd.blatt12.json
@@ -1,0 +1,404 @@
+{
+  "course": "mpd",
+  "name": "blatt12",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/blatt-12",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/blatt-12",
+  "repoBaseName": "mpd-blatt12",
+  "per": "student",
+  "description": "Blatt 12, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": true
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/labs/blatt-12.git",
+    "FromBranch": "startercode",
+    "Tag": "startercode",
+    "Template": true,
+    "TemplateMessage": "Startercode [skip ci]",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "devcontainer": {
+      "URL": "git@gitlab.lrz.de:mpd/devcontainer.git",
+      "FromBranch": "main",
+      "ToBranch": "devcontainer",
+      "Orphan": true,
+      "OrphanMessage": "DevContainer [skip ci]"
+    },
+    "solution": {
+      "URL": "git@gitlab.lrz.de:mpd/labs/blatt-12.git",
+      "FromBranch": "solution",
+      "ToBranch": "solution",
+      "Orphan": true,
+      "OrphanMessage": "Lösungsvorschlag [skip ci]"
+    }
+  },
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-blatt12-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-blatt12-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-blatt12-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-blatt12-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-blatt12-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-blatt12-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-blatt12-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-blatt12-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-blatt12-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-blatt12-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-blatt12-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-blatt12-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-blatt12-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-blatt12-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-blatt12-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-blatt12-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-blatt12-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-blatt12-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-blatt12-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-blatt12-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-blatt12-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-blatt12-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-blatt12-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-blatt12-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-blatt12-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-blatt12-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-blatt12-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-blatt12-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-blatt12-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-blatt12-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-blatt12-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-blatt12-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-blatt12-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-blatt12-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-blatt12-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-blatt12-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-blatt12-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-blatt12-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-blatt12-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-blatt12-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-blatt12-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/mpd.mockexam.json
+++ b/config/testdata/golden/mpd.mockexam.json
@@ -1,0 +1,404 @@
+{
+  "course": "mpd",
+  "name": "mockexam",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "mpd/semester/ob-26ss/mockexam",
+  "url": "https://gitlab.lrz.de/mpd/semester/ob-26ss/mockexam",
+  "repoBaseName": "mpd-mockexam",
+  "per": "student",
+  "description": "Probeprüfung, Moderne Programmierkonzepte und Datenstrukturen",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": true,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": true
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:mpd/labs/mockexam.git",
+    "FromBranch": "startercode",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": ".",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {
+    "devcontainer": {
+      "URL": "git@gitlab.lrz.de:mpd/devcontainer.git",
+      "FromBranch": "main",
+      "ToBranch": "devcontainer",
+      "Orphan": true,
+      "OrphanMessage": "publish: devcontainer [skip ci]"
+    },
+    "solution": {
+      "URL": "git@gitlab.lrz.de:mpd/labs/mockexam.git",
+      "FromBranch": "solution",
+      "ToBranch": "solution",
+      "Orphan": false,
+      "OrphanMessage": "Snapshot of solution"
+    }
+  },
+  "students": [
+    {
+      "raw": "s002.t002@example.edu",
+      "email": "s002.t002@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s002.t002",
+      "repoName": "mpd-mockexam-s002.t002"
+    },
+    {
+      "raw": "s012.t012@example.edu",
+      "email": "s012.t012@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s012.t012",
+      "repoName": "mpd-mockexam-s012.t012"
+    },
+    {
+      "raw": "s020.t020@example.edu",
+      "email": "s020.t020@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s020.t020",
+      "repoName": "mpd-mockexam-s020.t020"
+    },
+    {
+      "raw": "s028.t028@example.edu",
+      "email": "s028.t028@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s028.t028",
+      "repoName": "mpd-mockexam-s028.t028"
+    },
+    {
+      "raw": "s037.t037@example.edu",
+      "email": "s037.t037@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s037.t037",
+      "repoName": "mpd-mockexam-s037.t037"
+    },
+    {
+      "raw": "s042.t042@example.edu",
+      "email": "s042.t042@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s042.t042",
+      "repoName": "mpd-mockexam-s042.t042"
+    },
+    {
+      "raw": "s051.t051@example.edu",
+      "email": "s051.t051@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s051.t051",
+      "repoName": "mpd-mockexam-s051.t051"
+    },
+    {
+      "raw": "s061.t061@example.edu",
+      "email": "s061.t061@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s061.t061",
+      "repoName": "mpd-mockexam-s061.t061"
+    },
+    {
+      "raw": "s069.t069@example.edu",
+      "email": "s069.t069@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s069.t069",
+      "repoName": "mpd-mockexam-s069.t069"
+    },
+    {
+      "raw": "s074.t074@example.edu",
+      "email": "s074.t074@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s074.t074",
+      "repoName": "mpd-mockexam-s074.t074"
+    },
+    {
+      "raw": "s076.t076@example.edu",
+      "email": "s076.t076@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s076.t076",
+      "repoName": "mpd-mockexam-s076.t076"
+    },
+    {
+      "raw": "s099.t099@example.edu",
+      "email": "s099.t099@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s099.t099",
+      "repoName": "mpd-mockexam-s099.t099"
+    },
+    {
+      "raw": "s100.t100@example.edu",
+      "email": "s100.t100@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s100.t100",
+      "repoName": "mpd-mockexam-s100.t100"
+    },
+    {
+      "raw": "s102.t102@example.edu",
+      "email": "s102.t102@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s102.t102",
+      "repoName": "mpd-mockexam-s102.t102"
+    },
+    {
+      "raw": "s121.t121@example.edu",
+      "email": "s121.t121@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s121.t121",
+      "repoName": "mpd-mockexam-s121.t121"
+    },
+    {
+      "raw": "s126.t126@example.edu",
+      "email": "s126.t126@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s126.t126",
+      "repoName": "mpd-mockexam-s126.t126"
+    },
+    {
+      "raw": "s130.t130@example.edu",
+      "email": "s130.t130@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s130.t130",
+      "repoName": "mpd-mockexam-s130.t130"
+    },
+    {
+      "raw": "s131.t131@example.edu",
+      "email": "s131.t131@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s131.t131",
+      "repoName": "mpd-mockexam-s131.t131"
+    },
+    {
+      "raw": "s139.t139@example.edu",
+      "email": "s139.t139@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s139.t139",
+      "repoName": "mpd-mockexam-s139.t139"
+    },
+    {
+      "raw": "s145@example.edu",
+      "email": "s145@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s145",
+      "repoName": "mpd-mockexam-s145"
+    },
+    {
+      "raw": "s146.t146@example.edu",
+      "email": "s146.t146@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s146.t146",
+      "repoName": "mpd-mockexam-s146.t146"
+    },
+    {
+      "raw": "s147.t147@example.edu",
+      "email": "s147.t147@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s147.t147",
+      "repoName": "mpd-mockexam-s147.t147"
+    },
+    {
+      "raw": "s157.t157@example.edu",
+      "email": "s157.t157@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s157.t157",
+      "repoName": "mpd-mockexam-s157.t157"
+    },
+    {
+      "raw": "s158.t158@example.edu",
+      "email": "s158.t158@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s158.t158",
+      "repoName": "mpd-mockexam-s158.t158"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "mpd-mockexam-s161.t161"
+    },
+    {
+      "raw": "s168.t168@example.edu",
+      "email": "s168.t168@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s168.t168",
+      "repoName": "mpd-mockexam-s168.t168"
+    },
+    {
+      "raw": "s170.t170@example.edu",
+      "email": "s170.t170@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s170.t170",
+      "repoName": "mpd-mockexam-s170.t170"
+    },
+    {
+      "raw": "s171.t171@example.edu",
+      "email": "s171.t171@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s171.t171",
+      "repoName": "mpd-mockexam-s171.t171"
+    },
+    {
+      "raw": "s176.t176@example.edu",
+      "email": "s176.t176@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s176.t176",
+      "repoName": "mpd-mockexam-s176.t176"
+    },
+    {
+      "raw": "s178.t178@example.edu",
+      "email": "s178.t178@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s178.t178",
+      "repoName": "mpd-mockexam-s178.t178"
+    },
+    {
+      "raw": "s180.t180@example.edu",
+      "email": "s180.t180@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s180.t180",
+      "repoName": "mpd-mockexam-s180.t180"
+    },
+    {
+      "raw": "s182.t182@example.edu",
+      "email": "s182.t182@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s182.t182",
+      "repoName": "mpd-mockexam-s182.t182"
+    },
+    {
+      "raw": "s183.t183@example.edu",
+      "email": "s183.t183@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s183.t183",
+      "repoName": "mpd-mockexam-s183.t183"
+    },
+    {
+      "raw": "s192.t192@example.edu",
+      "email": "s192.t192@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s192.t192",
+      "repoName": "mpd-mockexam-s192.t192"
+    },
+    {
+      "raw": "s195.t195@example.edu",
+      "email": "s195.t195@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s195.t195",
+      "repoName": "mpd-mockexam-s195.t195"
+    },
+    {
+      "raw": "s197.t197@example.edu",
+      "email": "s197.t197@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s197.t197",
+      "repoName": "mpd-mockexam-s197.t197"
+    },
+    {
+      "raw": "s202.t202@example.edu",
+      "email": "s202.t202@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s202.t202",
+      "repoName": "mpd-mockexam-s202.t202"
+    },
+    {
+      "raw": "s213.t213@example.edu",
+      "email": "s213.t213@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s213.t213",
+      "repoName": "mpd-mockexam-s213.t213"
+    },
+    {
+      "raw": "s216.t216@example.edu",
+      "email": "s216.t216@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s216.t216",
+      "repoName": "mpd-mockexam-s216.t216"
+    },
+    {
+      "raw": "s218.t218@example.edu",
+      "email": "s218.t218@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s218.t218",
+      "repoName": "mpd-mockexam-s218.t218"
+    },
+    {
+      "raw": "s221.t221@example.edu",
+      "email": "s221.t221@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s221.t221",
+      "repoName": "mpd-mockexam-s221.t221"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/vss.blatt0.json
+++ b/config/testdata/golden/vss.blatt0.json
@@ -1,0 +1,571 @@
+{
+  "course": "vss",
+  "name": "blatt0",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "vss/semester/ob-26ss/blatt-0",
+  "url": "https://gitlab.lrz.de/vss/semester/ob-26ss/blatt-0",
+  "repoBaseName": "vss-blatt0",
+  "per": "student",
+  "description": "Blatt 0, Verteilte Softwaresysteme, SS 26",
+  "containerRegistry": false,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "merge",
+    "SquashOption": "default_off",
+    "PipelineMustSucceed": false,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": false,
+    "StatusChecksMustSucceed": false,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": false,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "startercode",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": false,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": false,
+    "IssueNumbers": null,
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:vss/startercode/startercodeB0.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/vss/26ss/blatt0",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": null,
+  "seeder": null,
+  "deferredBranches": {},
+  "students": [
+    {
+      "raw": "s003.t003@example.edu",
+      "email": "s003.t003@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s003.t003",
+      "repoName": "vss-blatt0-s003.t003"
+    },
+    {
+      "raw": "s004.t004@example.edu",
+      "email": "s004.t004@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s004.t004",
+      "repoName": "vss-blatt0-s004.t004"
+    },
+    {
+      "raw": "s013@example.edu",
+      "email": "s013@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s013",
+      "repoName": "vss-blatt0-s013"
+    },
+    {
+      "raw": "s019.t019@example.edu",
+      "email": "s019.t019@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s019.t019",
+      "repoName": "vss-blatt0-s019.t019"
+    },
+    {
+      "raw": "s021@example.edu",
+      "email": "s021@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s021",
+      "repoName": "vss-blatt0-s021"
+    },
+    {
+      "raw": "s029.t029@example.edu",
+      "email": "s029.t029@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s029.t029",
+      "repoName": "vss-blatt0-s029.t029"
+    },
+    {
+      "raw": "s034.t034@example.edu",
+      "email": "s034.t034@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s034.t034",
+      "repoName": "vss-blatt0-s034.t034"
+    },
+    {
+      "raw": "s036.t036@example.edu",
+      "email": "s036.t036@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s036.t036",
+      "repoName": "vss-blatt0-s036.t036"
+    },
+    {
+      "raw": "s039.t039@example.edu",
+      "email": "s039.t039@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s039.t039",
+      "repoName": "vss-blatt0-s039.t039"
+    },
+    {
+      "raw": "s044.t044@example.edu",
+      "email": "s044.t044@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s044.t044",
+      "repoName": "vss-blatt0-s044.t044"
+    },
+    {
+      "raw": "s045.t045@example.edu",
+      "email": "s045.t045@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s045.t045",
+      "repoName": "vss-blatt0-s045.t045"
+    },
+    {
+      "raw": "s047.t047@example.edu",
+      "email": "s047.t047@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s047.t047",
+      "repoName": "vss-blatt0-s047.t047"
+    },
+    {
+      "raw": "s053.t053@example.edu",
+      "email": "s053.t053@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s053.t053",
+      "repoName": "vss-blatt0-s053.t053"
+    },
+    {
+      "raw": "s054@example.edu",
+      "email": "s054@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s054",
+      "repoName": "vss-blatt0-s054"
+    },
+    {
+      "raw": "s055.t055@example.edu",
+      "email": "s055.t055@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s055.t055",
+      "repoName": "vss-blatt0-s055.t055"
+    },
+    {
+      "raw": "s066@example.edu",
+      "email": "s066@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s066",
+      "repoName": "vss-blatt0-s066"
+    },
+    {
+      "raw": "s067.t067@example.edu",
+      "email": "s067.t067@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s067.t067",
+      "repoName": "vss-blatt0-s067.t067"
+    },
+    {
+      "raw": "s070.t070@example.edu",
+      "email": "s070.t070@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s070.t070",
+      "repoName": "vss-blatt0-s070.t070"
+    },
+    {
+      "raw": "s071.t071@example.edu",
+      "email": "s071.t071@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s071.t071",
+      "repoName": "vss-blatt0-s071.t071"
+    },
+    {
+      "raw": "s073.t073@example.edu",
+      "email": "s073.t073@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s073.t073",
+      "repoName": "vss-blatt0-s073.t073"
+    },
+    {
+      "raw": "s075.t075@example.edu",
+      "email": "s075.t075@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s075.t075",
+      "repoName": "vss-blatt0-s075.t075"
+    },
+    {
+      "raw": "s078.t078@example.edu",
+      "email": "s078.t078@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s078.t078",
+      "repoName": "vss-blatt0-s078.t078"
+    },
+    {
+      "raw": "s081@example.edu",
+      "email": "s081@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s081",
+      "repoName": "vss-blatt0-s081"
+    },
+    {
+      "raw": "s083.t083@example.edu",
+      "email": "s083.t083@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s083.t083",
+      "repoName": "vss-blatt0-s083.t083"
+    },
+    {
+      "raw": "s084@example.edu",
+      "email": "s084@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s084",
+      "repoName": "vss-blatt0-s084"
+    },
+    {
+      "raw": "s085.t085@example.edu",
+      "email": "s085.t085@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s085.t085",
+      "repoName": "vss-blatt0-s085.t085"
+    },
+    {
+      "raw": "s088.t088@example.edu",
+      "email": "s088.t088@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s088.t088",
+      "repoName": "vss-blatt0-s088.t088"
+    },
+    {
+      "raw": "s089.t089@example.edu",
+      "email": "s089.t089@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s089.t089",
+      "repoName": "vss-blatt0-s089.t089"
+    },
+    {
+      "raw": "s092.t092@example.edu",
+      "email": "s092.t092@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s092.t092",
+      "repoName": "vss-blatt0-s092.t092"
+    },
+    {
+      "raw": "s096.t096@example.edu",
+      "email": "s096.t096@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s096.t096",
+      "repoName": "vss-blatt0-s096.t096"
+    },
+    {
+      "raw": "s103@example.edu",
+      "email": "s103@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s103",
+      "repoName": "vss-blatt0-s103"
+    },
+    {
+      "raw": "s107@example.edu",
+      "email": "s107@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s107",
+      "repoName": "vss-blatt0-s107"
+    },
+    {
+      "raw": "s109.t109@example.edu",
+      "email": "s109.t109@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s109.t109",
+      "repoName": "vss-blatt0-s109.t109"
+    },
+    {
+      "raw": "s114.t114@example.edu",
+      "email": "s114.t114@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s114.t114",
+      "repoName": "vss-blatt0-s114.t114"
+    },
+    {
+      "raw": "s128.t128@example.edu",
+      "email": "s128.t128@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s128.t128",
+      "repoName": "vss-blatt0-s128.t128"
+    },
+    {
+      "raw": "s129.t129@example.edu",
+      "email": "s129.t129@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s129.t129",
+      "repoName": "vss-blatt0-s129.t129"
+    },
+    {
+      "raw": "s132.t132@example.edu",
+      "email": "s132.t132@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s132.t132",
+      "repoName": "vss-blatt0-s132.t132"
+    },
+    {
+      "raw": "s133.t133@example.edu",
+      "email": "s133.t133@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s133.t133",
+      "repoName": "vss-blatt0-s133.t133"
+    },
+    {
+      "raw": "s136.t136@example.edu",
+      "email": "s136.t136@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s136.t136",
+      "repoName": "vss-blatt0-s136.t136"
+    },
+    {
+      "raw": "s137.t137@example.edu",
+      "email": "s137.t137@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s137.t137",
+      "repoName": "vss-blatt0-s137.t137"
+    },
+    {
+      "raw": "s142@example.edu",
+      "email": "s142@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s142",
+      "repoName": "vss-blatt0-s142"
+    },
+    {
+      "raw": "s143.t143@example.edu",
+      "email": "s143.t143@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s143.t143",
+      "repoName": "vss-blatt0-s143.t143"
+    },
+    {
+      "raw": "s144.t144@example.edu",
+      "email": "s144.t144@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s144.t144",
+      "repoName": "vss-blatt0-s144.t144"
+    },
+    {
+      "raw": "s151@example.edu",
+      "email": "s151@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s151",
+      "repoName": "vss-blatt0-s151"
+    },
+    {
+      "raw": "s152.t152@example.edu",
+      "email": "s152.t152@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s152.t152",
+      "repoName": "vss-blatt0-s152.t152"
+    },
+    {
+      "raw": "s155.t155@example.edu",
+      "email": "s155.t155@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s155.t155",
+      "repoName": "vss-blatt0-s155.t155"
+    },
+    {
+      "raw": "s161.t161@example.edu",
+      "email": "s161.t161@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s161.t161",
+      "repoName": "vss-blatt0-s161.t161"
+    },
+    {
+      "raw": "s165.t165@example.edu",
+      "email": "s165.t165@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s165.t165",
+      "repoName": "vss-blatt0-s165.t165"
+    },
+    {
+      "raw": "s166@example.edu",
+      "email": "s166@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s166",
+      "repoName": "vss-blatt0-s166"
+    },
+    {
+      "raw": "s169@example.edu",
+      "email": "s169@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s169",
+      "repoName": "vss-blatt0-s169"
+    },
+    {
+      "raw": "s184.t184@example.edu",
+      "email": "s184.t184@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s184.t184",
+      "repoName": "vss-blatt0-s184.t184"
+    },
+    {
+      "raw": "s185.t185@example.edu",
+      "email": "s185.t185@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s185.t185",
+      "repoName": "vss-blatt0-s185.t185"
+    },
+    {
+      "raw": "s189.t189@example.edu",
+      "email": "s189.t189@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s189.t189",
+      "repoName": "vss-blatt0-s189.t189"
+    },
+    {
+      "raw": "s190@example.edu",
+      "email": "s190@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s190",
+      "repoName": "vss-blatt0-s190"
+    },
+    {
+      "raw": "s191.t191@example.edu",
+      "email": "s191.t191@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s191.t191",
+      "repoName": "vss-blatt0-s191.t191"
+    },
+    {
+      "raw": "s194.t194@example.edu",
+      "email": "s194.t194@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s194.t194",
+      "repoName": "vss-blatt0-s194.t194"
+    },
+    {
+      "raw": "s198.t198@example.edu",
+      "email": "s198.t198@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s198.t198",
+      "repoName": "vss-blatt0-s198.t198"
+    },
+    {
+      "raw": "s200.t200@example.edu",
+      "email": "s200.t200@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s200.t200",
+      "repoName": "vss-blatt0-s200.t200"
+    },
+    {
+      "raw": "s205.t205@example.edu",
+      "email": "s205.t205@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s205.t205",
+      "repoName": "vss-blatt0-s205.t205"
+    },
+    {
+      "raw": "s206.t206@example.edu",
+      "email": "s206.t206@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s206.t206",
+      "repoName": "vss-blatt0-s206.t206"
+    },
+    {
+      "raw": "s207.t207@example.edu",
+      "email": "s207.t207@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s207.t207",
+      "repoName": "vss-blatt0-s207.t207"
+    },
+    {
+      "raw": "s209.t209@example.edu",
+      "email": "s209.t209@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s209.t209",
+      "repoName": "vss-blatt0-s209.t209"
+    },
+    {
+      "raw": "s215.t215@example.edu",
+      "email": "s215.t215@example.edu",
+      "username": null,
+      "id": null,
+      "repoSuffix": "s215.t215",
+      "repoName": "vss-blatt0-s215.t215"
+    }
+  ],
+  "groups": null
+}

--- a/config/testdata/golden/vss.blatt1.json
+++ b/config/testdata/golden/vss.blatt1.json
@@ -1,0 +1,824 @@
+{
+  "course": "vss",
+  "name": "blatt1",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "vss/semester/ob-26ss/blatt-1",
+  "url": "https://gitlab.lrz.de/vss/semester/ob-26ss/blatt-1",
+  "repoBaseName": "vss-blatt1",
+  "per": "group",
+  "description": "Blatt 1, Verteilte Softwaresysteme, SS 26",
+  "containerRegistry": true,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": null,
+    "ApprovalSettings": null
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "startercode",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": false,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:vss/startercode/startercodeB1.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/vss/26ss/blatt1",
+    "Branch": "develop",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": null,
+  "groups": [
+    {
+      "name": "grp00",
+      "repoName": "vss-blatt1-grp00",
+      "members": [
+        {
+          "raw": "s161.t161@example.edu",
+          "email": "s161.t161@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s161.t161",
+          "repoName": "vss-blatt1-s161.t161"
+        }
+      ]
+    },
+    {
+      "name": "grp01",
+      "repoName": "vss-blatt1-grp01",
+      "members": [
+        {
+          "raw": "s036.t036@example.edu",
+          "email": "s036.t036@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s036.t036",
+          "repoName": "vss-blatt1-s036.t036"
+        },
+        {
+          "raw": "s081@example.edu",
+          "email": "s081@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s081",
+          "repoName": "vss-blatt1-s081"
+        }
+      ]
+    },
+    {
+      "name": "grp02",
+      "repoName": "vss-blatt1-grp02",
+      "members": [
+        {
+          "raw": "s070.t070@example.edu",
+          "email": "s070.t070@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s070.t070",
+          "repoName": "vss-blatt1-s070.t070"
+        },
+        {
+          "raw": "s132.t132@example.edu",
+          "email": "s132.t132@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s132.t132",
+          "repoName": "vss-blatt1-s132.t132"
+        }
+      ]
+    },
+    {
+      "name": "grp03",
+      "repoName": "vss-blatt1-grp03",
+      "members": [
+        {
+          "raw": "s089.t089@example.edu",
+          "email": "s089.t089@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s089.t089",
+          "repoName": "vss-blatt1-s089.t089"
+        },
+        {
+          "raw": "s165.t165@example.edu",
+          "email": "s165.t165@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s165.t165",
+          "repoName": "vss-blatt1-s165.t165"
+        }
+      ]
+    },
+    {
+      "name": "grp04",
+      "repoName": "vss-blatt1-grp04",
+      "members": [
+        {
+          "raw": "s114.t114@example.edu",
+          "email": "s114.t114@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s114.t114",
+          "repoName": "vss-blatt1-s114.t114"
+        },
+        {
+          "raw": "s198.t198@example.edu",
+          "email": "s198.t198@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s198.t198",
+          "repoName": "vss-blatt1-s198.t198"
+        }
+      ]
+    },
+    {
+      "name": "grp05",
+      "repoName": "vss-blatt1-grp05",
+      "members": [
+        {
+          "raw": "s019.t019@example.edu",
+          "email": "s019.t019@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s019.t019",
+          "repoName": "vss-blatt1-s019.t019"
+        },
+        {
+          "raw": "s107@example.edu",
+          "email": "s107@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s107",
+          "repoName": "vss-blatt1-s107"
+        }
+      ]
+    },
+    {
+      "name": "grp06",
+      "repoName": "vss-blatt1-grp06",
+      "members": [
+        {
+          "raw": "s054@example.edu",
+          "email": "s054@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s054",
+          "repoName": "vss-blatt1-s054"
+        },
+        {
+          "raw": "s129.t129@example.edu",
+          "email": "s129.t129@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s129.t129",
+          "repoName": "vss-blatt1-s129.t129"
+        }
+      ]
+    },
+    {
+      "name": "grp07",
+      "repoName": "vss-blatt1-grp07",
+      "members": [
+        {
+          "raw": "s013@example.edu",
+          "email": "s013@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s013",
+          "repoName": "vss-blatt1-s013"
+        },
+        {
+          "raw": "s083.t083@example.edu",
+          "email": "s083.t083@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s083.t083",
+          "repoName": "vss-blatt1-s083.t083"
+        }
+      ]
+    },
+    {
+      "name": "grp08",
+      "repoName": "vss-blatt1-grp08",
+      "members": [
+        {
+          "raw": "s066@example.edu",
+          "email": "s066@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s066",
+          "repoName": "vss-blatt1-s066"
+        },
+        {
+          "raw": "s067.t067@example.edu",
+          "email": "s067.t067@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s067.t067",
+          "repoName": "vss-blatt1-s067.t067"
+        }
+      ]
+    },
+    {
+      "name": "grp09",
+      "repoName": "vss-blatt1-grp09",
+      "members": [
+        {
+          "raw": "s152.t152@example.edu",
+          "email": "s152.t152@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s152.t152",
+          "repoName": "vss-blatt1-s152.t152"
+        },
+        {
+          "raw": "s166@example.edu",
+          "email": "s166@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s166",
+          "repoName": "vss-blatt1-s166"
+        }
+      ]
+    },
+    {
+      "name": "grp10",
+      "repoName": "vss-blatt1-grp10",
+      "members": [
+        {
+          "raw": "s029.t029@example.edu",
+          "email": "s029.t029@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s029.t029",
+          "repoName": "vss-blatt1-s029.t029"
+        },
+        {
+          "raw": "s143.t143@example.edu",
+          "email": "s143.t143@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s143.t143",
+          "repoName": "vss-blatt1-s143.t143"
+        }
+      ]
+    },
+    {
+      "name": "grp11",
+      "repoName": "vss-blatt1-grp11",
+      "members": [
+        {
+          "raw": "s103@example.edu",
+          "email": "s103@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s103",
+          "repoName": "vss-blatt1-s103"
+        },
+        {
+          "raw": "s189.t189@example.edu",
+          "email": "s189.t189@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s189.t189",
+          "repoName": "vss-blatt1-s189.t189"
+        }
+      ]
+    },
+    {
+      "name": "grp12",
+      "repoName": "vss-blatt1-grp12",
+      "members": [
+        {
+          "raw": "s004.t004@example.edu",
+          "email": "s004.t004@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s004.t004",
+          "repoName": "vss-blatt1-s004.t004"
+        },
+        {
+          "raw": "s215.t215@example.edu",
+          "email": "s215.t215@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s215.t215",
+          "repoName": "vss-blatt1-s215.t215"
+        }
+      ]
+    },
+    {
+      "name": "grp13",
+      "repoName": "vss-blatt1-grp13",
+      "members": [
+        {
+          "raw": "s184.t184@example.edu",
+          "email": "s184.t184@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s184.t184",
+          "repoName": "vss-blatt1-s184.t184"
+        },
+        {
+          "raw": "s191.t191@example.edu",
+          "email": "s191.t191@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s191.t191",
+          "repoName": "vss-blatt1-s191.t191"
+        }
+      ]
+    },
+    {
+      "name": "grp14",
+      "repoName": "vss-blatt1-grp14",
+      "members": [
+        {
+          "raw": "s137.t137@example.edu",
+          "email": "s137.t137@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s137.t137",
+          "repoName": "vss-blatt1-s137.t137"
+        }
+      ]
+    },
+    {
+      "name": "grp15",
+      "repoName": "vss-blatt1-grp15",
+      "members": [
+        {
+          "raw": "s085.t085@example.edu",
+          "email": "s085.t085@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s085.t085",
+          "repoName": "vss-blatt1-s085.t085"
+        },
+        {
+          "raw": "s185.t185@example.edu",
+          "email": "s185.t185@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s185.t185",
+          "repoName": "vss-blatt1-s185.t185"
+        }
+      ]
+    },
+    {
+      "name": "grp16",
+      "repoName": "vss-blatt1-grp16",
+      "members": [
+        {
+          "raw": "s207.t207@example.edu",
+          "email": "s207.t207@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s207.t207",
+          "repoName": "vss-blatt1-s207.t207"
+        }
+      ]
+    },
+    {
+      "name": "grp17",
+      "repoName": "vss-blatt1-grp17",
+      "members": [
+        {
+          "raw": "s169@example.edu",
+          "email": "s169@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s169",
+          "repoName": "vss-blatt1-s169"
+        },
+        {
+          "raw": "s206.t206@example.edu",
+          "email": "s206.t206@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s206.t206",
+          "repoName": "vss-blatt1-s206.t206"
+        }
+      ]
+    },
+    {
+      "name": "grp18",
+      "repoName": "vss-blatt1-grp18",
+      "members": [
+        {
+          "raw": "s088.t088@example.edu",
+          "email": "s088.t088@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s088.t088",
+          "repoName": "vss-blatt1-s088.t088"
+        }
+      ]
+    },
+    {
+      "name": "grp19",
+      "repoName": "vss-blatt1-grp19",
+      "members": [
+        {
+          "raw": "s078.t078@example.edu",
+          "email": "s078.t078@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s078.t078",
+          "repoName": "vss-blatt1-s078.t078"
+        }
+      ]
+    },
+    {
+      "name": "grp20",
+      "repoName": "vss-blatt1-grp20",
+      "members": [
+        {
+          "raw": "s039.t039@example.edu",
+          "email": "s039.t039@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s039.t039",
+          "repoName": "vss-blatt1-s039.t039"
+        },
+        {
+          "raw": "s155.t155@example.edu",
+          "email": "s155.t155@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s155.t155",
+          "repoName": "vss-blatt1-s155.t155"
+        }
+      ]
+    },
+    {
+      "name": "grp21",
+      "repoName": "vss-blatt1-grp21",
+      "members": [
+        {
+          "raw": "s136.t136@example.edu",
+          "email": "s136.t136@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s136.t136",
+          "repoName": "vss-blatt1-s136.t136"
+        },
+        {
+          "raw": "s142@example.edu",
+          "email": "s142@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s142",
+          "repoName": "vss-blatt1-s142"
+        }
+      ]
+    },
+    {
+      "name": "grp22",
+      "repoName": "vss-blatt1-grp22",
+      "members": [
+        {
+          "raw": "s190@example.edu",
+          "email": "s190@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s190",
+          "repoName": "vss-blatt1-s190"
+        }
+      ]
+    },
+    {
+      "name": "grp23",
+      "repoName": "vss-blatt1-grp23",
+      "members": [
+        {
+          "raw": "s055.t055@example.edu",
+          "email": "s055.t055@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s055.t055",
+          "repoName": "vss-blatt1-s055.t055"
+        }
+      ]
+    },
+    {
+      "name": "grp24",
+      "repoName": "vss-blatt1-grp24",
+      "members": [
+        {
+          "raw": "s053.t053@example.edu",
+          "email": "s053.t053@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s053.t053",
+          "repoName": "vss-blatt1-s053.t053"
+        }
+      ]
+    },
+    {
+      "name": "grp25",
+      "repoName": "vss-blatt1-grp25",
+      "members": [
+        {
+          "raw": "s200.t200@example.edu",
+          "email": "s200.t200@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s200.t200",
+          "repoName": "vss-blatt1-s200.t200"
+        }
+      ]
+    },
+    {
+      "name": "grp26",
+      "repoName": "vss-blatt1-grp26",
+      "members": [
+        {
+          "raw": "s003.t003@example.edu",
+          "email": "s003.t003@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s003.t003",
+          "repoName": "vss-blatt1-s003.t003"
+        }
+      ]
+    },
+    {
+      "name": "grp27",
+      "repoName": "vss-blatt1-grp27",
+      "members": [
+        {
+          "raw": "s021@example.edu",
+          "email": "s021@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s021",
+          "repoName": "vss-blatt1-s021"
+        }
+      ]
+    },
+    {
+      "name": "grp28",
+      "repoName": "vss-blatt1-grp28",
+      "members": [
+        {
+          "raw": "s096.t096@example.edu",
+          "email": "s096.t096@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s096.t096",
+          "repoName": "vss-blatt1-s096.t096"
+        },
+        {
+          "raw": "s128.t128@example.edu",
+          "email": "s128.t128@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s128.t128",
+          "repoName": "vss-blatt1-s128.t128"
+        }
+      ]
+    },
+    {
+      "name": "grp29",
+      "repoName": "vss-blatt1-grp29",
+      "members": [
+        {
+          "raw": "s034.t034@example.edu",
+          "email": "s034.t034@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s034.t034",
+          "repoName": "vss-blatt1-s034.t034"
+        }
+      ]
+    },
+    {
+      "name": "grp30",
+      "repoName": "vss-blatt1-grp30",
+      "members": [
+        {
+          "raw": "s092.t092@example.edu",
+          "email": "s092.t092@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s092.t092",
+          "repoName": "vss-blatt1-s092.t092"
+        },
+        {
+          "raw": "s133.t133@example.edu",
+          "email": "s133.t133@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s133.t133",
+          "repoName": "vss-blatt1-s133.t133"
+        }
+      ]
+    },
+    {
+      "name": "grp32",
+      "repoName": "vss-blatt1-grp32",
+      "members": [
+        {
+          "raw": "s151@example.edu",
+          "email": "s151@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s151",
+          "repoName": "vss-blatt1-s151"
+        }
+      ]
+    },
+    {
+      "name": "grp33",
+      "repoName": "vss-blatt1-grp33",
+      "members": [
+        {
+          "raw": "s194.t194@example.edu",
+          "email": "s194.t194@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s194.t194",
+          "repoName": "vss-blatt1-s194.t194"
+        }
+      ]
+    },
+    {
+      "name": "grp35",
+      "repoName": "vss-blatt1-grp35",
+      "members": [
+        {
+          "raw": "s084@example.edu",
+          "email": "s084@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s084",
+          "repoName": "vss-blatt1-s084"
+        },
+        {
+          "raw": "s109.t109@example.edu",
+          "email": "s109.t109@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s109.t109",
+          "repoName": "vss-blatt1-s109.t109"
+        }
+      ]
+    },
+    {
+      "name": "grp36",
+      "repoName": "vss-blatt1-grp36",
+      "members": [
+        {
+          "raw": "s044.t044@example.edu",
+          "email": "s044.t044@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s044.t044",
+          "repoName": "vss-blatt1-s044.t044"
+        }
+      ]
+    },
+    {
+      "name": "grp37",
+      "repoName": "vss-blatt1-grp37",
+      "members": [
+        {
+          "raw": "s073.t073@example.edu",
+          "email": "s073.t073@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s073.t073",
+          "repoName": "vss-blatt1-s073.t073"
+        }
+      ]
+    },
+    {
+      "name": "grp38",
+      "repoName": "vss-blatt1-grp38",
+      "members": [
+        {
+          "raw": "s071.t071@example.edu",
+          "email": "s071.t071@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s071.t071",
+          "repoName": "vss-blatt1-s071.t071"
+        }
+      ]
+    },
+    {
+      "name": "grp39",
+      "repoName": "vss-blatt1-grp39",
+      "members": [
+        {
+          "raw": "s075.t075@example.edu",
+          "email": "s075.t075@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s075.t075",
+          "repoName": "vss-blatt1-s075.t075"
+        }
+      ]
+    },
+    {
+      "name": "grp40",
+      "repoName": "vss-blatt1-grp40",
+      "members": [
+        {
+          "raw": "s205.t205@example.edu",
+          "email": "s205.t205@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s205.t205",
+          "repoName": "vss-blatt1-s205.t205"
+        }
+      ]
+    },
+    {
+      "name": "grp41",
+      "repoName": "vss-blatt1-grp41",
+      "members": [
+        {
+          "raw": "s047.t047@example.edu",
+          "email": "s047.t047@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s047.t047",
+          "repoName": "vss-blatt1-s047.t047"
+        }
+      ]
+    },
+    {
+      "name": "grp42",
+      "repoName": "vss-blatt1-grp42",
+      "members": [
+        {
+          "raw": "s209.t209@example.edu",
+          "email": "s209.t209@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s209.t209",
+          "repoName": "vss-blatt1-s209.t209"
+        }
+      ]
+    },
+    {
+      "name": "grp43",
+      "repoName": "vss-blatt1-grp43",
+      "members": [
+        {
+          "raw": "s144.t144@example.edu",
+          "email": "s144.t144@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s144.t144",
+          "repoName": "vss-blatt1-s144.t144"
+        }
+      ]
+    }
+  ]
+}

--- a/config/testdata/golden/vss.blatt2.json
+++ b/config/testdata/golden/vss.blatt2.json
@@ -1,0 +1,856 @@
+{
+  "course": "vss",
+  "name": "blatt2",
+  "useCoursenameAsPrefix": true,
+  "useEmailDomainAsSuffix": false,
+  "path": "vss/semester/ob-26ss/blatt-2",
+  "url": "https://gitlab.lrz.de/vss/semester/ob-26ss/blatt-2",
+  "repoBaseName": "vss-blatt2",
+  "per": "group",
+  "description": "Blatt 2, Verteilte Softwaresysteme, SS 26",
+  "containerRegistry": true,
+  "accessLevel": "developer",
+  "accessLevelValue": 30,
+  "mergeRequest": {
+    "MergeMethod": "semi_linear",
+    "SquashOption": "never",
+    "PipelineMustSucceed": true,
+    "SkippedPipelinesAreSuccessful": false,
+    "AllThreadsMustBeResolved": true,
+    "StatusChecksMustSucceed": true,
+    "Approvals": [
+      {
+        "Name": "review",
+        "Branch": "",
+        "Branches": [
+          "main",
+          "startercode"
+        ],
+        "Usernames": [],
+        "Groups": [],
+        "MultiMemberGroupsOnly": true,
+        "RequiredApprovals": 1
+      },
+      {
+        "Name": "submission",
+        "Branch": "",
+        "Branches": [
+          "startercode"
+        ],
+        "Usernames": [
+          "obcode"
+        ],
+        "Groups": [],
+        "MultiMemberGroupsOnly": false,
+        "RequiredApprovals": 1
+      }
+    ],
+    "ApprovalSettings": {
+      "PreventApprovalByMergeRequestCreator": true,
+      "PreventApprovalsByUsersWhoAddCommits": false,
+      "PreventEditingApprovalRulesInMergeRequests": true,
+      "RequireUserReauthenticationToApprove": false,
+      "WhenCommitAdded": "removeAllApprovals"
+    }
+  },
+  "branches": [
+    {
+      "Name": "main",
+      "Protect": false,
+      "MergeOnly": true,
+      "Default": true,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    },
+    {
+      "Name": "startercode",
+      "Protect": true,
+      "MergeOnly": false,
+      "Default": false,
+      "AllowForcePush": false,
+      "CodeOwnerApprovalRequired": false
+    }
+  ],
+  "issues": {
+    "ReplicateFromStartercode": true,
+    "IssueNumbers": [
+      1
+    ],
+    "IncludeChildTasks": false
+  },
+  "startercode": {
+    "URL": "git@gitlab.lrz.de:vss/startercode/startercodeB2.git",
+    "FromBranch": "template",
+    "Tag": "",
+    "Template": false,
+    "TemplateMessage": "Initial",
+    "ToBranch": "main",
+    "AdditionalBranches": null
+  },
+  "clone": {
+    "LocalPath": "/tmp/glabs/vss/26ss/blatt2",
+    "Branch": "main",
+    "Force": false
+  },
+  "release": {
+    "MergeRequest": {
+      "SourceBranch": "develop",
+      "TargetBranch": "main",
+      "HasPipeline": true
+    },
+    "DockerImages": null
+  },
+  "seeder": null,
+  "deferredBranches": {},
+  "students": null,
+  "groups": [
+    {
+      "name": "grp00",
+      "repoName": "vss-blatt2-grp00",
+      "members": [
+        {
+          "raw": "s161.t161@example.edu",
+          "email": "s161.t161@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s161.t161",
+          "repoName": "vss-blatt2-s161.t161"
+        }
+      ]
+    },
+    {
+      "name": "grp01",
+      "repoName": "vss-blatt2-grp01",
+      "members": [
+        {
+          "raw": "s036.t036@example.edu",
+          "email": "s036.t036@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s036.t036",
+          "repoName": "vss-blatt2-s036.t036"
+        },
+        {
+          "raw": "s081@example.edu",
+          "email": "s081@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s081",
+          "repoName": "vss-blatt2-s081"
+        }
+      ]
+    },
+    {
+      "name": "grp02",
+      "repoName": "vss-blatt2-grp02",
+      "members": [
+        {
+          "raw": "s070.t070@example.edu",
+          "email": "s070.t070@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s070.t070",
+          "repoName": "vss-blatt2-s070.t070"
+        },
+        {
+          "raw": "s132.t132@example.edu",
+          "email": "s132.t132@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s132.t132",
+          "repoName": "vss-blatt2-s132.t132"
+        }
+      ]
+    },
+    {
+      "name": "grp03",
+      "repoName": "vss-blatt2-grp03",
+      "members": [
+        {
+          "raw": "s089.t089@example.edu",
+          "email": "s089.t089@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s089.t089",
+          "repoName": "vss-blatt2-s089.t089"
+        },
+        {
+          "raw": "s165.t165@example.edu",
+          "email": "s165.t165@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s165.t165",
+          "repoName": "vss-blatt2-s165.t165"
+        }
+      ]
+    },
+    {
+      "name": "grp04",
+      "repoName": "vss-blatt2-grp04",
+      "members": [
+        {
+          "raw": "s114.t114@example.edu",
+          "email": "s114.t114@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s114.t114",
+          "repoName": "vss-blatt2-s114.t114"
+        },
+        {
+          "raw": "s198.t198@example.edu",
+          "email": "s198.t198@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s198.t198",
+          "repoName": "vss-blatt2-s198.t198"
+        }
+      ]
+    },
+    {
+      "name": "grp05",
+      "repoName": "vss-blatt2-grp05",
+      "members": [
+        {
+          "raw": "s019.t019@example.edu",
+          "email": "s019.t019@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s019.t019",
+          "repoName": "vss-blatt2-s019.t019"
+        },
+        {
+          "raw": "s107@example.edu",
+          "email": "s107@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s107",
+          "repoName": "vss-blatt2-s107"
+        }
+      ]
+    },
+    {
+      "name": "grp06",
+      "repoName": "vss-blatt2-grp06",
+      "members": [
+        {
+          "raw": "s054@example.edu",
+          "email": "s054@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s054",
+          "repoName": "vss-blatt2-s054"
+        },
+        {
+          "raw": "s129.t129@example.edu",
+          "email": "s129.t129@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s129.t129",
+          "repoName": "vss-blatt2-s129.t129"
+        }
+      ]
+    },
+    {
+      "name": "grp07",
+      "repoName": "vss-blatt2-grp07",
+      "members": [
+        {
+          "raw": "s013@example.edu",
+          "email": "s013@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s013",
+          "repoName": "vss-blatt2-s013"
+        },
+        {
+          "raw": "s083.t083@example.edu",
+          "email": "s083.t083@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s083.t083",
+          "repoName": "vss-blatt2-s083.t083"
+        }
+      ]
+    },
+    {
+      "name": "grp08",
+      "repoName": "vss-blatt2-grp08",
+      "members": [
+        {
+          "raw": "s066@example.edu",
+          "email": "s066@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s066",
+          "repoName": "vss-blatt2-s066"
+        },
+        {
+          "raw": "s067.t067@example.edu",
+          "email": "s067.t067@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s067.t067",
+          "repoName": "vss-blatt2-s067.t067"
+        }
+      ]
+    },
+    {
+      "name": "grp09",
+      "repoName": "vss-blatt2-grp09",
+      "members": [
+        {
+          "raw": "s152.t152@example.edu",
+          "email": "s152.t152@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s152.t152",
+          "repoName": "vss-blatt2-s152.t152"
+        },
+        {
+          "raw": "s166@example.edu",
+          "email": "s166@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s166",
+          "repoName": "vss-blatt2-s166"
+        }
+      ]
+    },
+    {
+      "name": "grp10",
+      "repoName": "vss-blatt2-grp10",
+      "members": [
+        {
+          "raw": "s029.t029@example.edu",
+          "email": "s029.t029@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s029.t029",
+          "repoName": "vss-blatt2-s029.t029"
+        },
+        {
+          "raw": "s143.t143@example.edu",
+          "email": "s143.t143@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s143.t143",
+          "repoName": "vss-blatt2-s143.t143"
+        }
+      ]
+    },
+    {
+      "name": "grp11",
+      "repoName": "vss-blatt2-grp11",
+      "members": [
+        {
+          "raw": "s103@example.edu",
+          "email": "s103@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s103",
+          "repoName": "vss-blatt2-s103"
+        },
+        {
+          "raw": "s189.t189@example.edu",
+          "email": "s189.t189@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s189.t189",
+          "repoName": "vss-blatt2-s189.t189"
+        }
+      ]
+    },
+    {
+      "name": "grp12",
+      "repoName": "vss-blatt2-grp12",
+      "members": [
+        {
+          "raw": "s004.t004@example.edu",
+          "email": "s004.t004@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s004.t004",
+          "repoName": "vss-blatt2-s004.t004"
+        },
+        {
+          "raw": "s215.t215@example.edu",
+          "email": "s215.t215@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s215.t215",
+          "repoName": "vss-blatt2-s215.t215"
+        }
+      ]
+    },
+    {
+      "name": "grp13",
+      "repoName": "vss-blatt2-grp13",
+      "members": [
+        {
+          "raw": "s184.t184@example.edu",
+          "email": "s184.t184@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s184.t184",
+          "repoName": "vss-blatt2-s184.t184"
+        },
+        {
+          "raw": "s191.t191@example.edu",
+          "email": "s191.t191@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s191.t191",
+          "repoName": "vss-blatt2-s191.t191"
+        }
+      ]
+    },
+    {
+      "name": "grp14",
+      "repoName": "vss-blatt2-grp14",
+      "members": [
+        {
+          "raw": "s137.t137@example.edu",
+          "email": "s137.t137@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s137.t137",
+          "repoName": "vss-blatt2-s137.t137"
+        }
+      ]
+    },
+    {
+      "name": "grp15",
+      "repoName": "vss-blatt2-grp15",
+      "members": [
+        {
+          "raw": "s085.t085@example.edu",
+          "email": "s085.t085@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s085.t085",
+          "repoName": "vss-blatt2-s085.t085"
+        },
+        {
+          "raw": "s185.t185@example.edu",
+          "email": "s185.t185@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s185.t185",
+          "repoName": "vss-blatt2-s185.t185"
+        }
+      ]
+    },
+    {
+      "name": "grp16",
+      "repoName": "vss-blatt2-grp16",
+      "members": [
+        {
+          "raw": "s207.t207@example.edu",
+          "email": "s207.t207@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s207.t207",
+          "repoName": "vss-blatt2-s207.t207"
+        }
+      ]
+    },
+    {
+      "name": "grp17",
+      "repoName": "vss-blatt2-grp17",
+      "members": [
+        {
+          "raw": "s169@example.edu",
+          "email": "s169@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s169",
+          "repoName": "vss-blatt2-s169"
+        },
+        {
+          "raw": "s206.t206@example.edu",
+          "email": "s206.t206@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s206.t206",
+          "repoName": "vss-blatt2-s206.t206"
+        }
+      ]
+    },
+    {
+      "name": "grp18",
+      "repoName": "vss-blatt2-grp18",
+      "members": [
+        {
+          "raw": "s088.t088@example.edu",
+          "email": "s088.t088@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s088.t088",
+          "repoName": "vss-blatt2-s088.t088"
+        }
+      ]
+    },
+    {
+      "name": "grp19",
+      "repoName": "vss-blatt2-grp19",
+      "members": [
+        {
+          "raw": "s078.t078@example.edu",
+          "email": "s078.t078@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s078.t078",
+          "repoName": "vss-blatt2-s078.t078"
+        }
+      ]
+    },
+    {
+      "name": "grp20",
+      "repoName": "vss-blatt2-grp20",
+      "members": [
+        {
+          "raw": "s039.t039@example.edu",
+          "email": "s039.t039@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s039.t039",
+          "repoName": "vss-blatt2-s039.t039"
+        },
+        {
+          "raw": "s155.t155@example.edu",
+          "email": "s155.t155@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s155.t155",
+          "repoName": "vss-blatt2-s155.t155"
+        }
+      ]
+    },
+    {
+      "name": "grp21",
+      "repoName": "vss-blatt2-grp21",
+      "members": [
+        {
+          "raw": "s136.t136@example.edu",
+          "email": "s136.t136@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s136.t136",
+          "repoName": "vss-blatt2-s136.t136"
+        },
+        {
+          "raw": "s142@example.edu",
+          "email": "s142@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s142",
+          "repoName": "vss-blatt2-s142"
+        }
+      ]
+    },
+    {
+      "name": "grp22",
+      "repoName": "vss-blatt2-grp22",
+      "members": [
+        {
+          "raw": "s190@example.edu",
+          "email": "s190@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s190",
+          "repoName": "vss-blatt2-s190"
+        }
+      ]
+    },
+    {
+      "name": "grp23",
+      "repoName": "vss-blatt2-grp23",
+      "members": [
+        {
+          "raw": "s055.t055@example.edu",
+          "email": "s055.t055@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s055.t055",
+          "repoName": "vss-blatt2-s055.t055"
+        }
+      ]
+    },
+    {
+      "name": "grp24",
+      "repoName": "vss-blatt2-grp24",
+      "members": [
+        {
+          "raw": "s053.t053@example.edu",
+          "email": "s053.t053@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s053.t053",
+          "repoName": "vss-blatt2-s053.t053"
+        }
+      ]
+    },
+    {
+      "name": "grp25",
+      "repoName": "vss-blatt2-grp25",
+      "members": [
+        {
+          "raw": "s200.t200@example.edu",
+          "email": "s200.t200@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s200.t200",
+          "repoName": "vss-blatt2-s200.t200"
+        }
+      ]
+    },
+    {
+      "name": "grp26",
+      "repoName": "vss-blatt2-grp26",
+      "members": [
+        {
+          "raw": "s003.t003@example.edu",
+          "email": "s003.t003@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s003.t003",
+          "repoName": "vss-blatt2-s003.t003"
+        }
+      ]
+    },
+    {
+      "name": "grp27",
+      "repoName": "vss-blatt2-grp27",
+      "members": [
+        {
+          "raw": "s021@example.edu",
+          "email": "s021@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s021",
+          "repoName": "vss-blatt2-s021"
+        }
+      ]
+    },
+    {
+      "name": "grp28",
+      "repoName": "vss-blatt2-grp28",
+      "members": [
+        {
+          "raw": "s096.t096@example.edu",
+          "email": "s096.t096@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s096.t096",
+          "repoName": "vss-blatt2-s096.t096"
+        },
+        {
+          "raw": "s128.t128@example.edu",
+          "email": "s128.t128@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s128.t128",
+          "repoName": "vss-blatt2-s128.t128"
+        }
+      ]
+    },
+    {
+      "name": "grp29",
+      "repoName": "vss-blatt2-grp29",
+      "members": [
+        {
+          "raw": "s034.t034@example.edu",
+          "email": "s034.t034@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s034.t034",
+          "repoName": "vss-blatt2-s034.t034"
+        }
+      ]
+    },
+    {
+      "name": "grp30",
+      "repoName": "vss-blatt2-grp30",
+      "members": [
+        {
+          "raw": "s092.t092@example.edu",
+          "email": "s092.t092@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s092.t092",
+          "repoName": "vss-blatt2-s092.t092"
+        },
+        {
+          "raw": "s133.t133@example.edu",
+          "email": "s133.t133@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s133.t133",
+          "repoName": "vss-blatt2-s133.t133"
+        }
+      ]
+    },
+    {
+      "name": "grp32",
+      "repoName": "vss-blatt2-grp32",
+      "members": [
+        {
+          "raw": "s151@example.edu",
+          "email": "s151@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s151",
+          "repoName": "vss-blatt2-s151"
+        }
+      ]
+    },
+    {
+      "name": "grp33",
+      "repoName": "vss-blatt2-grp33",
+      "members": [
+        {
+          "raw": "s194.t194@example.edu",
+          "email": "s194.t194@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s194.t194",
+          "repoName": "vss-blatt2-s194.t194"
+        }
+      ]
+    },
+    {
+      "name": "grp35",
+      "repoName": "vss-blatt2-grp35",
+      "members": [
+        {
+          "raw": "s084@example.edu",
+          "email": "s084@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s084",
+          "repoName": "vss-blatt2-s084"
+        },
+        {
+          "raw": "s109.t109@example.edu",
+          "email": "s109.t109@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s109.t109",
+          "repoName": "vss-blatt2-s109.t109"
+        }
+      ]
+    },
+    {
+      "name": "grp36",
+      "repoName": "vss-blatt2-grp36",
+      "members": [
+        {
+          "raw": "s044.t044@example.edu",
+          "email": "s044.t044@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s044.t044",
+          "repoName": "vss-blatt2-s044.t044"
+        }
+      ]
+    },
+    {
+      "name": "grp37",
+      "repoName": "vss-blatt2-grp37",
+      "members": [
+        {
+          "raw": "s073.t073@example.edu",
+          "email": "s073.t073@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s073.t073",
+          "repoName": "vss-blatt2-s073.t073"
+        }
+      ]
+    },
+    {
+      "name": "grp38",
+      "repoName": "vss-blatt2-grp38",
+      "members": [
+        {
+          "raw": "s071.t071@example.edu",
+          "email": "s071.t071@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s071.t071",
+          "repoName": "vss-blatt2-s071.t071"
+        }
+      ]
+    },
+    {
+      "name": "grp39",
+      "repoName": "vss-blatt2-grp39",
+      "members": [
+        {
+          "raw": "s075.t075@example.edu",
+          "email": "s075.t075@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s075.t075",
+          "repoName": "vss-blatt2-s075.t075"
+        }
+      ]
+    },
+    {
+      "name": "grp40",
+      "repoName": "vss-blatt2-grp40",
+      "members": [
+        {
+          "raw": "s205.t205@example.edu",
+          "email": "s205.t205@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s205.t205",
+          "repoName": "vss-blatt2-s205.t205"
+        }
+      ]
+    },
+    {
+      "name": "grp41",
+      "repoName": "vss-blatt2-grp41",
+      "members": [
+        {
+          "raw": "s047.t047@example.edu",
+          "email": "s047.t047@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s047.t047",
+          "repoName": "vss-blatt2-s047.t047"
+        }
+      ]
+    },
+    {
+      "name": "grp42",
+      "repoName": "vss-blatt2-grp42",
+      "members": [
+        {
+          "raw": "s209.t209@example.edu",
+          "email": "s209.t209@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s209.t209",
+          "repoName": "vss-blatt2-s209.t209"
+        }
+      ]
+    },
+    {
+      "name": "grp43",
+      "repoName": "vss-blatt2-grp43",
+      "members": [
+        {
+          "raw": "s144.t144@example.edu",
+          "email": "s144.t144@example.edu",
+          "username": null,
+          "id": null,
+          "repoSuffix": "s144.t144",
+          "repoName": "vss-blatt2-s144.t144"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Schritt 0 des glabs-web-Plans: das Sicherheitsnetz, bevor irgendetwas am Config-Laden angefasst wird.

## Warum

`config/` baut `AssignmentConfig` heute aus ~63 einzelnen `viper.GetString("kurs.assignment.feld")`-Aufrufen zusammen — ohne yaml-Tags, mit Vererbung, die beim Lesen in globalen State zurückschreibt. Der geplante Umbau auf ein typisiertes Quellschema muss **verhaltenserhaltend** sein, und das lässt sich nur beweisen, wenn das IST-Verhalten vorher festgenagelt ist.

Dieser PR ändert **keinen Produktivcode** — nur Tests und Fixtures.

## Was drin ist

**Fixtures** (`config/testdata/courses/`):

- `mpd`, `vss`, `algdati`, `fundc`, `fun` — strukturgetreue Kopien der echten Kursdateien, Studi-Identitäten pseudonymisiert. Keine echten Adressen im öffentlichen Repo; verifiziert per Diff, dass sonst nichts an der Struktur abweicht.
- `casecourse` — synthetisch, und der eigentliche Grund für diesen PR. Die echten YAMLs sind durchgängig kleingeschrieben und können eine Änderung am Case-Handling **nicht** entdecken. Dieses Fixture nagelt die Asymmetrie fest, an der ein naiver yaml.v3-Decoder zerbräche:
  - viper schreibt Map-**Keys** klein (`Grp01` → `grp01`), lässt Listen-**Werte** aber in Ruhe
  - `gitlabProjectPath` behält bereits gültige Pfade verbatim (`Upper.Case`), parameterisiert ungültige (`plus+tag` → `plus-tag`)
- `legacy` — synthetisch. Nagelt die Legacy-Key-Shims **und ihre Aktivierungsregeln** fest (die startercode-Branch-Shims greifen nur, wenn `branches:` fehlt; die Issue-Shims nur, wenn `issues:` ganz fehlt). Die meisten davon haben in den echten Dateien null Abdeckung.

**Der Golden-View** zeichnet die **abgeleiteten Repo-Namen** auf, nicht nur die Rohconfig. Das ist der Punkt: eine Änderung am Case-Handling taucht in `Email`/`Raw` gar nicht auf — sie benennt still das GitLab-Projekt um. Gegenprobe gemacht: eine künstlich eingebaute Regression wird gefangen und zeigt exakt den geänderten `repoName`.

viper wird **pro Assignment** neu geladen, weil `GetAssignmentConfig` das gemergte `extends`-Ergebnis in den globalen State zurückschreibt — sonst hinge das Ergebnis von der Auflösungsreihenfolge ab.

## Zwei Bugs gefunden — bewusst eingefroren, nicht gefixt

Die Goldens frieren das Verhalten ein, **inklusive Bugs**. Sonst weiß man beim späteren Umbau bei jedem Diff nicht, ob er gewollt ist. Beide sind in den Fixtures dokumentiert und gehören in eigene Commits *nach* dem Schema-Umbau:

1. **`release.dockerImages` wird vom falschen Key gelesen.** `vss.yaml` legt die Images unter `release.mergeRequest.dockerImages`, `config/release.go:47` liest `release.dockerImages` → die sechs Images in `vss/blatt2` werden stillschweigend ignoriert.
2. **Der `approvalsRequired`-Alias ist toter Code.** viper schreibt den Key auf `approvalsrequired` klein, bevor die Alias-Tabelle in `config/assignment.go:443` ihn gegen die CamelCase-Schreibweise vergleicht — der Fall trifft nie zu. Ergebnis: `RequiredApprovals: 0` statt des konfigurierten Werts, also *keine* Approval-Pflicht. Der Golden `legacy.approvalslist.json` stellt die drei Schreibweisen nebeneinander: `required_approvals`→2 ✓, `approvalsRequired`→0 ✗, `requiredApprovals`→3 ✓.

Beide sind **latent, nicht aktiv**: keine echte Config nutzt den kaputten Alias, und `vss/blatt2` setzt `containerRegistry` ohnehin explizit. Genau die Klasse Fund, die das geplante `glabs config lint` künftig automatisch meldet.

## Verifikation

- `go test ./...` grün; `gofmt`, `go vet`, `golangci-lint` sauber
- Determinismus: zweimal `-update` erzeugt keine Diffs
- Netz greift: künstliche Regression wird gefangen
- Kein Leck: 0 Treffer für `@hm.edu` oder lokale Pfade im Diff, 3589 Pseudonyme

Refresh: `go test ./config/ -run TestGolden -update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)