### PR TITLE
feat(config): add typed source schema with config lint/fmt/migrate

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/logrusorgru/aurora/v4"
+	"github.com/obcode/glabs/v2/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configLintCmd, configFmtCmd, configMigrateCmd)
+	configFmtCmd.Flags().BoolVarP(&configWrite, "write", "w", false, "write the result back to the file instead of printing it")
+	configMigrateCmd.Flags().BoolVarP(&configWrite, "write", "w", false, "write the result back to the file instead of printing it")
+}
+
+var configWrite bool
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Inspect and maintain course configuration files",
+	Long: `Inspect and maintain course configuration files.
+
+These commands work on the course file as written, without resolving it: they
+never talk to GitLab and never need a token.`,
+}
+
+var configLintCmd = &cobra.Command{
+	Use:   "lint [course...]",
+	Short: "Report configuration that does not do what it looks like it does",
+	Long: `Report configuration that does not do what it looks like it does.
+
+glabs ignores unknown keys silently, so a typo looks exactly like a setting that
+works. lint names them, along with deprecated spellings and settings that are
+overridden by a newer block.
+
+With no arguments, every course listed in the main config is linted.
+
+Exits non-zero if any problem (as opposed to a mere deprecation) was found, so
+it can gate a commit hook or CI.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		problems := 0
+		for _, course := range coursesToProcess(args) {
+			path := courseFilePath(course)
+			source, decoded, err := decodeCourseFile(path)
+			if err != nil {
+				er(err)
+			}
+
+			findings := config.Lint(source, decoded)
+			if len(findings) == 0 {
+				fmt.Printf("%s %s\n", aurora.Green("ok"), path)
+				continue
+			}
+
+			fmt.Printf("%s\n", aurora.Bold(path))
+			for _, f := range findings {
+				label := aurora.Yellow(string(f.Severity))
+				if f.Severity == config.SeverityProblem {
+					label = aurora.Red(string(f.Severity))
+					problems++
+				}
+				fmt.Printf("  %s %s\n      %s\n", label, aurora.Cyan(f.Path), f.Message)
+			}
+		}
+
+		if problems > 0 {
+			fmt.Println()
+			fmt.Println(aurora.Red(fmt.Sprintf("%d problem(s) found", problems)))
+			os.Exit(1)
+		}
+	},
+}
+
+var configFmtCmd = &cobra.Command{
+	Use:   "fmt course [course...]",
+	Short: "Rewrite a course file in canonical form",
+	Long: `Rewrite a course file in canonical form.
+
+Note that comments and key order are not preserved: the file is rebuilt from the
+parsed configuration, not edited in place. Review the diff before committing.`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, course := range args {
+			rewriteCourseFile(courseFilePath(course))
+		}
+	},
+}
+
+var configMigrateCmd = &cobra.Command{
+	Use:   "migrate course [course...]",
+	Short: "Rewrite a course file, upgrading deprecated spellings",
+	Long: `Rewrite a course file, upgrading deprecated spellings.
+
+Deprecated key spellings are folded into their canonical field on read, and
+polymorphic blocks are written back in their modern shape, so migrating is the
+same operation as formatting. It is a separate command only because the intent
+differs: fmt is cosmetic, migrate changes what the file says.
+
+What it does NOT do is resolve superseded settings — if both startercode.devBranch
+and a branches: block are present, migrate keeps both and lint tells you which one
+wins. Deciding that is a judgement call, not a rewrite.
+
+Comments and key order are not preserved. Review the diff before committing.`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, course := range args {
+			rewriteCourseFile(courseFilePath(course))
+		}
+	},
+}
+
+func rewriteCourseFile(path string) {
+	source, _, err := decodeCourseFile(path)
+	if err != nil {
+		er(err)
+	}
+
+	encoded, err := config.EncodeCourse(source)
+	if err != nil {
+		er(err)
+	}
+
+	if !configWrite {
+		fmt.Print(string(encoded))
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		er(err)
+	}
+	if err := os.WriteFile(path, encoded, info.Mode().Perm()); err != nil {
+		er(err)
+	}
+	fmt.Printf("%s %s\n", aurora.Green("wrote"), path)
+}
+
+func decodeCourseFile(path string) (*config.CourseSource, *config.DecodeResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot read course file: %w", err)
+	}
+	source, decoded, err := config.DecodeCourse(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return source, decoded, nil
+}
+
+// coursesToProcess returns the requested courses, or every configured course
+// when none were named.
+func coursesToProcess(args []string) []string {
+	if len(args) > 0 {
+		return args
+	}
+	courses := viper.GetStringSlice("courses")
+	if len(courses) == 0 {
+		er("no courses configured; add a `courses:` list to the main config or name one explicitly")
+	}
+	return courses
+}
+
+// courseFilePath locates a course file the same way initConfig does: by name,
+// under coursesfilepath, with the extensions viper would have accepted.
+func courseFilePath(course string) string {
+	dir := viper.GetString("coursesfilepath")
+	for _, ext := range []string{".yaml", ".yml"} {
+		path := filepath.Join(dir, course+ext)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	er(fmt.Sprintf("cannot find a course file for %q: looked for %s.yaml and %s.yml in %q",
+		course, course, course, dir))
+	return ""
+}

--- a/config/decode.go
+++ b/config/decode.go
@@ -1,0 +1,237 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+	"gopkg.in/yaml.v3"
+)
+
+// Decoding a course file happens in two hops:
+//
+//	bytes --yaml.v3--> map[string]any --mapstructure--> *CourseSource
+//
+// yaml.v3 only ever sees generic maps, so its case-sensitive tag matching never
+// applies to field names. mapstructure does the struct mapping and folds case
+// (MatchName defaults to strings.EqualFold), which reproduces viper's key
+// handling exactly — viper decodes with mapstructure internally, which is why
+// `frombranch` and `fromBranch` are interchangeable today.
+//
+// Assignments are decoded one at a time rather than in a single pass over the
+// course. mapstructure's Metadata cannot name a key inside a ",remain" map — it
+// reports `[<interface {} Value>].clone.clone` — and `glabs config lint` is
+// only useful if it can say *which* assignment carries the stray key.
+
+// DecodeResult carries what a decode learned about the input beyond the values
+// themselves: keys nobody claimed, and deprecated spellings that were accepted.
+// `glabs config lint` reports these; ordinary loading ignores them.
+type DecodeResult struct {
+	// UnknownKeys are dotted paths present in the file that no field matches.
+	// They are silently ignored by the loader, which is exactly why they are
+	// worth reporting: `clone.clone` and `release.mergeRequest.dockerImages`
+	// both look effective and are not.
+	UnknownKeys []string
+	// LegacyKeys are dotted paths that were accepted via a deprecated alias,
+	// with an explanation.
+	LegacyKeys []LegacyKey
+}
+
+type LegacyKey struct {
+	Path string
+	Hint string
+}
+
+// legacyAliases maps deprecated key spellings to their canonical field name.
+// Lookup folds case, which matters: viper lowercases keys before its own alias
+// table sees them, which is why `approvalsRequired` never worked there. Here it
+// does — see TestDecodeAcceptsAliasViperMissed.
+var legacyAliases = map[string]string{
+	"allow_force_push":             "allowForcePush",
+	"code_owner_approval_required": "codeOwnerApprovalRequired",
+	"required_approvals":           "requiredApprovals",
+	"approvalsrequired":            "requiredApprovals",
+}
+
+// courseSourceRaw mirrors CourseSource but keeps the assignments unparsed, so
+// each can be decoded separately with its own metadata.
+type courseSourceRaw struct {
+	CoursePath             string              `mapstructure:"coursepath"`
+	SemesterPath           string              `mapstructure:"semesterpath"`
+	UseCoursenameAsPrefix  bool                `mapstructure:"useCoursenameAsPrefix"`
+	UseEmailDomainAsSuffix *bool               `mapstructure:"useEmailDomainAsSuffix"`
+	Students               []string            `mapstructure:"students"`
+	Groups                 map[string][]string `mapstructure:"groups"`
+	Assignments            map[string]any      `mapstructure:",remain"`
+}
+
+// DecodeCourse decodes a course file. The file must have exactly one top-level
+// key — the course name — whose value is the course mapping.
+func DecodeCourse(data []byte) (*CourseSource, *DecodeResult, error) {
+	var top map[string]any
+	if err := yaml.Unmarshal(data, &top); err != nil {
+		return nil, nil, fmt.Errorf("cannot parse course file as YAML: %w", err)
+	}
+
+	switch len(top) {
+	case 1:
+	case 0:
+		return nil, nil, fmt.Errorf("course file is empty: expected a single top-level key naming the course")
+	default:
+		names := make([]string, 0, len(top))
+		for name := range top {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return nil, nil, fmt.Errorf("course file has %d top-level keys (%s): expected exactly one, naming the course",
+			len(top), strings.Join(names, ", "))
+	}
+
+	var name string
+	var body any
+	for k, v := range top {
+		name, body = k, v
+	}
+
+	return DecodeCourseBody(name, body)
+}
+
+// DecodeCourseBody decodes an already-parsed course mapping. The web server
+// uses this for documents coming from MongoDB rather than from a file.
+func DecodeCourseBody(name string, body any) (*CourseSource, *DecodeResult, error) {
+	if body == nil {
+		return nil, nil, fmt.Errorf("course %s: configuration is empty", name)
+	}
+
+	normalized, legacy := normalizeLegacyKeys(body, name)
+
+	var raw courseSourceRaw
+	var md mapstructure.Metadata
+	if err := decodeInto(&raw, normalized, &md); err != nil {
+		return nil, nil, fmt.Errorf("course %s: cannot decode course settings: %w", name, err)
+	}
+
+	course := &CourseSource{
+		Name:                   name,
+		CoursePath:             raw.CoursePath,
+		SemesterPath:           raw.SemesterPath,
+		UseCoursenameAsPrefix:  raw.UseCoursenameAsPrefix,
+		UseEmailDomainAsSuffix: raw.UseEmailDomainAsSuffix,
+		Students:               raw.Students,
+		Groups:                 raw.Groups,
+	}
+
+	result := &DecodeResult{LegacyKeys: legacy}
+	result.UnknownKeys = append(result.UnknownKeys, prefixPaths(name, md.Unused)...)
+
+	if len(raw.Assignments) > 0 {
+		course.Assignments = make(map[string]*AssignmentSource, len(raw.Assignments))
+	}
+	for assignmentName, assignmentBody := range raw.Assignments {
+		path := name + "." + assignmentName
+		if assignmentBody == nil {
+			return nil, nil, fmt.Errorf("%s: assignment configuration is empty", path)
+		}
+
+		var assignment AssignmentSource
+		var amd mapstructure.Metadata
+		if err := decodeInto(&assignment, assignmentBody, &amd); err != nil {
+			return nil, nil, fmt.Errorf("%s: cannot decode assignment: %w", path, err)
+		}
+		course.Assignments[assignmentName] = &assignment
+		result.UnknownKeys = append(result.UnknownKeys, prefixPaths(path, amd.Unused)...)
+	}
+
+	sort.Strings(result.UnknownKeys)
+	return course, result, nil
+}
+
+func decodeInto(target any, input any, md *mapstructure.Metadata) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           target,
+		Metadata:         md,
+		TagName:          "mapstructure",
+		WeaklyTypedInput: true,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			approvalsDecodeHook,
+		),
+	})
+	if err != nil {
+		return fmt.Errorf("cannot create decoder: %w", err)
+	}
+	return decoder.Decode(input)
+}
+
+func prefixPaths(prefix string, paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		full := prefix + "." + p
+		if _, ok := seen[full]; ok {
+			continue
+		}
+		seen[full] = struct{}{}
+		out = append(out, full)
+	}
+	return out
+}
+
+// approvalsDecodeHook accepts the legacy bare-list form of
+// mergeRequest.approvals by rewriting it into the modern {rules: [...]} shape
+// before the struct decode sees it (see config/assignment.go:333-344 for the
+// behaviour this reproduces).
+func approvalsDecodeHook(from reflect.Type, to reflect.Type, data any) (any, error) {
+	if to != reflect.TypeOf(ApprovalsSource{}) {
+		return data, nil
+	}
+	switch from.Kind() {
+	case reflect.Slice, reflect.Array:
+		return map[string]any{"rules": data}, nil
+	default:
+		return data, nil
+	}
+}
+
+// normalizeLegacyKeys rewrites deprecated key spellings to their canonical form
+// and records where it did so. It walks the raw tree because the aliases are
+// key names, not values, and mapstructure has no per-key alias facility.
+func normalizeLegacyKeys(value any, path string) (any, []LegacyKey) {
+	var found []LegacyKey
+
+	var walk func(any, string) any
+	walk = func(v any, p string) any {
+		switch typed := v.(type) {
+		case map[string]any:
+			out := make(map[string]any, len(typed))
+			for key, item := range typed {
+				childPath := p + "." + key
+				if canonical, ok := legacyAliases[strings.ToLower(key)]; ok {
+					found = append(found, LegacyKey{
+						Path: childPath,
+						Hint: fmt.Sprintf("%q is a deprecated spelling of %q", key, canonical),
+					})
+					key = canonical
+				}
+				out[key] = walk(item, childPath)
+			}
+			return out
+		case []any:
+			out := make([]any, len(typed))
+			for i, item := range typed {
+				out[i] = walk(item, fmt.Sprintf("%s[%d]", p, i))
+			}
+			return out
+		default:
+			return v
+		}
+	}
+
+	normalized := walk(value, path)
+	sort.Slice(found, func(i, j int) bool { return found[i].Path < found[j].Path })
+	return normalized, found
+}

--- a/config/decode_test.go
+++ b/config/decode_test.go
@@ -1,0 +1,374 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func contains(list []string, want string) bool { return slices.Contains(list, want) }
+
+func hasSuffix(list []string, suffix string) bool {
+	return slices.ContainsFunc(list, func(s string) bool { return strings.HasSuffix(s, suffix) })
+}
+
+// decodeFixture decodes a course fixture by name from testdata/courses/.
+func decodeFixture(t *testing.T, name string) (*CourseSource, *DecodeResult) {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "courses", name+".yaml"))
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+	course, result, err := DecodeCourse(data)
+	if err != nil {
+		t.Fatalf("DecodeCourse(%s): %v", name, err)
+	}
+	return course, result
+}
+
+// Every real course file must decode, and the decode must be lossless in the
+// sense that re-encoding and decoding again yields the same source. Byte
+// equality is explicitly NOT the goal — comments and key order do not survive a
+// struct — but the *meaning* must.
+func TestRoundTripAllFixtures(t *testing.T) {
+	t.Parallel()
+
+	paths, err := filepath.Glob(filepath.Join("testdata", "courses", "*.yaml"))
+	if err != nil {
+		t.Fatalf("globbing fixtures: %v", err)
+	}
+	if len(paths) < 5 {
+		t.Fatalf("found only %d course fixtures — glob broken?", len(paths))
+	}
+
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			t.Parallel()
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("reading fixture: %v", err)
+			}
+
+			first, _, err := DecodeCourse(data)
+			if err != nil {
+				t.Fatalf("first decode: %v", err)
+			}
+
+			encoded, err := EncodeCourse(first)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+
+			second, _, err := DecodeCourse(encoded)
+			if err != nil {
+				t.Fatalf("second decode of re-encoded source: %v\n--- encoded ---\n%s", err, encoded)
+			}
+
+			if diff := cmp.Diff(first, second); diff != "" {
+				t.Errorf("round trip changed the source (-first +second):\n%s", diff)
+			}
+		})
+	}
+}
+
+// The assignments must land in the ",remain" map rather than being reported as
+// unknown, and the course settings must not leak into it.
+func TestDecodeSeparatesCourseSettingsFromAssignments(t *testing.T) {
+	t.Parallel()
+
+	course, _ := decodeFixture(t, "vss")
+
+	if course.Name != "vss" {
+		t.Errorf("Name = %q, want %q", course.Name, "vss")
+	}
+	if course.CoursePath != "vss/semester" {
+		t.Errorf("CoursePath = %q, want %q", course.CoursePath, "vss/semester")
+	}
+	if !course.UseCoursenameAsPrefix {
+		t.Error("UseCoursenameAsPrefix = false, want true")
+	}
+	if course.UseEmailDomainAsSuffix == nil || *course.UseEmailDomainAsSuffix {
+		t.Errorf("UseEmailDomainAsSuffix = %v, want explicit false", course.UseEmailDomainAsSuffix)
+	}
+	// Counted from the fixture: 63 student entries, 42 group keys (grp00–grp43
+	// with gaps). Asserted so a decoder that silently drops entries is caught.
+	if len(course.Students) != 63 {
+		t.Errorf("len(Students) = %d, want 63", len(course.Students))
+	}
+	if len(course.Groups) != 42 {
+		t.Errorf("len(Groups) = %d, want 42", len(course.Groups))
+	}
+
+	wantAssignments := []string{"blatt0", "blatt1", "blatt2"}
+	if len(course.Assignments) != len(wantAssignments) {
+		t.Fatalf("assignments = %v, want exactly %v", keysOf(course.Assignments), wantAssignments)
+	}
+	for _, name := range wantAssignments {
+		if course.Assignments[name] == nil {
+			t.Errorf("assignment %q missing; got %v", name, keysOf(course.Assignments))
+		}
+	}
+}
+
+func keysOf(m map[string]*AssignmentSource) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// mapstructure must fold case exactly like viper does, or configs that work
+// today would silently lose fields.
+func TestDecodeFoldsFieldNameCase(t *testing.T) {
+	t.Parallel()
+
+	course, _ := decodeFixture(t, "casecourse")
+
+	a := course.Assignments["mixedfields"]
+	if a == nil {
+		t.Fatal("assignment mixedfields missing")
+	}
+	if a.Startercode.FromBranch != "template" {
+		t.Errorf("`frombranch` did not fold onto FromBranch: got %q", a.Startercode.FromBranch)
+	}
+	if a.Startercode.ToBranch != "main" {
+		t.Errorf("`tobranch` did not fold onto ToBranch: got %q", a.Startercode.ToBranch)
+	}
+	if a.Startercode.TemplateMessage != "Init" {
+		t.Errorf("`templatemessage` did not fold onto TemplateMessage: got %q", a.Startercode.TemplateMessage)
+	}
+	if len(a.Branches) != 2 {
+		t.Fatalf("len(Branches) = %d, want 2", len(a.Branches))
+	}
+	if !a.Branches[0].MergeOnly {
+		t.Error("`mergeonly` did not fold onto MergeOnly")
+	}
+	if !a.Branches[1].AllowForcePush {
+		t.Error("`allow_force_push` alias did not reach AllowForcePush")
+	}
+}
+
+// Map keys are data, not field names: unlike viper, the typed decoder must keep
+// them verbatim. Resolve is responsible for lowercasing them where the old
+// loader did (groups, deferredBranches) — the source keeps what was written.
+func TestDecodeKeepsMapKeysVerbatim(t *testing.T) {
+	t.Parallel()
+
+	course, _ := decodeFixture(t, "casecourse")
+
+	if _, ok := course.Groups["Grp01"]; !ok {
+		t.Errorf("group key was not kept verbatim; got %v", keysOfStrings(course.Groups))
+	}
+
+	a := course.Assignments["upperkeys"]
+	if a == nil {
+		t.Fatal("assignment upperkeys missing")
+	}
+	if _, ok := a.DeferredBranches["DevContainer"]; !ok {
+		t.Errorf("deferredBranch key was not kept verbatim; got %v", keysOfDeferred(a.DeferredBranches))
+	}
+}
+
+func keysOfStrings(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func keysOfDeferred(m map[string]*DeferredBranchSource) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// The bare-list form of approvals must normalize into Rules, and encoding must
+// always emit the modern {settings, rules} shape — that is what makes
+// `glabs config migrate` upgrade files for free.
+func TestDecodeNormalizesLegacyApprovalsList(t *testing.T) {
+	t.Parallel()
+
+	course, _ := decodeFixture(t, "legacy")
+
+	a := course.Assignments["approvalslist"]
+	if a == nil {
+		t.Fatal("assignment approvalslist missing")
+	}
+	if a.MergeRequest.Approvals == nil {
+		t.Fatal("Approvals is nil; the bare-list form was not accepted")
+	}
+	rules := a.MergeRequest.Approvals.Rules
+	if len(rules) != 3 {
+		t.Fatalf("len(Rules) = %d, want 3", len(rules))
+	}
+	if rules[0].Name != "review" || rules[0].RequiredApprovals != 2 {
+		t.Errorf("rules[0] = %+v, want name=review requiredApprovals=2 (via the required_approvals alias)", rules[0])
+	}
+
+	encoded, err := EncodeCourse(course)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if !containsAll(string(encoded), "approvals:", "rules:") {
+		t.Errorf("encoded output does not use the modern approvals shape:\n%s", encoded)
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+// The schema must claim every key the real course files use. This is the
+// completeness guard, and it is what makes the round-trip test meaningful: a
+// round trip would happily pass while dropping a field the decoder never knew
+// about, because it would be absent on both sides.
+//
+// Anything reported here is a key the loader silently ignores. Today exactly
+// two classes exist, both pre-existing bugs frozen by the goldens:
+//
+//   - `clone.clone` — a stray key present in every real course file. It does
+//     nothing; the clone command has no such option.
+//   - `vss.blatt2.release.mergeRequest.dockerImages` — the images are nested
+//     under mergeRequest, but config/release.go:47 reads release.dockerImages,
+//     so all six are ignored.
+//
+// A new entry means either a genuine typo in a course file or a field missing
+// from the schema. Both are worth failing over.
+func TestSchemaClaimsEveryKeyInRealFixtures(t *testing.T) {
+	t.Parallel()
+
+	knownUnclaimed := map[string]bool{
+		"vss.blatt2.release.mergeRequest.dockerImages": true,
+	}
+
+	paths, err := filepath.Glob(filepath.Join("testdata", "courses", "*.yaml"))
+	if err != nil {
+		t.Fatalf("globbing fixtures: %v", err)
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading fixture: %v", err)
+		}
+		_, result, err := DecodeCourse(data)
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+
+		for _, key := range result.UnknownKeys {
+			if strings.HasSuffix(key, ".clone.clone") || knownUnclaimed[key] {
+				continue
+			}
+			t.Errorf("%s: key %q is claimed by no field — schema gap or a typo in the fixture",
+				filepath.Base(path), key)
+		}
+	}
+}
+
+func TestDecodeReportsUnknownAndLegacyKeys(t *testing.T) {
+	t.Parallel()
+
+	// vss.yaml carries `clone.clone: true`, which no field claims, and puts
+	// dockerImages under mergeRequest where nothing reads it. Both are silently
+	// ignored by the loader; lint must surface them, with the assignment named.
+	_, result := decodeFixture(t, "vss")
+	for _, want := range []string{
+		"vss.blatt0.clone.clone",
+		"vss.blatt2.release.mergeRequest.dockerImages",
+	} {
+		if !contains(result.UnknownKeys, want) {
+			t.Errorf("UnknownKeys = %v, want it to contain %q", result.UnknownKeys, want)
+		}
+	}
+
+	_, result = decodeFixture(t, "legacy")
+	if len(result.LegacyKeys) == 0 {
+		t.Fatal("LegacyKeys is empty, want the deprecated approvals spellings reported")
+	}
+	var paths []string
+	for _, k := range result.LegacyKeys {
+		paths = append(paths, k.Path)
+	}
+	if !hasSuffix(paths, "required_approvals") {
+		t.Errorf("LegacyKeys = %v, want required_approvals reported", paths)
+	}
+	if !hasSuffix(paths, "approvalsRequired") {
+		t.Errorf("LegacyKeys = %v, want approvalsRequired reported", paths)
+	}
+}
+
+// The typed decoder accepts `approvalsRequired`, which the viper-based loader
+// silently ignores: viper lowercases keys to `approvalsrequired` before the
+// alias table in config/assignment.go:443 compares them against the camelCase
+// spelling, so that case never matches and the rule ends up requiring 0
+// approvals instead of the configured number.
+//
+// This is a deliberate divergence and the only known one. It means the golden
+// for legacy.approvalslist will change when Resolve() replaces the viper path.
+// Fix the viper path first, in its own commit with its own golden diff, so the
+// resolver swap itself stays a zero-diff proof.
+func TestDecodeAcceptsAliasViperMissed(t *testing.T) {
+	t.Parallel()
+
+	course, _ := decodeFixture(t, "legacy")
+	rules := course.Assignments["approvalslist"].MergeRequest.Approvals.Rules
+
+	var second *ApprovalRuleSource
+	for i := range rules {
+		if rules[i].Name == "second" {
+			second = &rules[i]
+		}
+	}
+	if second == nil {
+		t.Fatalf("rule %q missing; got %d rules", "second", len(rules))
+	}
+	if second.RequiredApprovals != 1 {
+		t.Errorf("RequiredApprovals = %d, want 1 via the approvalsRequired alias (viper yields 0 here)",
+			second.RequiredApprovals)
+	}
+}
+
+func TestDecodeCourseErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{name: "empty file", yaml: "", wantErr: "course file is empty"},
+		{name: "two top-level keys", yaml: "a:\n  x: 1\nb:\n  y: 2\n", wantErr: "has 2 top-level keys (a, b)"},
+		{name: "not yaml", yaml: "\tthis: [is: not", wantErr: "cannot parse course file as YAML"},
+		{name: "course body is null", yaml: "onlykey:\n", wantErr: "configuration is empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := DecodeCourse([]byte(tt.yaml))
+			if err == nil {
+				t.Fatalf("DecodeCourse(%q) = nil error, want error containing %q", tt.yaml, tt.wantErr)
+			}
+			if !containsAll(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/config/encode.go
+++ b/config/encode.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// yamlIndent matches the indentation of the existing course files. yaml.v3
+// defaults to 4, which would reformat every line of every file.
+const yamlIndent = 2
+
+// EncodeCourse renders a course source back to a course file: a single
+// top-level key naming the course, with the course mapping underneath.
+//
+// This is the canonical form. Deprecated spellings are gone (decoding folded
+// them into their canonical field) and polymorphic blocks come out in their
+// modern shape — which is what makes `glabs config fmt` and `glabs config
+// migrate` fall out of the schema rather than needing their own rewriting pass.
+//
+// Comments and key order are NOT preserved: a struct has neither. Callers that
+// must not lose them should keep the original bytes and only re-encode once the
+// source has actually been edited.
+func EncodeCourse(course *CourseSource) ([]byte, error) {
+	if course == nil {
+		return nil, fmt.Errorf("cannot encode a nil course")
+	}
+	if course.Name == "" {
+		return nil, fmt.Errorf("cannot encode a course without a name: it is the file's top-level key")
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(yamlIndent)
+
+	if err := enc.Encode(map[string]*CourseSource{course.Name: course}); err != nil {
+		return nil, fmt.Errorf("course %s: cannot encode configuration: %w", course.Name, err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("course %s: cannot finish encoding: %w", course.Name, err)
+	}
+	return buf.Bytes(), nil
+}

--- a/config/lint.go
+++ b/config/lint.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Finding is one problem found in a course source.
+type Finding struct {
+	// Path is the dotted location, e.g. "vss.blatt2.release.mergeRequest.dockerImages".
+	Path string
+	// Message says what is wrong, in terms of what the config does or fails to do.
+	Message string
+	// Severity distinguishes "this silently does nothing" from "this still works
+	// but has a better spelling".
+	Severity Severity
+}
+
+type Severity string
+
+const (
+	// SeverityProblem: the config does not do what it looks like it does.
+	SeverityProblem Severity = "problem"
+	// SeverityDeprecated: it works, but the spelling or shape is obsolete.
+	SeverityDeprecated Severity = "deprecated"
+)
+
+func (f Finding) String() string { return fmt.Sprintf("%s: %s: %s", f.Severity, f.Path, f.Message) }
+
+// Lint reports everything questionable about a decoded course source.
+//
+// The interesting category is keys that are silently ignored. The loader has
+// never complained about them, so they look effective and are not — `clone.clone`
+// (present in every real course file, does nothing) and
+// `release.mergeRequest.dockerImages` (six images configured, none applied,
+// because config/release.go:47 reads release.dockerImages) are both live
+// examples.
+func Lint(course *CourseSource, decoded *DecodeResult) []Finding {
+	var findings []Finding
+
+	for _, key := range decoded.UnknownKeys {
+		findings = append(findings, Finding{
+			Path:     key,
+			Message:  "no such configuration key; it is silently ignored" + unknownKeyHint(key),
+			Severity: SeverityProblem,
+		})
+	}
+
+	for _, legacy := range decoded.LegacyKeys {
+		findings = append(findings, Finding{
+			Path:     legacy.Path,
+			Message:  legacy.Hint + "; `glabs config migrate` rewrites it",
+			Severity: SeverityDeprecated,
+		})
+	}
+
+	for _, name := range sortedAssignmentNames(course) {
+		findings = append(findings, lintAssignment(course, name, course.Assignments[name])...)
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool { return findings[i].Path < findings[j].Path })
+	return findings
+}
+
+// unknownKeyHint points at the likely intent for the unknown keys that actually
+// occur, rather than leaving the reader to guess.
+func unknownKeyHint(key string) string {
+	switch {
+	case strings.HasSuffix(key, ".clone.clone"):
+		return " (the clone command has no such option; configuring `clone:` at all is what enables it)"
+	case strings.HasSuffix(key, ".release.mergeRequest.dockerImages"):
+		return " (dockerImages belongs under `release:`, not under `release.mergeRequest:`)"
+	default:
+		return ""
+	}
+}
+
+func lintAssignment(course *CourseSource, name string, a *AssignmentSource) []Finding {
+	path := course.Name + "." + name
+	var findings []Finding
+
+	add := func(sub, msg string, sev Severity) {
+		p := path
+		if sub != "" {
+			p += "." + sub
+		}
+		findings = append(findings, Finding{Path: p, Message: msg, Severity: sev})
+	}
+
+	if a.Extends != "" {
+		if _, ok := course.Assignments[a.Extends]; !ok {
+			add("extends", fmt.Sprintf("extends %q, which is not an assignment in this course", a.Extends), SeverityProblem)
+		}
+	}
+
+	if s := a.Startercode; s != nil {
+		if s.URL == "" {
+			add("startercode.url", "startercode without a url", SeverityProblem)
+		}
+		// The startercode branch keys are only honoured when `branches:` is
+		// absent (config/repo.go:98). With both present the legacy ones do
+		// nothing at all, which is worth saying out loud.
+		legacyBranchKeys := []struct {
+			key string
+			set bool
+		}{
+			{"devBranch", s.DevBranch != ""},
+			{"protectToBranch", s.ProtectToBranch},
+			{"protectDevBranchMergeOnly", s.ProtectDevBranchMergeOnly},
+		}
+		for _, k := range legacyBranchKeys {
+			if !k.set {
+				continue
+			}
+			if len(a.Branches) > 0 {
+				add("startercode."+k.key, "ignored because `branches:` is configured, which supersedes it", SeverityProblem)
+			} else {
+				add("startercode."+k.key, "deprecated; express this with a `branches:` block instead", SeverityDeprecated)
+			}
+		}
+
+		// Same shape for the issue keys, but the trigger is different: an
+		// `issues:` block disables them merely by existing (config/repo.go:193).
+		if a.Issues != nil {
+			if s.ReplicateIssue {
+				add("startercode.replicateIssue", "ignored because an `issues:` block is configured, which supersedes it", SeverityProblem)
+			}
+			if len(s.IssueNumbers) > 0 {
+				add("startercode.issueNumbers", "ignored because an `issues:` block is configured, which supersedes it", SeverityProblem)
+			}
+		} else {
+			if s.ReplicateIssue {
+				add("startercode.replicateIssue", "deprecated; use `issues.replicateFromStartercode` instead", SeverityDeprecated)
+			}
+			if len(s.IssueNumbers) > 0 {
+				add("startercode.issueNumbers", "deprecated; use `issues.issueNumbers` instead", SeverityDeprecated)
+			}
+		}
+	}
+
+	if a.Seeder != nil {
+		if a.Seeder.Cmd == "" {
+			add("seeder.cmd", "seeder without a cmd", SeverityProblem)
+		}
+		if a.Seeder.SignKey != "" {
+			add("seeder.signKey", "a PGP private key inline in a config file, which gitleaks will flag and which lands in every clone of this repository", SeverityDeprecated)
+		}
+	}
+
+	if mr := a.MergeRequest; mr != nil && mr.Approvals != nil {
+		for i, rule := range mr.Approvals.Rules {
+			rp := fmt.Sprintf("mergeRequest.approvals.rules[%d]", i)
+			if rule.Branch != "" {
+				add(rp+".branch", "deprecated singular form; use `branches` instead", SeverityDeprecated)
+			}
+			if rule.Branch == "" && len(rule.Branches) == 0 {
+				add(rp, fmt.Sprintf("rule %q has no branches and is silently dropped", rule.Name), SeverityProblem)
+			}
+			if rule.RequiredApprovals < 0 {
+				add(rp+".requiredApprovals", "negative; clamped to 0", SeverityProblem)
+			}
+		}
+		if s := mr.Approvals.Settings; s != nil && s.WhenCommitAdded != nil {
+			if !validWhenCommitAdded(*s.WhenCommitAdded) {
+				add("mergeRequest.approvals.settings.whenCommitAdded",
+					fmt.Sprintf("invalid value %q, must be one of %s, %s, %s", *s.WhenCommitAdded,
+						ApprovalKeepApprovals, ApprovalRemoveAllApprovals, ApprovalRemoveCodeOwnerApprovalsIfFilesChanged),
+					SeverityProblem)
+			}
+		}
+	}
+
+	return findings
+}
+
+func validWhenCommitAdded(v string) bool {
+	switch ApprovalWhenCommitAdded(v) {
+	case ApprovalKeepApprovals, ApprovalRemoveAllApprovals, ApprovalRemoveCodeOwnerApprovalsIfFilesChanged:
+		return true
+	default:
+		return false
+	}
+}
+
+func sortedAssignmentNames(course *CourseSource) []string {
+	names := make([]string, 0, len(course.Assignments))
+	for name := range course.Assignments {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/config/lint_test.go
+++ b/config/lint_test.go
@@ -1,0 +1,206 @@
+package config
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func lintFixture(t *testing.T, name string) []Finding {
+	t.Helper()
+	course, decoded := decodeFixture(t, name)
+	return Lint(course, decoded)
+}
+
+func findingFor(findings []Finding, path string) *Finding {
+	for i := range findings {
+		if findings[i].Path == path {
+			return &findings[i]
+		}
+	}
+	return nil
+}
+
+func paths(findings []Finding) []string {
+	out := make([]string, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, f.Path)
+	}
+	return out
+}
+
+// The two silently-ignored keys in the real configs are the reason lint exists:
+// nothing complains about them today, so they look like settings that work.
+func TestLintReportsSilentlyIgnoredKeys(t *testing.T) {
+	t.Parallel()
+
+	findings := lintFixture(t, "vss")
+
+	f := findingFor(findings, "vss.blatt2.release.mergeRequest.dockerImages")
+	if f == nil {
+		t.Fatalf("dockerImages under mergeRequest not reported; got %v", paths(findings))
+	}
+	if f.Severity != SeverityProblem {
+		t.Errorf("severity = %q, want %q: the six images are configured and never applied", f.Severity, SeverityProblem)
+	}
+	if !strings.Contains(f.Message, "belongs under `release:`") {
+		t.Errorf("message %q does not say where dockerImages belongs", f.Message)
+	}
+
+	f = findingFor(findings, "vss.blatt0.clone.clone")
+	if f == nil {
+		t.Fatalf("stray clone.clone not reported; got %v", paths(findings))
+	}
+	if f.Severity != SeverityProblem {
+		t.Errorf("severity = %q, want %q", f.Severity, SeverityProblem)
+	}
+}
+
+// A superseded setting is worse than a merely deprecated one: it is present,
+// looks meaningful, and does nothing. lint must distinguish the two.
+func TestLintDistinguishesSupersededFromDeprecated(t *testing.T) {
+	t.Parallel()
+
+	findings := lintFixture(t, "legacy")
+
+	// devbranch has no branches: block, so the legacy keys are honoured.
+	if f := findingFor(findings, "legacy.devbranch.startercode.devBranch"); f == nil {
+		t.Errorf("devBranch not reported at all; got %v", paths(findings))
+	} else if f.Severity != SeverityDeprecated {
+		t.Errorf("severity = %q, want %q: without a branches: block the key still works",
+			f.Severity, SeverityDeprecated)
+	}
+
+	// devbranchoverridden has one, so they are dead.
+	if f := findingFor(findings, "legacy.devbranchoverridden.startercode.devBranch"); f == nil {
+		t.Errorf("overridden devBranch not reported; got %v", paths(findings))
+	} else {
+		if f.Severity != SeverityProblem {
+			t.Errorf("severity = %q, want %q: with a branches: block the key does nothing",
+				f.Severity, SeverityProblem)
+		}
+		if !strings.Contains(f.Message, "supersedes") {
+			t.Errorf("message %q does not explain what overrides it", f.Message)
+		}
+	}
+
+	// Same shape for issues, but the trigger is the block merely existing.
+	if f := findingFor(findings, "legacy.legacyissuesshadowed.startercode.replicateIssue"); f == nil {
+		t.Errorf("shadowed replicateIssue not reported; got %v", paths(findings))
+	} else if f.Severity != SeverityProblem {
+		t.Errorf("severity = %q, want %q", f.Severity, SeverityProblem)
+	}
+}
+
+func TestLintReportsDroppedAndClampedApprovalRules(t *testing.T) {
+	t.Parallel()
+
+	findings := lintFixture(t, "legacy")
+
+	if f := findingFor(findings, "legacy.approvalsnormalized.mergeRequest.approvals.rules[0]"); f == nil {
+		t.Errorf("rule without branches not reported; got %v", paths(findings))
+	} else if !strings.Contains(f.Message, "silently dropped") {
+		t.Errorf("message %q does not say the rule is dropped", f.Message)
+	}
+
+	if f := findingFor(findings, "legacy.approvalsnormalized.mergeRequest.approvals.rules[1].requiredApprovals"); f == nil {
+		t.Errorf("negative requiredApprovals not reported; got %v", paths(findings))
+	}
+}
+
+func TestLintReportsDeprecatedAliases(t *testing.T) {
+	t.Parallel()
+
+	findings := lintFixture(t, "legacy")
+
+	for _, want := range []string{
+		"legacy.approvalslist.mergeRequest.approvals[0].required_approvals",
+		"legacy.approvalslist.mergeRequest.approvals[1].approvalsRequired",
+	} {
+		f := findingFor(findings, want)
+		if f == nil {
+			t.Errorf("alias %q not reported; got %v", want, paths(findings))
+			continue
+		}
+		if f.Severity != SeverityDeprecated {
+			t.Errorf("%s: severity = %q, want %q", want, f.Severity, SeverityDeprecated)
+		}
+		if !strings.Contains(f.Message, "migrate") {
+			t.Errorf("%s: message %q does not point at `glabs config migrate`", want, f.Message)
+		}
+	}
+}
+
+func TestLintReportsBrokenExtends(t *testing.T) {
+	t.Parallel()
+
+	course := &CourseSource{
+		Name: "c",
+		Assignments: map[string]*AssignmentSource{
+			"child": {Extends: "nosuchparent"},
+		},
+	}
+	findings := Lint(course, &DecodeResult{})
+
+	if f := findingFor(findings, "c.child.extends"); f == nil {
+		t.Fatalf("dangling extends not reported; got %v", paths(findings))
+	} else if f.Severity != SeverityProblem {
+		t.Errorf("severity = %q, want %q", f.Severity, SeverityProblem)
+	}
+}
+
+// A clean course must lint clean, or the command is noise and gets ignored.
+//
+// Built here rather than taken from testdata: none of the fixtures are clean.
+// Neither is any real course file — every one carries at least a stray
+// clone.clone — which is the whole reason this command exists.
+func TestLintAcceptsCleanCourse(t *testing.T) {
+	t.Parallel()
+
+	branch := "main"
+	course := &CourseSource{
+		Name:                  "clean",
+		CoursePath:            "clean/semester",
+		SemesterPath:          "ss2026",
+		UseCoursenameAsPrefix: true,
+		Students:              []string{"a@example.edu"},
+		Assignments: map[string]*AssignmentSource{
+			"base": {Abstract: true, Per: "student"},
+			"blatt01": {
+				Extends:        "base",
+				AssignmentPath: "blatt-01",
+				Description:    "Blatt 1",
+				Startercode: &StartercodeSource{
+					URL:        "git@gitlab.lrz.de:clean/startercode.git",
+					FromBranch: "template",
+					ToBranch:   "main",
+				},
+				Branches: []BranchRuleSource{{Name: "main", Default: true, MergeOnly: true}},
+				Issues:   &IssuesSource{ReplicateFromStartercode: true, IssueNumbers: []int{1}},
+				Clone:    &CloneSource{Branch: &branch},
+				MergeRequest: &MergeRequestSource{
+					MergeMethod: "semi_linear",
+					Approvals: &ApprovalsSource{
+						Rules: []ApprovalRuleSource{{Name: "review", Branches: []string{"main"}, RequiredApprovals: 1}},
+					},
+				},
+			},
+		},
+	}
+
+	if findings := Lint(course, &DecodeResult{}); len(findings) != 0 {
+		t.Errorf("clean course produced findings: %v", paths(findings))
+	}
+}
+
+// Deterministic output matters: lint is meant to gate commits, and a set that
+// reorders between runs makes a diff unreadable.
+func TestLintIsOrdered(t *testing.T) {
+	t.Parallel()
+
+	findings := lintFixture(t, "legacy")
+	got := paths(findings)
+	if !slices.IsSorted(got) {
+		t.Errorf("findings are not sorted by path: %v", got)
+	}
+}

--- a/config/source.go
+++ b/config/source.go
@@ -1,0 +1,198 @@
+package config
+
+// Source form of the configuration: a faithful, typed 1:1 model of a course
+// YAML file, before any resolution.
+//
+// This is deliberately NOT AssignmentConfig. AssignmentConfig is the *resolved*
+// form — `extends` applied, course-level students merged in, Path/URL computed.
+// The source form is what a human writes and what round-trips:
+//
+//	YAML  <->  CourseSource  <->  BSON
+//	                  |
+//	                  v  Resolve()
+//	           AssignmentConfig
+//
+// Three tag sets, one per direction:
+//   - yaml:        encoding back to a course file (config/encode.go)
+//   - bson:        storage (the web server keeps course sources in MongoDB)
+//   - mapstructure: decoding (config/decode.go)
+//
+// Decoding goes through mapstructure rather than yaml.v3 directly because
+// viper — the loader being replaced — matches keys case-insensitively, and
+// real configs rely on it (`frombranch` and `fromBranch` both work today).
+// yaml.v3 matches tags exactly and would silently drop such keys. mapstructure
+// folds case by default, which is exactly viper's own behaviour: viper decodes
+// with mapstructure internally.
+//
+// Pointer fields mark "absent" where absent and zero mean different things —
+// i.e. exactly where the viper-based loader calls IsSet or checks a map lookup's
+// ok. Everywhere else a plain value is enough, because the loader treats empty
+// as absent anyway (`if len(x) > 0`).
+
+// CourseSource is one course file. The file has a single top-level key (the
+// course name) whose value is this struct.
+type CourseSource struct {
+	// Name is the file's top-level key. It is not part of the mapping itself.
+	Name string `yaml:"-" bson:"name" mapstructure:"-"`
+
+	CoursePath   string `yaml:"coursepath,omitempty" bson:"coursepath,omitempty" mapstructure:"coursepath"`
+	SemesterPath string `yaml:"semesterpath,omitempty" bson:"semesterpath,omitempty" mapstructure:"semesterpath"`
+
+	UseCoursenameAsPrefix bool `yaml:"useCoursenameAsPrefix,omitempty" bson:"useCoursenameAsPrefix,omitempty" mapstructure:"useCoursenameAsPrefix"`
+	// Pointer: absent means true (config/assignment.go:100-105), false means false.
+	UseEmailDomainAsSuffix *bool `yaml:"useEmailDomainAsSuffix,omitempty" bson:"useEmailDomainAsSuffix,omitempty" mapstructure:"useEmailDomainAsSuffix"`
+
+	Students []string            `yaml:"students,omitempty" bson:"students,omitempty" mapstructure:"students"`
+	Groups   map[string][]string `yaml:"groups,omitempty" bson:"groups,omitempty" mapstructure:"groups"`
+
+	// Assignments are siblings of the course settings above, not nested under a
+	// key. yaml ",inline" reproduces that layout on encode; mapstructure
+	// ",remain" collects them on decode. In BSON they get their own subdocument
+	// so they cannot collide with the course settings.
+	Assignments map[string]*AssignmentSource `yaml:",inline" bson:"assignments,omitempty" mapstructure:",remain"`
+}
+
+// AssignmentSource is a single assignment as written in the course file, with
+// `extends` unresolved.
+type AssignmentSource struct {
+	// Meta keys. Never inherited, never part of the effective config.
+	Extends  string `yaml:"extends,omitempty" bson:"extends,omitempty" mapstructure:"extends"`
+	Abstract bool   `yaml:"abstract,omitempty" bson:"abstract,omitempty" mapstructure:"abstract"`
+
+	AssignmentPath    string `yaml:"assignmentpath,omitempty" bson:"assignmentpath,omitempty" mapstructure:"assignmentpath"`
+	Description       string `yaml:"description,omitempty" bson:"description,omitempty" mapstructure:"description"`
+	Per               string `yaml:"per,omitempty" bson:"per,omitempty" mapstructure:"per"`
+	ContainerRegistry bool   `yaml:"containerRegistry,omitempty" bson:"containerRegistry,omitempty" mapstructure:"containerRegistry"`
+	AccessLevel       string `yaml:"accesslevel,omitempty" bson:"accesslevel,omitempty" mapstructure:"accesslevel"`
+
+	Students []string            `yaml:"students,omitempty" bson:"students,omitempty" mapstructure:"students"`
+	Groups   map[string][]string `yaml:"groups,omitempty" bson:"groups,omitempty" mapstructure:"groups"`
+
+	MergeRequest     *MergeRequestSource              `yaml:"mergeRequest,omitempty" bson:"mergeRequest,omitempty" mapstructure:"mergeRequest"`
+	Branches         []BranchRuleSource               `yaml:"branches,omitempty" bson:"branches,omitempty" mapstructure:"branches"`
+	Issues           *IssuesSource                    `yaml:"issues,omitempty" bson:"issues,omitempty" mapstructure:"issues"`
+	Startercode      *StartercodeSource               `yaml:"startercode,omitempty" bson:"startercode,omitempty" mapstructure:"startercode"`
+	DeferredBranches map[string]*DeferredBranchSource `yaml:"deferredBranches,omitempty" bson:"deferredBranches,omitempty" mapstructure:"deferredBranches"`
+	Clone            *CloneSource                     `yaml:"clone,omitempty" bson:"clone,omitempty" mapstructure:"clone"`
+	Release          *ReleaseSource                   `yaml:"release,omitempty" bson:"release,omitempty" mapstructure:"release"`
+	Seeder           *SeederSource                    `yaml:"seeder,omitempty" bson:"seeder,omitempty" mapstructure:"seeder"`
+}
+
+type StartercodeSource struct {
+	URL                string   `yaml:"url,omitempty" bson:"url,omitempty" mapstructure:"url"`
+	FromBranch         string   `yaml:"fromBranch,omitempty" bson:"fromBranch,omitempty" mapstructure:"fromBranch"`
+	Tag                string   `yaml:"tag,omitempty" bson:"tag,omitempty" mapstructure:"tag"`
+	Template           bool     `yaml:"template,omitempty" bson:"template,omitempty" mapstructure:"template"`
+	TemplateMessage    string   `yaml:"templateMessage,omitempty" bson:"templateMessage,omitempty" mapstructure:"templateMessage"`
+	ToBranch           string   `yaml:"toBranch,omitempty" bson:"toBranch,omitempty" mapstructure:"toBranch"`
+	AdditionalBranches []string `yaml:"additionalBranches,omitempty" bson:"additionalBranches,omitempty" mapstructure:"additionalBranches"`
+
+	// Deprecated: superseded by the assignment-level `branches:` block, which
+	// wins outright when present (config/repo.go:98). Read only for older
+	// configs; `glabs config migrate` rewrites them.
+	DevBranch                 string `yaml:"devBranch,omitempty" bson:"devBranch,omitempty" mapstructure:"devBranch"`
+	ProtectToBranch           bool   `yaml:"protectToBranch,omitempty" bson:"protectToBranch,omitempty" mapstructure:"protectToBranch"`
+	ProtectDevBranchMergeOnly bool   `yaml:"protectDevBranchMergeOnly,omitempty" bson:"protectDevBranchMergeOnly,omitempty" mapstructure:"protectDevBranchMergeOnly"`
+
+	// Deprecated: superseded by the assignment-level `issues:` block, which
+	// disables these entirely by merely being present (config/repo.go:193).
+	ReplicateIssue bool  `yaml:"replicateIssue,omitempty" bson:"replicateIssue,omitempty" mapstructure:"replicateIssue"`
+	IssueNumbers   []int `yaml:"issueNumbers,omitempty" bson:"issueNumbers,omitempty" mapstructure:"issueNumbers"`
+}
+
+type BranchRuleSource struct {
+	Name                      string `yaml:"name,omitempty" bson:"name,omitempty" mapstructure:"name"`
+	Protect                   bool   `yaml:"protect,omitempty" bson:"protect,omitempty" mapstructure:"protect"`
+	MergeOnly                 bool   `yaml:"mergeOnly,omitempty" bson:"mergeOnly,omitempty" mapstructure:"mergeOnly"`
+	Default                   bool   `yaml:"default,omitempty" bson:"default,omitempty" mapstructure:"default"`
+	AllowForcePush            bool   `yaml:"allowForcePush,omitempty" bson:"allowForcePush,omitempty" mapstructure:"allowForcePush"`
+	CodeOwnerApprovalRequired bool   `yaml:"codeOwnerApprovalRequired,omitempty" bson:"codeOwnerApprovalRequired,omitempty" mapstructure:"codeOwnerApprovalRequired"`
+}
+
+type IssuesSource struct {
+	ReplicateFromStartercode bool  `yaml:"replicateFromStartercode,omitempty" bson:"replicateFromStartercode,omitempty" mapstructure:"replicateFromStartercode"`
+	IssueNumbers             []int `yaml:"issueNumbers,omitempty" bson:"issueNumbers,omitempty" mapstructure:"issueNumbers"`
+	IncludeChildTasks        bool  `yaml:"includeChildTasks,omitempty" bson:"includeChildTasks,omitempty" mapstructure:"includeChildTasks"`
+}
+
+type DeferredBranchSource struct {
+	// Pointer: absent falls back to the startercode URL, empty does not
+	// (config/assignment.go:66-68).
+	URL        *string `yaml:"url,omitempty" bson:"url,omitempty" mapstructure:"url"`
+	FromBranch string  `yaml:"fromBranch,omitempty" bson:"fromBranch,omitempty" mapstructure:"fromBranch"`
+	// Pointer: absent falls back to FromBranch (config/assignment.go:71-74).
+	ToBranch *string `yaml:"toBranch,omitempty" bson:"toBranch,omitempty" mapstructure:"toBranch"`
+	// Pointer: absent means true (config/assignment.go:75-79).
+	Orphan *bool `yaml:"orphan,omitempty" bson:"orphan,omitempty" mapstructure:"orphan"`
+	// Pointer: absent gets a generated message (config/assignment.go:81-84).
+	OrphanMessage *string `yaml:"orphanMessage,omitempty" bson:"orphanMessage,omitempty" mapstructure:"orphanMessage"`
+}
+
+type CloneSource struct {
+	// Pointer: absent means "." (config/repo.go:212-215).
+	LocalPath *string `yaml:"localpath,omitempty" bson:"localpath,omitempty" mapstructure:"localpath"`
+	// Pointer: absent means the assignment's default branch (config/repo.go:217-220).
+	Branch *string `yaml:"branch,omitempty" bson:"branch,omitempty" mapstructure:"branch"`
+	Force  bool    `yaml:"force,omitempty" bson:"force,omitempty" mapstructure:"force"`
+}
+
+type ReleaseSource struct {
+	MergeRequest *ReleaseMergeRequestSource `yaml:"mergeRequest,omitempty" bson:"mergeRequest,omitempty" mapstructure:"mergeRequest"`
+	DockerImages []string                   `yaml:"dockerImages,omitempty" bson:"dockerImages,omitempty" mapstructure:"dockerImages"`
+}
+
+type ReleaseMergeRequestSource struct {
+	Source   string `yaml:"source,omitempty" bson:"source,omitempty" mapstructure:"source"`
+	Target   string `yaml:"target,omitempty" bson:"target,omitempty" mapstructure:"target"`
+	Pipeline bool   `yaml:"pipeline,omitempty" bson:"pipeline,omitempty" mapstructure:"pipeline"`
+}
+
+type SeederSource struct {
+	Cmd             string   `yaml:"cmd,omitempty" bson:"cmd,omitempty" mapstructure:"cmd"`
+	Args            []string `yaml:"args,omitempty" bson:"args,omitempty" mapstructure:"args"`
+	Name            string   `yaml:"name,omitempty" bson:"name,omitempty" mapstructure:"name"`
+	EMail           string   `yaml:"email,omitempty" bson:"email,omitempty" mapstructure:"email"`
+	SignKey         string   `yaml:"signKey,omitempty" bson:"signKey,omitempty" mapstructure:"signKey"`
+	ToBranch        string   `yaml:"toBranch,omitempty" bson:"toBranch,omitempty" mapstructure:"toBranch"`
+	ProtectToBranch bool     `yaml:"protectToBranch,omitempty" bson:"protectToBranch,omitempty" mapstructure:"protectToBranch"`
+}
+
+type MergeRequestSource struct {
+	MergeMethod                   string           `yaml:"mergeMethod,omitempty" bson:"mergeMethod,omitempty" mapstructure:"mergeMethod"`
+	SquashOption                  string           `yaml:"squashOption,omitempty" bson:"squashOption,omitempty" mapstructure:"squashOption"`
+	Pipeline                      bool             `yaml:"pipeline,omitempty" bson:"pipeline,omitempty" mapstructure:"pipeline"`
+	SkippedPipelinesAreSuccessful bool             `yaml:"skippedPipelinesAreSuccessful,omitempty" bson:"skippedPipelinesAreSuccessful,omitempty" mapstructure:"skippedPipelinesAreSuccessful"`
+	AllThreadsMustBeResolved      bool             `yaml:"allThreadsMustBeResolved,omitempty" bson:"allThreadsMustBeResolved,omitempty" mapstructure:"allThreadsMustBeResolved"`
+	StatusChecksMustSucceed       bool             `yaml:"statusChecksMustSucceed,omitempty" bson:"statusChecksMustSucceed,omitempty" mapstructure:"statusChecksMustSucceed"`
+	Approvals                     *ApprovalsSource `yaml:"approvals,omitempty" bson:"approvals,omitempty" mapstructure:"approvals"`
+}
+
+// ApprovalsSource is polymorphic in the source: either a bare list of rules
+// (the original form) or a {settings, rules} mapping. Decoding normalizes the
+// list form into Rules (see approvalsDecodeHook); encoding always emits the
+// mapping form, which is how `glabs config migrate` upgrades old files.
+type ApprovalsSource struct {
+	Settings *ApprovalSettingsSource `yaml:"settings,omitempty" bson:"settings,omitempty" mapstructure:"settings"`
+	Rules    []ApprovalRuleSource    `yaml:"rules,omitempty" bson:"rules,omitempty" mapstructure:"rules"`
+}
+
+type ApprovalRuleSource struct {
+	Name string `yaml:"name,omitempty" bson:"name,omitempty" mapstructure:"name"`
+	// Deprecated: singular form, folded into Branches on resolve.
+	Branch                string   `yaml:"branch,omitempty" bson:"branch,omitempty" mapstructure:"branch"`
+	Branches              []string `yaml:"branches,omitempty" bson:"branches,omitempty" mapstructure:"branches"`
+	Usernames             []string `yaml:"usernames,omitempty" bson:"usernames,omitempty" mapstructure:"usernames"`
+	Groups                []string `yaml:"groups,omitempty" bson:"groups,omitempty" mapstructure:"groups"`
+	MultiMemberGroupsOnly bool     `yaml:"multiMemberGroupsOnly,omitempty" bson:"multiMemberGroupsOnly,omitempty" mapstructure:"multiMemberGroupsOnly"`
+	RequiredApprovals     int      `yaml:"requiredApprovals,omitempty" bson:"requiredApprovals,omitempty" mapstructure:"requiredApprovals"`
+}
+
+// ApprovalSettingsSource fields are pointers throughout: each is only sent to
+// GitLab when explicitly configured (config/assignment.go:385-412).
+type ApprovalSettingsSource struct {
+	PreventApprovalByMergeRequestCreator       *bool   `yaml:"preventApprovalByMergeRequestCreator,omitempty" bson:"preventApprovalByMergeRequestCreator,omitempty" mapstructure:"preventApprovalByMergeRequestCreator"`
+	PreventApprovalsByUsersWhoAddCommits       *bool   `yaml:"preventApprovalsByUsersWhoAddCommits,omitempty" bson:"preventApprovalsByUsersWhoAddCommits,omitempty" mapstructure:"preventApprovalsByUsersWhoAddCommits"`
+	PreventEditingApprovalRulesInMergeRequests *bool   `yaml:"preventEditingApprovalRulesInMergeRequests,omitempty" bson:"preventEditingApprovalRulesInMergeRequests,omitempty" mapstructure:"preventEditingApprovalRulesInMergeRequests"`
+	RequireUserReauthenticationToApprove       *bool   `yaml:"requireUserReauthenticationToApprove,omitempty" bson:"requireUserReauthenticationToApprove,omitempty" mapstructure:"requireUserReauthenticationToApprove"`
+	WhenCommitAdded                            *string `yaml:"whenCommitAdded,omitempty" bson:"whenCommitAdded,omitempty" mapstructure:"whenCommitAdded"`
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -173,6 +173,70 @@ glabs show <course> <assignment> [groups...|students...]
 
 Shows how glabs interprets your config after merging course-level and assignment-level settings. Useful for debugging.
 
+### config
+
+Inspect and maintain course configuration files. These subcommands read the
+course file as written, without resolving it — they never talk to GitLab and
+never need a token.
+
+#### config lint
+
+```text
+glabs config lint [course...]
+```
+
+Reports configuration that does not do what it looks like it does. With no
+arguments, lints every course in the `courses:` list.
+
+This matters because glabs ignores unknown keys **silently**: a typo is
+indistinguishable from a setting that works. Two real examples it catches:
+
+```text
+problem  vss.blatt2.release.mergeRequest.dockerImages
+    no such configuration key; it is silently ignored (dockerImages belongs
+    under `release:`, not under `release.mergeRequest:`)
+problem  vss.blatt0.clone.clone
+    no such configuration key; it is silently ignored (the clone command has no
+    such option; configuring `clone:` at all is what enables it)
+```
+
+Findings come in two severities:
+
+| Severity | Meaning |
+|---|---|
+| `problem` | The setting is present and has no effect — a typo, or a key superseded by a newer block. |
+| `deprecated` | It still works, but the spelling or shape is obsolete. `glabs config migrate` fixes these. |
+
+Exits non-zero if any `problem` was found, so it can gate a pre-commit hook or CI.
+
+#### config fmt
+
+```text
+glabs config fmt <course> [course...] [-w|--write]
+```
+
+Rewrites a course file in canonical form. Prints to stdout by default; `-w`
+writes back in place.
+
+#### config migrate
+
+```text
+glabs config migrate <course> [course...] [-w|--write]
+```
+
+Rewrites a course file, upgrading deprecated key spellings (`required_approvals`
+→ `requiredApprovals`) and polymorphic blocks (a bare `approvals:` list →
+`approvals.rules:`).
+
+It does **not** resolve superseded settings. If a file has both
+`startercode.devBranch` and a `branches:` block, migrate keeps both and `lint`
+tells you which one wins — deciding that is a judgement call, not a rewrite.
+
+> **Both `fmt` and `migrate` rebuild the file from the parsed configuration, so
+> comments and key order are not preserved.** The meaning is preserved (verified
+> against every course file), but the diff will be large. Review it before
+> committing, and keep your course files in version control.
+
 ### version
 
 Print glabs version.

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect


### PR DESCRIPTION
Schritt 2a des glabs-web-Plans. **Rein additiv** — der bestehende viper-Auflösungspfad ist unangetastet, die Goldens sind unverändert.

## Warum jetzt schon Nutzen entsteht

glabs ignoriert unbekannte Config-Keys **stillschweigend**. Ein Tippfehler sieht damit exakt aus wie eine Einstellung, die wirkt. `glabs config lint` sagt es laut — und findet in Deinen echten Kursdateien zwei Klassen toter Config, die seit jeher drinstehen:

```
problem  vss.blatt2.release.mergeRequest.dockerImages
    no such configuration key; it is silently ignored (dockerImages belongs
    under `release:`, not under `release.mergeRequest:`)
problem  vss.blatt0.clone.clone
    no such configuration key; it is silently ignored (the clone command has no
    such option; configuring `clone:` at all is what enables it)
```

`clone.clone` steckt in **jeder einzelnen** Kursdatei (fundc 8×, vss 3×, algdati 2×, mpd, fun). Die sechs Docker-Images in `vss/blatt2` werden komplett ignoriert.

**Keiner der beiden wird hier gefixt.** Beide sind von den Goldens eingefroren und gehören in eigene Commits, damit der Migrationsdiff zuordenbar bleibt.

Dazu `fmt` (kanonische Form) und `migrate` (Legacy-Schreibweisen hochziehen). Alle drei brauchen `Resolve()` nicht — genau deshalb kommt 2a ohne Risiko aus.

## Der Schema-Gedanke

`config/source.go` modelliert die **Quellform**: `extends` unaufgelöst, Course-Level-Students ungemerged. Das ist, was YAML ⇄ Mongo ⇄ GraphQL round-trippt. `AssignmentConfig` bleibt, was es ist: das aufgelöste Ergebnis. Drei Tag-Sets, eines pro Richtung. Pointer-Felder markieren „abwesend" **exakt dort**, wo der heutige Loader `IsSet` aufruft oder ein `ok` aus einem Map-Lookup prüft — und sonst nirgends.

**Decode geht `bytes → map` (yaml.v3) → `struct` (mapstructure)**, nicht direkt über yaml.v3. Grund: viper matcht Keys case-insensitiv und echte Configs verlassen sich darauf (`frombranch` und `fromBranch` funktionieren heute beide). yaml.v3 matcht Tags exakt und hätte solche Keys still verschluckt. mapstructure foldet Case — das *ist* viper's Verhalten, viper dekodiert intern mit mapstructure.

**Assignments werden einzeln dekodiert.** mapstructures `Metadata` kann einen Key innerhalb einer `,remain`-Map nicht benennen (es meldet `[<interface {} Value>].clone.clone`), und lint ist nur brauchbar, wenn es sagen kann, *welches* Assignment den Streu-Key trägt.

## Zwei Tests tragen die Beweislast

**`TestSchemaClaimsEveryKeyInRealFixtures`** ist die Vollständigkeitsgarantie. Ohne sie wäre der Round-Trip-Test fast wertlos: ein Feld, das der Decoder gar nicht kennt, ist auf **beiden** Seiten abwesend und besteht den Test. Der Test nutzt mapstructures `Unused` — jeder Key, den kein Feld beansprucht, taucht dort auf. Ergebnis: das Schema beansprucht jeden Key in allen sieben Fixtures, bis auf die zwei bekannten Bugs.

**Der Round-Trip** wird auf *Bedeutung* geprüft, nicht auf Bytes — ein Struct hat keine Kommentare und keine Key-Reihenfolge. Zusätzlich verifiziert: `fmt` ist auf allen fünf **echten** Kursdateien bedeutungserhaltend und idempotent.

## Eine bewusste Abweichung, dokumentiert

`TestDecodeAcceptsAliasViperMissed`: der typisierte Decoder akzeptiert `approvalsRequired`, das viper stillschweigend ignoriert (viper schreibt den Key klein, bevor die Alias-Tabelle ihn gegen die CamelCase-Schreibweise vergleicht → trifft nie).

**Konsequenz für die Reihenfolge:** in 2b würde der Golden `legacy.approvalslist` dadurch von 0 auf 1 kippen. Ich schlage vor, **beide Bugs vorher** im viper-Pfad zu fixen, jeder mit eigenem Commit und eigenem Golden-Diff — dann bleibt der Resolver-Tausch in 2b ein Null-Diff-Beweis. Beim `dockerImages`-Bug brauche ich dafür Deine Entscheidung: Code an die YAML anpassen oder YAML an den Code?

## Verifikation

- `go test ./...` grün; `gofmt`, `go vet`, `golangci-lint` sauber
- **Goldens unverändert** → der Auflösungspfad ist nachweislich nicht angefasst
- `glabs config lint` gegen die echten `glabs-yaml`-Dateien: findet beide Bugklassen, exit=1
- `glabs config fmt` gegen alle fünf echten Dateien: bedeutungserhaltend + idempotent
- Doku: `docs/commands.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)