### PR TITLE
fix(config): honour the approvalsRequired alias regardless of key case

### DIFF
--- a/config/assignment.go
+++ b/config/assignment.go
@@ -456,8 +456,13 @@ func normalizeMergeRequestApprovalConfigKeys(value any) any {
 	case map[string]any:
 		normalized := make(map[string]any, len(typed))
 		for key, item := range typed {
-			switch key {
-			case "required_approvals", "approvalsRequired":
+			// Fold case before comparing. viper lowercases every key it loads,
+			// so by the time an alias reaches this table it reads
+			// `approvalsrequired`, never `approvalsRequired` — which meant that
+			// spelling matched nothing and the rule silently ended up requiring
+			// 0 approvals instead of the configured number.
+			switch strings.ToLower(key) {
+			case "required_approvals", "approvalsrequired":
 				key = "requiredApprovals"
 			}
 			normalized[key] = normalizeMergeRequestApprovalConfigKeys(item)

--- a/config/decode_test.go
+++ b/config/decode_test.go
@@ -233,71 +233,78 @@ func containsAll(s string, subs ...string) bool {
 	return true
 }
 
-// The schema must claim every key the real course files use. This is the
-// completeness guard, and it is what makes the round-trip test meaningful: a
-// round trip would happily pass while dropping a field the decoder never knew
-// about, because it would be absent on both sides.
+// realCourseFixtures are the mirrors of actual course files. The synthetic
+// fixtures (casecourse, legacy) deliberately carry odd config and are excluded.
+var realCourseFixtures = []string{"mpd", "vss", "algdati", "fundc", "fun"}
+
+// The schema must claim every key the real course files use, with no exceptions.
+// This is the completeness guard, and it is what makes the round-trip test
+// meaningful: a round trip would happily pass while dropping a field the decoder
+// never knew about, because it would be absent on both sides.
 //
-// Anything reported here is a key the loader silently ignores. Today exactly
-// two classes exist, both pre-existing bugs frozen by the goldens:
-//
-//   - `clone.clone` — a stray key present in every real course file. It does
-//     nothing; the clone command has no such option.
-//   - `vss.blatt2.release.mergeRequest.dockerImages` — the images are nested
-//     under mergeRequest, but config/release.go:47 reads release.dockerImages,
-//     so all six are ignored.
-//
-// A new entry means either a genuine typo in a course file or a field missing
-// from the schema. Both are worth failing over.
+// Anything reported here is a key the loader silently ignores — either a schema
+// gap or a genuine typo in a course file. There used to be two classes of the
+// latter (`clone.clone` in every file, and dockerImages nested one level too
+// deep in vss/blatt2); both are fixed, which is why this allows nothing.
 func TestSchemaClaimsEveryKeyInRealFixtures(t *testing.T) {
 	t.Parallel()
 
-	knownUnclaimed := map[string]bool{
-		"vss.blatt2.release.mergeRequest.dockerImages": true,
-	}
-
-	paths, err := filepath.Glob(filepath.Join("testdata", "courses", "*.yaml"))
-	if err != nil {
-		t.Fatalf("globbing fixtures: %v", err)
-	}
-
-	for _, path := range paths {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("reading fixture: %v", err)
-		}
-		_, result, err := DecodeCourse(data)
-		if err != nil {
-			t.Fatalf("%s: %v", path, err)
-		}
-
+	for _, name := range realCourseFixtures {
+		_, result := decodeFixture(t, name)
 		for _, key := range result.UnknownKeys {
-			if strings.HasSuffix(key, ".clone.clone") || knownUnclaimed[key] {
-				continue
-			}
-			t.Errorf("%s: key %q is claimed by no field — schema gap or a typo in the fixture",
-				filepath.Base(path), key)
+			t.Errorf("%s.yaml: key %q is claimed by no field — schema gap or a typo in the fixture",
+				name, key)
 		}
 	}
 }
 
-func TestDecodeReportsUnknownAndLegacyKeys(t *testing.T) {
+// decodeYAML decodes an inline course document. Used where a fixture would have
+// to carry deliberately broken config that the completeness guard would then
+// flag.
+func decodeYAML(t *testing.T, doc string) (*CourseSource, *DecodeResult) {
+	t.Helper()
+	course, result, err := DecodeCourse([]byte(doc))
+	if err != nil {
+		t.Fatalf("DecodeCourse: %v", err)
+	}
+	return course, result
+}
+
+// Unknown keys are the reason lint exists: the loader ignores them silently, so
+// they look exactly like settings that work. Both cases below were real, and
+// both were live in the course files until `glabs config lint` surfaced them.
+func TestDecodeReportsUnknownKeys(t *testing.T) {
 	t.Parallel()
 
-	// vss.yaml carries `clone.clone: true`, which no field claims, and puts
-	// dockerImages under mergeRequest where nothing reads it. Both are silently
-	// ignored by the loader; lint must surface them, with the assignment named.
-	_, result := decodeFixture(t, "vss")
+	_, result := decodeYAML(t, `
+demo:
+  coursepath: demo/semester
+  blatt1:
+    assignmentpath: blatt-1
+    clone:
+      localpath: /tmp/demo
+      clone: true               # no such option; a `+"`clone:`"+` block alone enables cloning
+    release:
+      mergeRequest:
+        pipeline: true
+        dockerImages:           # belongs under release:, not under release.mergeRequest:
+          - service/one
+`)
+
 	for _, want := range []string{
-		"vss.blatt0.clone.clone",
-		"vss.blatt2.release.mergeRequest.dockerImages",
+		"demo.blatt1.clone.clone",
+		"demo.blatt1.release.mergeRequest.dockerImages",
 	} {
 		if !contains(result.UnknownKeys, want) {
 			t.Errorf("UnknownKeys = %v, want it to contain %q", result.UnknownKeys, want)
 		}
 	}
+}
 
-	_, result = decodeFixture(t, "legacy")
+func TestDecodeReportsLegacyKeys(t *testing.T) {
+	t.Parallel()
+
+	_, result := decodeFixture(t, "legacy")
 	if len(result.LegacyKeys) == 0 {
 		t.Fatal("LegacyKeys is empty, want the deprecated approvals spellings reported")
 	}
@@ -313,17 +320,12 @@ func TestDecodeReportsUnknownAndLegacyKeys(t *testing.T) {
 	}
 }
 
-// The typed decoder accepts `approvalsRequired`, which the viper-based loader
-// silently ignores: viper lowercases keys to `approvalsrequired` before the
-// alias table in config/assignment.go:443 compares them against the camelCase
-// spelling, so that case never matches and the rule ends up requiring 0
-// approvals instead of the configured number.
-//
-// This is a deliberate divergence and the only known one. It means the golden
-// for legacy.approvalslist will change when Resolve() replaces the viper path.
-// Fix the viper path first, in its own commit with its own golden diff, so the
-// resolver swap itself stays a zero-diff proof.
-func TestDecodeAcceptsAliasViperMissed(t *testing.T) {
+// `approvalsRequired` used to be dead: viper lowercases keys to
+// `approvalsrequired` before the alias table sees them, so the camelCase entry
+// matched nothing and the rule silently required 0 approvals. Both loaders now
+// fold case, so both accept it — asserted here and, for the viper path, by the
+// legacy.approvalslist golden.
+func TestDecodeAcceptsApprovalsRequiredAlias(t *testing.T) {
 	t.Parallel()
 
 	course, _ := decodeFixture(t, "legacy")

--- a/config/lint_test.go
+++ b/config/lint_test.go
@@ -29,30 +29,62 @@ func paths(findings []Finding) []string {
 	return out
 }
 
-// The two silently-ignored keys in the real configs are the reason lint exists:
-// nothing complains about them today, so they look like settings that work.
+// Silently-ignored keys are the reason lint exists: nothing complains about
+// them, so they look exactly like settings that work. Both cases here were real
+// and were live in the course files until lint surfaced them — `clone.clone` in
+// every single one, and dockerImages nested a level too deep in vss/blatt2,
+// where all six images were dropped on the floor.
 func TestLintReportsSilentlyIgnoredKeys(t *testing.T) {
 	t.Parallel()
 
-	findings := lintFixture(t, "vss")
+	course, decoded := decodeYAML(t, `
+demo:
+  coursepath: demo/semester
+  blatt1:
+    assignmentpath: blatt-1
+    clone:
+      localpath: /tmp/demo
+      clone: true
+    release:
+      mergeRequest:
+        pipeline: true
+        dockerImages:
+          - service/one
+`)
+	findings := Lint(course, decoded)
 
-	f := findingFor(findings, "vss.blatt2.release.mergeRequest.dockerImages")
+	f := findingFor(findings, "demo.blatt1.release.mergeRequest.dockerImages")
 	if f == nil {
 		t.Fatalf("dockerImages under mergeRequest not reported; got %v", paths(findings))
 	}
 	if f.Severity != SeverityProblem {
-		t.Errorf("severity = %q, want %q: the six images are configured and never applied", f.Severity, SeverityProblem)
+		t.Errorf("severity = %q, want %q: the images are configured and never applied", f.Severity, SeverityProblem)
 	}
 	if !strings.Contains(f.Message, "belongs under `release:`") {
 		t.Errorf("message %q does not say where dockerImages belongs", f.Message)
 	}
 
-	f = findingFor(findings, "vss.blatt0.clone.clone")
+	f = findingFor(findings, "demo.blatt1.clone.clone")
 	if f == nil {
 		t.Fatalf("stray clone.clone not reported; got %v", paths(findings))
 	}
 	if f.Severity != SeverityProblem {
 		t.Errorf("severity = %q, want %q", f.Severity, SeverityProblem)
+	}
+}
+
+// The real course files must lint free of problems. Deprecations are allowed to
+// remain — they still work — but anything that silently does nothing is a bug
+// in the config and should not be sitting there unnoticed.
+func TestLintFindsNoProblemsInRealFixtures(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range realCourseFixtures {
+		for _, f := range lintFixture(t, name) {
+			if f.Severity == SeverityProblem {
+				t.Errorf("%s.yaml: %s: %s", name, f.Path, f.Message)
+			}
+		}
 	}
 }
 

--- a/config/testdata/courses/algdati.yaml
+++ b/config/testdata/courses/algdati.yaml
@@ -38,7 +38,6 @@ algdati:
     clone:
       localpath: /tmp/glabs/algdati/25ws/blatt3
       branch: develop
-      clone: true
     release:
       mergeRequest:
         pipeline: true
@@ -55,7 +54,6 @@ algdati:
     clone:
       localpath: /tmp/glabs/algdati/25ws/blatt4
       branch: develop
-      clone: true
     release:
       mergeRequest:
         pipeline: true

--- a/config/testdata/courses/fun.yaml
+++ b/config/testdata/courses/fun.yaml
@@ -38,7 +38,6 @@ fun:
     clone:
       localpath: /tmp/glabs/fun/25ws/projekte
       branch: main
-      clone: true
 
   students:
     # Student 161

--- a/config/testdata/courses/fundc.yaml
+++ b/config/testdata/courses/fundc.yaml
@@ -32,7 +32,6 @@ fundc:
     clone:
       localpath: /tmp/glabs/fundc/24ss/blatt04
       branch: develop
-      clone: true
     release:
       mergeRequest:
         pipeline: true
@@ -50,7 +49,6 @@ fundc:
     clone:
       localpath: /tmp/glabs/fundc/24ss/blatt05
       branch: develop
-      clone: true
     # accesslevel: guest
 
   blatt06:
@@ -65,7 +63,6 @@ fundc:
     clone:
       localpath: /tmp/glabs/fundc/24ss/blatt06
       branch: develop
-      clone: true
     # accesslevel: guest
 
   blatt07:
@@ -80,7 +77,6 @@ fundc:
     clone:
       localpath: /tmp/glabs/fundc/24ss/blatt07
       branch: develop
-      clone: true
     release:
       mergeRequest:
         pipeline: true
@@ -98,7 +94,6 @@ fundc:
     clone:
       localpath: /tmp/glabs/fundc/24ss/blatt08
       branch: develop
-      clone: true
     release:
       mergeRequest:
         pipeline: true
@@ -116,7 +111,6 @@ fundc:
     clone:
       localpath: /tmp/glabs/fundc/24ss/blatt09
       branch: develop
-      clone: true
     release:
       mergeRequest:
         pipeline: true
@@ -134,7 +128,6 @@ fundc:
     clone:
       localpath: /tmp/glabs/fundc/25ss/blatt10
       branch: develop
-      clone: true
     release:
       mergeRequest:
         pipeline: true
@@ -152,7 +145,6 @@ fundc:
     clone:
       localpath: /tmp/glabs/fundc/25ss/blatt11
       branch: develop
-      clone: true
     release:
       mergeRequest:
         pipeline: true

--- a/config/testdata/courses/mpd.yaml
+++ b/config/testdata/courses/mpd.yaml
@@ -92,7 +92,6 @@ mpd:
         orphanMessage: Lösungsvorschlag [skip ci]
     clone:
       localpath: /tmp/glabs/mpd/26ss/blatt1
-      clone: true
 
   # ---------------------------------------------------------------------------
   # blatt07 + mockexam: devcontainer + (nicht-orphan) Lösungs-Branch,

--- a/config/testdata/courses/vss.yaml
+++ b/config/testdata/courses/vss.yaml
@@ -34,7 +34,6 @@ vss:
     clone:
       localpath: /tmp/glabs/vss/26ss/blatt0
       branch: develop
-      clone: true
 
 # glabs report vss blatt1 --html -o vss-blatt1.html
   blatt1:
@@ -65,7 +64,6 @@ vss:
     clone:
       localpath: /tmp/glabs/vss/26ss/blatt1
       branch: develop
-      clone: true
     # accesslevel: guest
     release:
       mergeRequest:
@@ -118,18 +116,17 @@ vss:
     clone:
       localpath: /tmp/glabs/vss/26ss/blatt2
       branch: main
-      clone: true
     # accesslevel: guest
     release:
       mergeRequest:
         pipeline: true
-        dockerImages:
-          - service/customer
-          - service/order
-          - service/payment
-          - service/shipment
-          - service/stock
-          - service/supplier
+      dockerImages:
+        - service/customer
+        - service/order
+        - service/payment
+        - service/shipment
+        - service/stock
+        - service/supplier
 
   students:
     - s161.t161@example.edu

--- a/config/testdata/golden/legacy.approvalslist.json
+++ b/config/testdata/golden/legacy.approvalslist.json
@@ -44,7 +44,7 @@
           "tutors"
         ],
         "MultiMemberGroupsOnly": true,
-        "RequiredApprovals": 0
+        "RequiredApprovals": 1
       },
       {
         "Name": "canonical",

--- a/config/testdata/golden/vss.blatt2.json
+++ b/config/testdata/golden/vss.blatt2.json
@@ -98,7 +98,14 @@
       "TargetBranch": "main",
       "HasPipeline": true
     },
-    "DockerImages": null
+    "DockerImages": [
+      "service/customer",
+      "service/order",
+      "service/payment",
+      "service/shipment",
+      "service/stock",
+      "service/supplier"
+    ]
   },
   "seeder": null,
   "deferredBranches": {},


### PR DESCRIPTION
Zwei Commits, die den Weg für den Resolver-Tausch (Schritt 2b) freiräumen. Beide ändern genau einen Golden — jeder zuordenbar.

## 1. `fix(config)`: der `approvalsRequired`-Alias war toter Code

`approvalsRequired` ist als Alias von `requiredApprovals` dokumentiert und tat **nichts**. viper schreibt jeden geladenen Key klein — bis die Alias-Tabelle in `normalizeMergeRequestApprovalConfigKeys` ihn sah, hieß er `approvalsrequired` und traf die CamelCase-Zeile nie. Die Regel dekodierte dann mit `RequiredApprovals: 0`: **gar keine Approval-Pflicht** statt der konfigurierten Anzahl.

`required_approvals` funktionierte nur zufällig — es ist schon kleingeschrieben.

Gefunden hat das der typisierte Decoder aus #76: der foldet Case durchgängig und war damit an genau diesem Key anderer Meinung als der viper-Pfad.

Keine echte Kursdatei nutzt den Alias, es ändert sich also praktisch nichts. Der Golden `legacy.approvalslist` nagelt es fest — die drei Schreibweisen nebeneinander:

| Schreibweise | vorher | nachher |
|---|---|---|
| `required_approvals: 2` | 2 | 2 |
| `approvalsRequired: 1` | **0** ✗ | **1** ✓ |
| `requiredApprovals: 3` | 3 | 3 |

## 2. `test(config)`: Fixtures an die bereinigten Kursdateien angleichen

Die echten Kursdateien haben gerade ihre zwei stillschweigend ignorierten Keys verloren (obcode/glabs-yaml@7ccb482):

- **`clone.clone`** — steckte in **jeder einzelnen** Datei (16×) und war nie eine Option; allein ein `clone:`-Block schaltet das Klonen ein.
- **`release.mergeRequest.dockerImages`** in vss/blatt2 — `config/release.go` liest sie aus `release.dockerImages`, alle sechs fielen unter den Tisch.

Hier nachgezogen, damit die Fixtures weiter das spiegeln, was sie spiegeln sollen. **Nur ein Golden bewegt sich**: `vss/blatt2` löst jetzt die sechs Images auf statt `null`. Das Entfernen von `clone.clone` ändert erwartungsgemäß nichts — verifiziert durch `glabs show` über 19 Assignments in allen fünf Kursen, bevor die Änderung upstream ging.

**Schöner Nebeneffekt:** mit sauberen Fixtures braucht die Vollständigkeitsgarantie **keine Ausnahmeliste mehr** — das Schema beansprucht jetzt jeden Key in jeder echten Kursdatei. Die Testfälle, die auf den kaputten Fixtures beruhten, wandern in Inline-Dokumente, damit die Garantie nicht von einer absichtlich kaputten Fixture aufgeweicht werden kann.

Neu dazu: `TestLintFindsNoProblemsInRealFixtures` hält es so. Deprecations bleiben erlaubt — die funktionieren ja — aber ein Key, der still nichts tut, soll nicht wieder unbemerkt in einer Kursdatei sitzen.

## Warum das vor Schritt 2b kommt

Sonst würde der Resolver-Tausch **beide** Golden-Änderungen mit sich schleppen und wäre kein Null-Diff-Beweis mehr. So bleibt 2b, was es sein soll: die Goldens laufen unverändert durch, oder der Tausch ist falsch.

## Verifikation

- `go test ./...` grün; `gofmt`, `go vet`, `golangci-lint` sauber
- Golden-Diff: **exakt 2 Dateien**, jede einem Commit zuordenbar
- `glabs config lint` gegen die echten Dateien: **null `problem`-Funde**, exit=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)