### PR TITLE
feat(git)!: use the PAT over HTTPS for all git, drop SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This README is the quick entry point. The full user handbook lives in the docs f
 Prerequisite: Go 1.24+
 
 ```sh
-go install github.com/obcode/glabs/v2@latest
+go install github.com/obcode/glabs/v3@latest
 ```
 
 ### Add glabs to your PATH

--- a/cmd/addgroupguests.go
+++ b/cmd/addgroupguests.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/git"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/git"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/paths_test.go
+++ b/cmd/paths_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// Course files stopped going through viper's config-path loader, which expanded
+// $HOME and ~ implicitly. findCourseFile has to do it explicitly, or a
+// coursesfilepath like "$HOME/courses" is taken literally and the file is not
+// found. This is a regression guard for exactly that.
+func TestFindCourseFileExpandsHomeAndEnv(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mpd.yaml"), []byte("mpd:\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", dir)
+	t.Setenv("GLABS_TEST_DIR", dir)
+
+	for _, coursesfilepath := range []string{dir, "$HOME", "~", "$GLABS_TEST_DIR"} {
+		viper.Reset()
+		viper.Set("coursesfilepath", coursesfilepath)
+
+		got, err := findCourseFile("mpd")
+		if err != nil {
+			t.Errorf("coursesfilepath=%q: findCourseFile returned %v", coursesfilepath, err)
+			continue
+		}
+		if want := filepath.Join(dir, "mpd.yaml"); got != want {
+			t.Errorf("coursesfilepath=%q: findCourseFile = %q, want %q", coursesfilepath, got, want)
+		}
+	}
+	viper.Reset()
+}
+
+func TestFindCourseFileMissing(t *testing.T) {
+	viper.Reset()
+	viper.Set("coursesfilepath", t.TempDir())
+	t.Cleanup(viper.Reset)
+
+	if _, err := findCourseFile("nosuchcourse"); err == nil {
+		t.Fatal("findCourseFile(nosuchcourse) succeeded, want an error naming the file")
+	}
+}

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
-	"github.com/obcode/glabs/v2/gitlab/report"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
+	"github.com/obcode/glabs/v3/gitlab/report"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -93,7 +93,7 @@ func initConfig() {
 // findCourseFile locates a course file by name under coursesfilepath, accepting
 // the extensions viper used to search for.
 func findCourseFile(course string) (string, error) {
-	dir := viper.GetString("coursesfilepath")
+	dir := expandPath(viper.GetString("coursesfilepath"))
 	for _, ext := range []string{".yaml", ".yml"} {
 		path := filepath.Join(dir, course+ext)
 		if _, err := os.Stat(path); err == nil {
@@ -102,4 +102,17 @@ func findCourseFile(course string) (string, error) {
 	}
 	return "", fmt.Errorf("cannot find a course file for %q: looked for %s.yaml and %s.yml in %q",
 		course, course, course, dir)
+}
+
+// expandPath resolves ~, $HOME and other environment variables in a path read
+// from the config file. viper's config-path loader did this implicitly; course
+// files no longer go through it, so a value like "$HOME/courses" has to be
+// expanded here — otherwise it is taken literally and the directory is not found.
+func expandPath(path string) string {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		if home, err := homedir.Dir(); err == nil {
+			path = home + path[1:]
+		}
+	}
+	return os.ExpandEnv(path)
 }

--- a/cmd/setaccess.go
+++ b/cmd/setaccess.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/logrusorgru/aurora/v4"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/spf13/cobra"
 )
 

--- a/config/clone_url_test.go
+++ b/config/clone_url_test.go
@@ -1,0 +1,37 @@
+package config
+
+import "testing"
+
+func TestHTTPSCloneURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ssh notation", "git@gitlab.lrz.de:mpd/startercode/blatt-01.git", "https://gitlab.lrz.de/mpd/startercode/blatt-01.git"},
+		{"ssh without .git", "git@gitlab.lrz.de:mpd/startercode/blatt-01", "https://gitlab.lrz.de/mpd/startercode/blatt-01.git"},
+		{"https already", "https://gitlab.lrz.de/mpd/startercode/blatt-01.git", "https://gitlab.lrz.de/mpd/startercode/blatt-01.git"},
+		{"https without .git", "https://gitlab.lrz.de/mpd/startercode/blatt-01", "https://gitlab.lrz.de/mpd/startercode/blatt-01.git"},
+		{"whitespace", "  git@gitlab.lrz.de:mpd/x.git  ", "https://gitlab.lrz.de/mpd/x.git"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HTTPSCloneURL(tt.in)
+			if err != nil {
+				t.Fatalf("HTTPSCloneURL(%q): %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("HTTPSCloneURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPSCloneURLErrors(t *testing.T) {
+	for _, in := range []string{"", "  ", "ssh://gitlab.lrz.de/x", "git@nocolon"} {
+		if _, err := HTTPSCloneURL(in); err == nil {
+			t.Errorf("HTTPSCloneURL(%q) = nil error, want an error", in)
+		}
+	}
+}

--- a/config/lint.go
+++ b/config/lint.go
@@ -140,6 +140,7 @@ func lintAssignment(course *CourseSource, name string, a *AssignmentSource) []Fi
 	}
 
 	if a.Seeder != nil {
+		add("seeder", "the seeder is deprecated and will be removed; it is not available in the web app", SeverityDeprecated)
 		if a.Seeder.Cmd == "" {
 			add("seeder.cmd", "seeder without a cmd", SeverityProblem)
 		}

--- a/config/urls.go
+++ b/config/urls.go
@@ -16,46 +16,56 @@ func (cfg *AssignmentConfig) StartercodeURL() {
 }
 
 func (cfg *AssignmentConfig) gitURLToWebURL(raw, branch string) (string, error) {
+	base, err := gitURLToHTTPSBase(raw)
+	if err != nil {
+		return "", err
+	}
+	if branch == "" {
+		return base, nil
+	}
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	return base + "-/tree/" + url.PathEscape(branch), nil
+}
+
+// HTTPSCloneURL turns a starter-code or repository URL into the HTTPS clone URL
+// glabs talks to. The SSH form `git@host:path.git` stays valid *notation* in a
+// course file — it is what people paste out of GitLab — but glabs clones and
+// pushes over HTTPS with a PAT, so every URL is normalized to https here.
+func HTTPSCloneURL(raw string) (string, error) {
+	base, err := gitURLToHTTPSBase(raw)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasSuffix(base, ".git") {
+		base += ".git"
+	}
+	return base, nil
+}
+
+// gitURLToHTTPSBase accepts either an https URL (returned as-is, minus any .git)
+// or the SSH form git@host:path[.git], and returns https://host/path.
+func gitURLToHTTPSBase(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
-
 	if raw == "" {
-		return "", fmt.Errorf("leere URL")
+		return "", fmt.Errorf("empty URL")
 	}
 
-	// Bereits Web-URL -> direkt zurückgeben
 	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {
-		base := raw
-		if branch == "" {
-			return base, nil
-		}
-		encBranch := url.PathEscape(branch)
-		if !strings.HasSuffix(base, "/") {
-			base += "/"
-		}
-		return base + "-/tree/" + encBranch, nil
+		return strings.TrimSuffix(raw, ".git"), nil
 	}
 
-	// Git SSH Form: git@host:path.git
 	if strings.HasPrefix(raw, "git@") {
 		rest := strings.TrimPrefix(raw, "git@")
-		i := strings.Index(rest, ":")
-		if i < 0 {
-			return "", fmt.Errorf("ungültige SSH-URL: %q", raw)
+		host, path, found := strings.Cut(rest, ":")
+		if !found {
+			return "", fmt.Errorf("invalid SSH URL: %q", raw)
 		}
-
-		host := rest[:i]
-		path := rest[i+1:]
-		path = strings.TrimSuffix(path, ".git")
-
-		base := "https://" + host + "/" + path
-		if branch == "" {
-			return base, nil
-		}
-		encBranch := url.PathEscape(branch)
-		return base + "/-/tree/" + encBranch, nil
+		return "https://" + host + "/" + strings.TrimSuffix(path, ".git"), nil
 	}
 
-	return "", fmt.Errorf("nicht unterstütztes URL-Format: %q", raw)
+	return "", fmt.Errorf("unsupported URL format: %q", raw)
 }
 
 func (cfg *AssignmentConfig) Urls(assignment bool) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,8 +18,6 @@ gitlab:
   host: https://gitlab.example.org
   token: <personal-access-token>
 
-sshprivatekey: /path/to/private/key
-
 coursesfilepath: /absolute/path/to/course-configs
 courses:
   - mpd
@@ -31,14 +29,15 @@ courses:
 | Key | Purpose | Required | Default |
 |---|---|---|---|
 | `gitlab.host` | Base URL of your GitLab instance | Yes | — |
-| `gitlab.token` | Personal access token with API scope | Yes | — |
-| `sshprivatekey` | Path to unencrypted SSH key for git operations | No | System default SSH key |
+| `gitlab.token` | Personal access token, scopes `api` and `write_repository` | Yes | — |
 | `coursesfilepath` | Directory containing course config files | Yes | — |
 | `courses` | List of course file basenames to load | Yes | — |
 
 ### Notes
 
-- **sshprivatekey**: Only needed if default SSH key doesn't work
+- **gitlab.token**: used for both the API and git. It needs `write_repository` in
+  addition to `api`, because glabs pushes over HTTPS. Since glabs v3 there is no
+  separate SSH key.
 - **coursesfilepath**: Must be absolute path
 - **courses**: Filenames without extension (glabs adds .yaml/.yml/etc)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ Essential defaults for your first assignment:
 From source:
 
 ```sh
-go install github.com/obcode/glabs@latest
+go install github.com/obcode/glabs/v3@latest
 ```
 
 From local checkout:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,3 +1,45 @@
+# Migration Guide: v3 — PAT-only, no SSH
+
+glabs v3 drops SSH for git. Everything — cloning starter code, pushing to student
+repositories — now goes over HTTPS with `gitlab.token`, the same token already
+used for the API.
+
+**What you need to do:**
+
+1. **Give the token the `write_repository` scope.** It needed `api` before;
+   pushing over HTTPS additionally needs `write_repository`. Create a new token
+   with both scopes and update `gitlab.token`.
+2. **Remove `sshprivatekey`** from your main config. It is no longer read.
+3. **Reinstall with the new module path:**
+   ```sh
+   go install github.com/obcode/glabs/v3@latest
+   ```
+
+**What you do *not* need to change:** your course files, if their starter-code
+and `deferredBranches` URLs point at your GitLab instance. SSH notation
+(`git@gitlab.lrz.de:...`) stays valid — glabs normalizes it to HTTPS.
+
+**The one capability that is gone: starter code from another host.** Under SSH,
+a starter repo or deferred branch could live anywhere the operator's key had
+access — `git@github.com:...`, a second GitLab, etc. The PAT authenticates
+against *one* host, your GitLab instance, so:
+
+- A starter repo or deferred branch on **your GitLab instance** — works.
+- A **public** repo on another host (GitHub, …) — still works; a public clone
+  needs no credential.
+- A **private** repo on another host — no longer works. glabs has no credential
+  for that host, and deliberately does not send your GitLab token to it (that
+  would leak it). You will get a plain "authentication required".
+
+If you host starter code on another private host, mirror it into your GitLab
+instance and point the URL there.
+
+Why the whole change: one credential instead of two, and the same transport in
+the CLI and the upcoming web server, where a shared SSH key would have access to
+every user's repositories.
+
+---
+
 # Migration Guide: Startercode Refactor
 
 This guide helps you migrate from legacy assignment config keys under `startercode` to the new independent blocks:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,25 +75,23 @@ invalid API token
 glabs check <course>  # Validates token access
 ```
 
-### SSH key issues (startercode)
+### Git operations fail (startercode, push, clone)
+
+Since glabs v3, all git operations go over HTTPS with `gitlab.token` — there is
+no SSH key. Starter-code URLs may still be written in SSH notation
+(`git@gitlab.lrz.de:...`); glabs normalizes them to HTTPS.
 
 **Symptoms:**
 ```
-Permission denied (publickey)
-ssh: connect to host gitlab.lrz.de port 22: Connection refused
+authentication required
+403 Forbidden
 ```
 
 **Checks:**
-- SSH key loaded: `ssh-add -l`
-- Key has permission to read starter repo
-- URL is SSH format: `git@gitlab.lrz.de:...` (not https)
-- Can clone manually: `git clone git@gitlab.lrz.de:...`
-
-**Configure custom key:**
-```yaml
-# main config
-sshprivatekey: /path/to/id_rsa
-```
+- `gitlab.token` is set and not expired
+- The token has both the `api` **and** `write_repository` scopes — pushing needs
+  `write_repository`, which a token with only `api` does not have
+- The token's user can read the starter repo and write the target group
 
 ## Repository generation
 

--- a/git/auth.go
+++ b/git/auth.go
@@ -2,28 +2,66 @@ package git
 
 import (
 	"fmt"
-	"os"
+	"net/url"
+	"strings"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/spf13/viper"
 )
 
-func GetAuth() (ssh.AuthMethod, error) {
-	privateKeyFile := viper.GetString("sshprivatekey")
+// GetAuth returns the credential glabs uses to talk to its own GitLab instance:
+// the personal access token, over HTTPS.
+//
+// glabs used to authenticate git with an SSH key (`sshprivatekey`), separate
+// from the token it already needed for the API. That is gone: one credential,
+// one transport, the same in the CLI and — once it exists — the web server,
+// where a per-user SSH key would be a shared identity with access to every
+// user's repositories. The token needs the `write_repository` scope in addition
+// to `api`.
+//
+// GitLab accepts the token as the HTTP password with any non-empty username;
+// "oauth2" is the conventional one.
+func GetAuth() (transport.AuthMethod, error) {
+	token := viper.GetString("gitlab.token")
+	if token == "" {
+		return nil, fmt.Errorf("gitlab.token is required for git operations (needs the api and write_repository scopes)")
+	}
+	return &githttp.BasicAuth{Username: "oauth2", Password: token}, nil
+}
 
-	if privateKeyFile == "" {
+// AuthForURL returns the credential to use when cloning the given URL.
+//
+// The token authenticates against one host: the configured GitLab instance.
+// Under SSH this was invisible — the operator's key worked against any host, so
+// a starter repo or deferred branch could live on github.com or another GitLab.
+// Over HTTPS with a PAT that no longer holds, and sending the GitLab token to a
+// foreign host would leak it. So the token is attached only for the GitLab host;
+// any other host is cloned unauthenticated, which works for public repositories
+// and fails with a plain "authentication required" for private ones.
+func AuthForURL(rawURL string) (transport.AuthMethod, error) {
+	onGitLab, err := isConfiguredGitLabHost(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if !onGitLab {
 		return nil, nil
 	}
+	return GetAuth()
+}
 
-	_, err := os.Stat(privateKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read ssh key from file: %w", err)
+func isConfiguredGitLabHost(rawURL string) (bool, error) {
+	gitlabHost := viper.GetString("gitlab.host")
+	if gitlabHost == "" {
+		return false, fmt.Errorf("gitlab.host is not configured")
 	}
-
-	publicKeys, err := ssh.NewPublicKeysFromFile("git", privateKeyFile, "")
+	gl, err := url.Parse(gitlabHost)
 	if err != nil {
-		return nil, fmt.Errorf("cannot generate publickeys from file %s:  %w", privateKeyFile, err)
+		return false, fmt.Errorf("gitlab.host %q is not a valid URL: %w", gitlabHost, err)
 	}
-
-	return publicKeys, nil
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		return false, fmt.Errorf("cannot parse URL %q: %w", rawURL, err)
+	}
+	return strings.EqualFold(gl.Host, target.Host), nil
 }

--- a/git/auth_test.go
+++ b/git/auth_test.go
@@ -1,9 +1,9 @@
 package git
 
 import (
-	"os"
 	"testing"
 
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/spf13/viper"
 )
 
@@ -13,57 +13,74 @@ func resetViper(t *testing.T) {
 	t.Cleanup(viper.Reset)
 }
 
-func TestGetAuth_NoKeyConfigured(t *testing.T) {
+func TestGetAuthUsesTheTokenOverHTTPS(t *testing.T) {
 	resetViper(t)
-	// sshprivatekey not set → returns nil, nil
+	viper.Set("gitlab.token", "glpat-secret")
 
 	auth, err := GetAuth()
 	if err != nil {
-		t.Fatalf("GetAuth() error = %v, want nil", err)
+		t.Fatalf("GetAuth() error = %v", err)
+	}
+
+	basic, ok := auth.(*githttp.BasicAuth)
+	if !ok {
+		t.Fatalf("GetAuth() = %T, want *http.BasicAuth", auth)
+	}
+	if basic.Password != "glpat-secret" {
+		t.Errorf("Password = %q, want the token", basic.Password)
+	}
+	if basic.Username == "" {
+		t.Error("Username is empty; GitLab needs a non-empty username with the token")
+	}
+}
+
+// Without a token there is nothing to authenticate with. This used to be
+// allowed — an empty sshprivatekey fell back to the ssh-agent — but the token is
+// now mandatory for any git operation.
+func TestGetAuthRequiresAToken(t *testing.T) {
+	resetViper(t)
+
+	if _, err := GetAuth(); err == nil {
+		t.Fatal("GetAuth() succeeded without a token, want an error")
+	}
+}
+
+// The token is attached only for the configured GitLab host. Sending it to a
+// foreign host (a starter repo on github.com, say) would both fail and leak the
+// token, so those are cloned unauthenticated.
+func TestAuthForURLIsHostScoped(t *testing.T) {
+	resetViper(t)
+	viper.Set("gitlab.host", "https://gitlab.lrz.de")
+	viper.Set("gitlab.token", "glpat-secret")
+
+	onGitLab, err := AuthForURL("https://gitlab.lrz.de/mpd/startercode/blatt-01.git")
+	if err != nil {
+		t.Fatalf("AuthForURL(gitlab): %v", err)
+	}
+	if _, ok := onGitLab.(*githttp.BasicAuth); !ok {
+		t.Errorf("AuthForURL(gitlab host) = %T, want *http.BasicAuth with the token", onGitLab)
+	}
+
+	foreign, err := AuthForURL("https://github.com/foo/bar.git")
+	if err != nil {
+		t.Fatalf("AuthForURL(github): %v", err)
+	}
+	if foreign != nil {
+		t.Errorf("AuthForURL(foreign host) = %v, want nil: the GitLab token must not be sent to another host", foreign)
+	}
+}
+
+// A foreign host is allowed even without a token — a public repo needs none. The
+// token requirement only bites for the GitLab host itself.
+func TestAuthForURLForeignHostWithoutToken(t *testing.T) {
+	resetViper(t)
+	viper.Set("gitlab.host", "https://gitlab.lrz.de")
+
+	auth, err := AuthForURL("https://github.com/foo/public.git")
+	if err != nil {
+		t.Fatalf("AuthForURL(github, no token): %v", err)
 	}
 	if auth != nil {
-		t.Fatalf("GetAuth() = %v, want nil", auth)
-	}
-}
-
-func TestGetAuth_ExplicitlyEmpty(t *testing.T) {
-	resetViper(t)
-	viper.Set("sshprivatekey", "")
-
-	auth, err := GetAuth()
-	if err != nil {
-		t.Fatalf("GetAuth() error = %v, want nil", err)
-	}
-	if auth != nil {
-		t.Fatalf("GetAuth() = %v, want nil", auth)
-	}
-}
-
-func TestGetAuth_MissingFile(t *testing.T) {
-	resetViper(t)
-	viper.Set("sshprivatekey", "/nonexistent/totally/missing/key")
-
-	_, err := GetAuth()
-	if err == nil {
-		t.Fatal("GetAuth() expected error for missing file, got nil")
-	}
-}
-
-func TestGetAuth_InvalidKeyContent(t *testing.T) {
-	resetViper(t)
-
-	f, err := os.CreateTemp(t.TempDir(), "sshkey-*")
-	if err != nil {
-		t.Fatalf("creating temp file: %v", err)
-	}
-	_, _ = f.WriteString("this is not a valid SSH private key")
-	f.Close()
-
-	viper.Set("sshprivatekey", f.Name())
-
-	// File exists but content is not a valid key → error from ssh.NewPublicKeysFromFile
-	_, err = GetAuth()
-	if err == nil {
-		t.Fatal("GetAuth() expected error for invalid key content, got nil")
+		t.Errorf("AuthForURL = %v, want nil", auth)
 	}
 }

--- a/git/clone.go
+++ b/git/clone.go
@@ -3,14 +3,13 @@ package git
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 )
@@ -35,17 +34,18 @@ func Clone(cfg *config.AssignmentConfig, noSpinner bool) {
 	}
 }
 
+// ProjectRepoUrl is the HTTPS clone URL for a student's or group's repository.
+// cfg.URL is already https://host/coursepath, so the repository URL is just that
+// plus the repo name; glabs clones it over HTTPS with the token.
 func ProjectRepoUrl(cfg *config.AssignmentConfig, suffix string) string {
-	return fmt.Sprintf("%s/%s-%s",
-		strings.Replace(strings.Replace(cfg.URL, "https://", "git@", 1), "/", ":", 1),
-		cfg.RepoBaseName(), suffix)
+	return fmt.Sprintf("%s/%s-%s.git", cfg.URL, cfg.RepoBaseName(), suffix)
 }
 
 func localpath(cfg *config.AssignmentConfig, suffix string) string {
 	return fmt.Sprintf("%s/%s", cfg.Clone.LocalPath, cfg.RepoNameWithSuffix(suffix))
 }
 
-func clone(localpath, branch, cloneurl string, auth ssh.AuthMethod, force bool, noSpinner bool) {
+func clone(localpath, branch, cloneurl string, auth transport.AuthMethod, force bool, noSpinner bool) {
 	cfg := yacspin.Config{
 		Frequency: 100 * time.Millisecond,
 		CharSet:   yacspin.CharSets[69],

--- a/git/clone_helpers_test.go
+++ b/git/clone_helpers_test.go
@@ -1,13 +1,12 @@
 package git
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
-func TestCloneurl_HTTPS(t *testing.T) {
+func TestProjectRepoUrlIsHTTPS(t *testing.T) {
 	cfg := &config.AssignmentConfig{
 		URL:                   "https://gitlab.example.org/mpd/ss26/blatt-01",
 		Name:                  "blatt01",
@@ -16,34 +15,13 @@ func TestCloneurl_HTTPS(t *testing.T) {
 	}
 
 	got := ProjectRepoUrl(cfg, "alice")
-	want := "git@gitlab.example.org:mpd/ss26/blatt-01/mpd-blatt01-alice"
+	want := "https://gitlab.example.org/mpd/ss26/blatt-01/mpd-blatt01-alice.git"
 	if got != want {
-		t.Fatalf("cloneurl() = %q, want %q", got, want)
+		t.Fatalf("ProjectRepoUrl() = %q, want %q", got, want)
 	}
 }
 
-func TestCloneurl_ContainsExpectedParts(t *testing.T) {
-	cfg := &config.AssignmentConfig{
-		URL:                   "https://gitlab.example.org/mpd/ss26/blatt-01",
-		Name:                  "blatt01",
-		Course:                "mpd",
-		UseCoursenameAsPrefix: true,
-	}
-
-	got := ProjectRepoUrl(cfg, "bob")
-
-	if strings.Contains(got, "https://") {
-		t.Fatalf("cloneurl() should not contain https://, got %q", got)
-	}
-	if !strings.HasPrefix(got, "git@") {
-		t.Fatalf("cloneurl() should start with git@, got %q", got)
-	}
-	if !strings.HasSuffix(got, "bob") {
-		t.Fatalf("cloneurl() should end with suffix, got %q", got)
-	}
-}
-
-func TestCloneurl_WithoutCoursePrefix(t *testing.T) {
+func TestProjectRepoUrlWithoutCoursePrefix(t *testing.T) {
 	cfg := &config.AssignmentConfig{
 		URL:                   "https://gitlab.example.org/mpd/ss26/blatt-01",
 		Name:                  "blatt01",
@@ -52,9 +30,9 @@ func TestCloneurl_WithoutCoursePrefix(t *testing.T) {
 	}
 
 	got := ProjectRepoUrl(cfg, "team1")
-	want := "git@gitlab.example.org:mpd/ss26/blatt-01/blatt01-team1"
+	want := "https://gitlab.example.org/mpd/ss26/blatt-01/blatt01-team1.git"
 	if got != want {
-		t.Fatalf("cloneurl() = %q, want %q", got, want)
+		t.Fatalf("ProjectRepoUrl() = %q, want %q", got, want)
 	}
 }
 

--- a/git/clone_runtime_test.go
+++ b/git/clone_runtime_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
 func TestClone_NoSpinner_CloneErrorNoPanic(t *testing.T) {

--- a/git/push.go
+++ b/git/push.go
@@ -8,7 +8,7 @@ import (
 	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
@@ -42,7 +42,7 @@ func Push(assignmentCfg *config.AssignmentConfig, projectname string, sourceRepo
 
 	conf := &gitconfig.RemoteConfig{
 		Name: project.Name,
-		URLs: []string{project.SSHURLToRepo},
+		URLs: []string{project.HTTPURLToRepo},
 	}
 
 	remote, err := sourceRepo.Repo.CreateRemote(conf)
@@ -54,7 +54,7 @@ func Push(assignmentCfg *config.AssignmentConfig, projectname string, sourceRepo
 			log.Debug().Err(err).Msg("cannot stop spinner")
 		}
 		log.Debug().Err(err).
-			Str("name", project.Name).Str("url", project.SSHURLToRepo).
+			Str("name", project.Name).Str("url", project.HTTPURLToRepo).
 			Msg("cannot create remote")
 		return fmt.Errorf("cannot create remote: %w", err)
 	}

--- a/git/sourcerepo.go
+++ b/git/sourcerepo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/logrusorgru/aurora"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"github.com/theckman/yacspin"
@@ -62,7 +63,16 @@ func PrepareSourceRepo(url, fromBranch string, singleCommit bool, commitMessage 
 		}
 	}()
 
-	auth, err := GetAuth()
+	// The starter-code (or deferred-branch) URL may be written in SSH notation
+	// (git@host:path.git); glabs clones over HTTPS with the token, so normalize
+	// it first, then pick the credential based on its host.
+	cloneURL, err := config.HTTPSCloneURL(url)
+	if err != nil {
+		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
+		return nil, err
+	}
+
+	auth, err := AuthForURL(cloneURL)
 	if err != nil {
 		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
 		fmt.Printf("error: %v", err)
@@ -75,7 +85,7 @@ func PrepareSourceRepo(url, fromBranch string, singleCommit bool, commitMessage 
 	sourceRef := plumbing.NewBranchReferenceName(fromBranch)
 
 	repo, err := git.Clone(storer, fs, &git.CloneOptions{
-		URL:           url,
+		URL:           cloneURL,
 		ReferenceName: sourceRef,
 		SingleBranch:  true,
 		Auth:          auth,

--- a/git/types.go
+++ b/git/types.go
@@ -3,11 +3,11 @@ package git
 import (
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 )
 
 type SourceRepo struct {
 	Repo *git.Repository
 	Ref  plumbing.ReferenceName
-	Auth ssh.AuthMethod
+	Auth transport.AuthMethod
 }

--- a/gitlab/approvals.go
+++ b/gitlab/approvals.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/archive.go
+++ b/gitlab/archive.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
@@ -115,7 +115,7 @@ func (c *Client) archive(assignmentCfg *config.AssignmentConfig, project *gitlab
 			return ""
 		}()).
 		Str("name", project.Name).
-		Str("toURL", project.SSHURLToRepo).
+		Str("toURL", project.HTTPURLToRepo).
 		Msg("protecting branch")
 
 	var err error
@@ -124,7 +124,7 @@ func (c *Client) archive(assignmentCfg *config.AssignmentConfig, project *gitlab
 		if err != nil {
 			log.Debug().Err(err).
 				Str("name", project.Name).
-				Str("toURL", project.SSHURLToRepo).
+				Str("toURL", project.HTTPURLToRepo).
 				Msg("cannot unarchive project")
 
 			if spin {
@@ -140,7 +140,7 @@ func (c *Client) archive(assignmentCfg *config.AssignmentConfig, project *gitlab
 		if err != nil {
 			log.Debug().Err(err).
 				Str("name", project.Name).
-				Str("toURL", project.SSHURLToRepo).
+				Str("toURL", project.HTTPURLToRepo).
 				Msg("cannot archive project")
 
 			if spin {

--- a/gitlab/archive_contract_test.go
+++ b/gitlab/archive_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/branches.go
+++ b/gitlab/branches.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/branches_contract_test.go
+++ b/gitlab/branches_contract_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/check.go
+++ b/gitlab/check.go
@@ -2,7 +2,7 @@ package gitlab
 
 import (
 	"github.com/gookit/color"
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 )
 

--- a/gitlab/check_test.go
+++ b/gitlab/check_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/delete.go
+++ b/gitlab/delete.go
@@ -3,7 +3,7 @@ package gitlab
 import (
 	"fmt"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/delete_contract_test.go
+++ b/gitlab/delete_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
 // groupSearchHandler returns a handler that mocks getGroupID + Search.ProjectsByGroup + DeleteProject.

--- a/gitlab/generate.go
+++ b/gitlab/generate.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/git"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/git"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 )

--- a/gitlab/groups.go
+++ b/gitlab/groups.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/groups_contract_test.go
+++ b/gitlab/groups_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
 func TestGetGroupIDByFullPath_FindsGroup(t *testing.T) {

--- a/gitlab/integration_gitlab_test.go
+++ b/gitlab/integration_gitlab_test.go
@@ -12,7 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
+	g "github.com/obcode/glabs/v3/git"
+	"github.com/spf13/viper"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
@@ -24,6 +26,12 @@ const (
 	runIntegrationEnv  = "GLABS_RUN_GITLAB_TC"
 	gitLabRootPassword = "zXq7!Rp3@Wk9#Tm2vL"
 )
+
+func resetViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+}
 
 func requireIntegrationEnabled(t *testing.T) {
 	t.Helper()
@@ -42,7 +50,7 @@ func createRootToken(ctx context.Context, t *testing.T, c testcontainers.Contain
 		"user = User.find_by_username('root')",
 		"token = user.personal_access_tokens.find_by(name: 'glabs-integration-token')",
 		"token&.revoke!",
-		"token = user.personal_access_tokens.create!(name: 'glabs-integration-token', scopes: [:api], expires_at: 365.days.from_now)",
+		"token = user.personal_access_tokens.create!(name: 'glabs-integration-token', scopes: [:api, :write_repository], expires_at: 365.days.from_now)",
 		fmt.Sprintf("token.set_token('%s')", gitLabRootToken),
 		"token.save!",
 		"puts token.token",
@@ -282,6 +290,75 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 		}
 		if proj.Archived {
 			t.Fatal("expected project to be unarchived after Archive(unarchive=true)")
+		}
+	})
+
+	// ── Sub-test: git transport over HTTPS with the PAT ──────────────────────
+	// This is the proof for the v3 breaking change: git now speaks HTTPS with
+	// the token instead of SSH with a key. It clones a source project and pushes
+	// it to a target, then reads the file back through the API.
+	t.Run("GitTransportOverHTTPS", func(t *testing.T) {
+		resetViper(t)
+		// createRootToken sets the token value to this constant, and the scope now
+		// includes write_repository.
+		viper.Set("gitlab.token", gitLabRootToken)
+		viper.Set("gitlab.host", baseURL)
+		t.Cleanup(viper.Reset)
+
+		// A source project with a committed file on main.
+		srcName := "transport-src"
+		initReadme := true
+		srcProject, _, err := client.Projects.CreateProject(&gitlabapi.CreateProjectOptions{
+			Name:                 &srcName,
+			NamespaceID:          &parent.ID,
+			InitializeWithReadme: &initReadme,
+		})
+		if err != nil {
+			t.Fatalf("creating source project failed: %v", err)
+		}
+
+		// GitLab's external_url inside the container is http://localhost (port 80),
+		// but the test reaches it on the mapped port, so project.HTTPURLToRepo
+		// points at the wrong port. Build the reachable URL from baseURL instead.
+		gitURL := func(p *gitlabapi.Project) string { return baseURL + "/" + p.PathWithNamespace + ".git" }
+
+		// Clone it over HTTPS+PAT — proves the clone side of the transport.
+		sourceRepo, err := g.PrepareSourceRepo(gitURL(srcProject), "main", false, "")
+		if err != nil {
+			t.Fatalf("PrepareSourceRepo over HTTPS failed: %v", err)
+		}
+
+		// An empty target project to push into.
+		dstName := "transport-dst"
+		emptyReadme := false
+		dstProject, _, err := client.Projects.CreateProject(&gitlabapi.CreateProjectOptions{
+			Name:                 &dstName,
+			NamespaceID:          &parent.ID,
+			InitializeWithReadme: &emptyReadme,
+		})
+		if err != nil {
+			t.Fatalf("creating destination project failed: %v", err)
+		}
+		dstProject.HTTPURLToRepo = gitURL(dstProject)
+
+		cfg := &config.AssignmentConfig{
+			Course: "it", Name: "transport",
+			URL:         baseURL + "/" + dstProject.PathWithNamespace,
+			Startercode: &config.Startercode{ToBranch: "main"},
+		}
+		// Push over HTTPS+PAT — proves the push side of the transport.
+		if err := g.Push(cfg, dstProject.Name, sourceRepo, "main", true, dstProject); err != nil {
+			t.Fatalf("Push over HTTPS failed: %v", err)
+		}
+
+		// The README the source was initialized with must now be in the target.
+		file, _, err := client.RepositoryFiles.GetFile(dstProject.ID, "README.md",
+			&gitlabapi.GetFileOptions{Ref: gitlabapi.Ptr("main")})
+		if err != nil {
+			t.Fatalf("reading pushed file back failed: %v", err)
+		}
+		if file.FileName != "README.md" {
+			t.Errorf("pushed file = %q, want README.md", file.FileName)
 		}
 	})
 

--- a/gitlab/issues.go
+++ b/gitlab/issues.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/issues_contract_test.go
+++ b/gitlab/issues_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/projects.go
+++ b/gitlab/projects.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/projects_contract_test.go
+++ b/gitlab/projects_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
 func TestGetProjectByName_FindsSingleProject(t *testing.T) {

--- a/gitlab/protect.go
+++ b/gitlab/protect.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
@@ -68,7 +68,7 @@ func (c *Client) protectBranchForMemberCount(assignmentCfg *config.AssignmentCon
 
 	log.Debug().
 		Str("name", project.Name).
-		Str("toURL", project.SSHURLToRepo).
+		Str("toURL", project.HTTPURLToRepo).
 		Interface("branches", assignmentCfg.Branches).
 		Msg("protecting branch")
 
@@ -163,7 +163,7 @@ func (c *Client) protectSingleBranch(
 		if err != nil {
 			log.Debug().Err(err).
 				Str("name", project.Name).
-				Str("toURL", project.SSHURLToRepo).
+				Str("toURL", project.HTTPURLToRepo).
 				Str("branch", branch.Name).
 				Msg("cannot update protected branch")
 			return fmt.Errorf("error while trying to update protected branch %s: %w", branch.Name, err)
@@ -175,7 +175,7 @@ func (c *Client) protectSingleBranch(
 	if !isProtectedBranchNotFoundError(err) {
 		log.Debug().Err(err).
 			Str("name", project.Name).
-			Str("toURL", project.SSHURLToRepo).
+			Str("toURL", project.HTTPURLToRepo).
 			Str("branch", branch.Name).
 			Msg("cannot read protected branch")
 		return fmt.Errorf("error while trying to read protected branch %s: %w", branch.Name, err)
@@ -198,7 +198,7 @@ func (c *Client) recreateProtectedBranch(
 	if err != nil && !isProtectedBranchNotFoundError(err) {
 		log.Debug().Err(err).
 			Str("name", project.Name).
-			Str("toURL", project.SSHURLToRepo).
+			Str("toURL", project.HTTPURLToRepo).
 			Str("branch", branch.Name).
 			Msg("cannot unprotect branch")
 		return fmt.Errorf("error while trying to unprotect branch %s: %w", branch.Name, err)
@@ -217,7 +217,7 @@ func (c *Client) recreateProtectedBranch(
 	if err != nil {
 		log.Debug().Err(err).
 			Str("name", project.Name).
-			Str("toURL", project.SSHURLToRepo).
+			Str("toURL", project.HTTPURLToRepo).
 			Str("branch", branch.Name).
 			Msg("error while protecting branch")
 		return fmt.Errorf("error while trying to protect branch %s: %w", branch.Name, err)

--- a/gitlab/protect_contract_test.go
+++ b/gitlab/protect_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/push.go
+++ b/gitlab/push.go
@@ -3,8 +3,8 @@ package gitlab
 import (
 	"fmt"
 
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/git"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/git"
 )
 
 func (c *Client) Push(assignmentCfg *config.AssignmentConfig, branchname string) error {

--- a/gitlab/report.go
+++ b/gitlab/report.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/obcode/glabs/v2/config"
-	r "github.com/obcode/glabs/v2/gitlab/report"
+	"github.com/obcode/glabs/v3/config"
+	r "github.com/obcode/glabs/v3/gitlab/report"
 )
 
 func (c *Client) Report(assignmentCfg *config.AssignmentConfig, templateFile *string, output *string) {

--- a/gitlab/report_contract_test.go
+++ b/gitlab/report_contract_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
 // makeFullReportHandler returns a handler that mocks all calls needed by report().

--- a/gitlab/report_helper.go
+++ b/gitlab/report_helper.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/gitlab/report"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab/report"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"

--- a/gitlab/report_helper_contract_test.go
+++ b/gitlab/report_helper_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 

--- a/gitlab/runtime_test.go
+++ b/gitlab/runtime_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/spf13/viper"
 )
 

--- a/gitlab/seeder.go
+++ b/gitlab/seeder.go
@@ -12,8 +12,9 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	cfg "github.com/obcode/glabs/v2/config"
-	g "github.com/obcode/glabs/v2/git"
+	"github.com/logrusorgru/aurora"
+	cfg "github.com/obcode/glabs/v3/config"
+	g "github.com/obcode/glabs/v3/git"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
@@ -24,6 +25,12 @@ func localpath(cfg *cfg.AssignmentConfig, project string) string {
 
 func (c *Client) runSeeder(assignmentCfg *cfg.AssignmentConfig, project *gitlab.Project) error {
 
+	// Deprecated. The seeder runs an arbitrary command from the config file; in a
+	// shared/web context that is remote code execution, so it will not be offered
+	// there and is slated for removal from the CLI too. No course file uses it.
+	fmt.Fprintln(os.Stderr, aurora.Yellow(
+		"warning: the seeder is deprecated and will be removed in a future release"))
+
 	path := localpath(assignmentCfg, project.Name)
 
 	err := os.Mkdir(path, 0755)
@@ -33,10 +40,16 @@ func (c *Client) runSeeder(assignmentCfg *cfg.AssignmentConfig, project *gitlab.
 		return err
 	}
 	path, _ = filepath.Abs(path)
-	args := assignmentCfg.Seeder.Args
-	for index, item := range assignmentCfg.Seeder.Args {
+
+	// Copy rather than write back into assignmentCfg.Seeder.Args: the same config
+	// is reused for every project in the per-student/per-group loop, and
+	// substituting %s in place would consume the placeholder after the first one.
+	args := make([]string, len(assignmentCfg.Seeder.Args))
+	for i, item := range assignmentCfg.Seeder.Args {
 		if strings.Count(item, "%s") == 1 {
-			args[index] = fmt.Sprintf(item, path)
+			args[i] = fmt.Sprintf(item, path)
+		} else {
+			args[i] = item
 		}
 	}
 
@@ -143,13 +156,13 @@ func push(assignmentCfg *cfg.AssignmentConfig, repo *git.Repository, wtree *git.
 
 	conf := &config.RemoteConfig{
 		Name: project.Name,
-		URLs: []string{project.SSHURLToRepo},
+		URLs: []string{project.HTTPURLToRepo},
 	}
 
 	remote, err := repo.CreateRemote(conf)
 	if err != nil {
 		log.Debug().Err(err).
-			Str("name", project.Name).Str("url", project.SSHURLToRepo).
+			Str("name", project.Name).Str("url", project.HTTPURLToRepo).
 			Msg("cannot create remote")
 		return fmt.Errorf("cannot create remote: %w", err)
 	}
@@ -160,7 +173,7 @@ func push(assignmentCfg *cfg.AssignmentConfig, repo *git.Repository, wtree *git.
 	log.Debug().
 		Str("refSpec", string(refSpec)).
 		Str("name", project.Name).
-		Str("toURL", project.SSHURLToRepo).
+		Str("toURL", project.HTTPURLToRepo).
 		Str("toBranch", assignmentCfg.Seeder.ToBranch).
 		Msg("pushing seeded repository")
 
@@ -172,7 +185,7 @@ func push(assignmentCfg *cfg.AssignmentConfig, repo *git.Repository, wtree *git.
 	err = repo.Push(pushOpts)
 	if err != nil {
 		log.Debug().Err(err).
-			Str("name", project.Name).Str("url", project.SSHURLToRepo).
+			Str("name", project.Name).Str("url", project.HTTPURLToRepo).
 			Msg("cannot push to remote")
 		return fmt.Errorf("cannot push to remote: %w", err)
 	}

--- a/gitlab/setaccess.go
+++ b/gitlab/setaccess.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"

--- a/gitlab/setaccess_contract_test.go
+++ b/gitlab/setaccess_contract_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
 // ---- Setaccess (top-level) --------------------------------------------------

--- a/gitlab/starterrepo.go
+++ b/gitlab/starterrepo.go
@@ -7,8 +7,8 @@ import (
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	cfg "github.com/obcode/glabs/v2/config"
-	g "github.com/obcode/glabs/v2/git"
+	cfg "github.com/obcode/glabs/v3/config"
+	g "github.com/obcode/glabs/v3/git"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
@@ -16,13 +16,13 @@ import (
 func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.SourceRepo, project *gitlab.Project) error {
 	conf := &config.RemoteConfig{
 		Name: project.Name,
-		URLs: []string{project.SSHURLToRepo},
+		URLs: []string{project.HTTPURLToRepo},
 	}
 
 	remote, err := from.Repo.CreateRemote(conf)
 	if err != nil {
 		log.Debug().Err(err).
-			Str("name", project.Name).Str("url", project.SSHURLToRepo).
+			Str("name", project.Name).Str("url", project.HTTPURLToRepo).
 			Msg("cannot create remote")
 		return fmt.Errorf("cannot create remote: %w", err)
 	}
@@ -36,7 +36,7 @@ func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.So
 	log.Debug().
 		Str("refSpec", string(refSpec)).
 		Str("name", project.Name).
-		Str("toURL", project.SSHURLToRepo).
+		Str("toURL", project.HTTPURLToRepo).
 		Str("fromBranch", from.Ref.Short()).
 		Str("toBranch", assignmentCfg.Startercode.ToBranch).
 		Msg("pushing starter code")
@@ -49,7 +49,7 @@ func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.So
 	err = from.Repo.Push(pushOpts)
 	if err != nil {
 		log.Debug().Err(err).
-			Str("name", project.Name).Str("url", project.SSHURLToRepo).
+			Str("name", project.Name).Str("url", project.HTTPURLToRepo).
 			Msg("cannot push to remote")
 		return fmt.Errorf("cannot push to remote: %w", err)
 	}
@@ -70,7 +70,7 @@ func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.So
 		log.Debug().
 			Str("refSpec", string(tagRefSpec)).
 			Str("name", project.Name).
-			Str("toURL", project.SSHURLToRepo).
+			Str("toURL", project.HTTPURLToRepo).
 			Str("tag", tagName).
 			Msg("pushing startercode tag")
 
@@ -94,7 +94,7 @@ func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.So
 		log.Debug().
 			Str("refSpec", string(refSpec)).
 			Str("name", project.Name).
-			Str("toURL", project.SSHURLToRepo).
+			Str("toURL", project.HTTPURLToRepo).
 			Str("branch", additionalBranch).
 			Msg("pushing additional startercode branch")
 
@@ -109,7 +109,7 @@ func (c *Client) pushStartercode(assignmentCfg *cfg.AssignmentConfig, from *g.So
 				Str("branch", additionalBranch).
 				Str("refSpec", refSpec.String()).
 				Str("name", project.Name).
-				Str("url", project.SSHURLToRepo).
+				Str("url", project.HTTPURLToRepo).
 				Msg("cannot push additional branch to remote, continuing with other setup steps")
 			continue
 		}

--- a/gitlab/update.go
+++ b/gitlab/update.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/obcode/glabs/v2/config"
-	"github.com/obcode/glabs/v2/git"
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/git"
 	"github.com/rs/zerolog/log"
 	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"

--- a/gitlab/update_contract_test.go
+++ b/gitlab/update_contract_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
 // ---- Update (top-level) -----------------------------------------------------

--- a/gitlab/users.go
+++ b/gitlab/users.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )

--- a/gitlab/users_contract_test.go
+++ b/gitlab/users_contract_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/obcode/glabs/v2/config"
+	"github.com/obcode/glabs/v3/config"
 )
 
 // ---- getUser ----------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/obcode/glabs/v2
+module github.com/obcode/glabs/v3
 
 go 1.26
 
@@ -7,6 +7,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/go-viper/mapstructure/v2 v2.4.0
+	github.com/google/go-cmp v0.7.0
 	github.com/gookit/color v1.6.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/logrusorgru/aurora/v4 v4.0.0
@@ -19,6 +20,7 @@ require (
 	gitlab.com/gitlab-org/api/client-go/v2 v2.20.1
 	golang.org/x/term v0.42.0
 	golang.org/x/text v0.35.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -48,7 +50,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -106,5 +107,4 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/obcode/glabs/v2/cmd"
+	"github.com/obcode/glabs/v3/cmd"
 	"github.com/spf13/viper"
 )
 


### PR DESCRIPTION
Schritt 3 des glabs-web-Plans — **der Breaking Change (v3.0.0)**. Der einzige Bruch, den Du nach außen kommunizierst.

## Was sich ändert

glabs authentifizierte die API mit einem Token und git mit einem **separaten SSH-Key** (`sshprivatekey`). Jetzt ist alles der Token, über HTTPS: ein Credential, ein Transport — und, der eigentliche Grund, derselbe in CLI und kommendem Web-Server, wo ein Per-User-SSH-Key eine geteilte Identität mit Zugriff auf *jedes* Nutzer-Repo wäre.

**Deine Kursdateien bleiben unverändert.** Startercode- und `deferredBranches`-URLs in SSH-Notation (`git@host:path.git`) bleiben gültig — sie werden beim Auflösen nach HTTPS normalisiert.

## Der Cross-Host-Verlust (danke @obraun für den Hinweis)

Das ist die eine Fähigkeit, die SSH hatte und HTTPS nicht: Startercode von einem **anderen Host**. Unter SSH ging alles, wozu der Key des Operators Zugriff hatte.

Beim ersten Umsetzen hatte ich es **falsch** — und das ist erwähnenswert: die erste Fassung hängte den PAT an *jeden* Clone, hätte also Deinen GitLab-Token als HTTP-Passwort an `github.com` & Co. geschickt. Funktional kaputt *und* ein Token-Leak.

`AuthForURL` hängt den Token jetzt **nur für die konfigurierte GitLab-Instanz** an:

| Startercode-/deferredBranch-Host | Verhalten |
|---|---|
| Deine GitLab-Instanz | PAT → funktioniert |
| **öffentliches** Repo, anderer Host | kein Credential nötig → funktioniert weiter |
| **privates** Repo, anderer Host | klare „authentication required", Token wird *nicht* geleakt |

Deckt Startercode **und** deferredBranches ab, weil beide über `PrepareSourceRepo` klonen. Wer privaten Fremdhost-Startercode nutzt: in die GitLab-Instanz spiegeln.

## Gegen echtes GitLab bewiesen

Der Git-Transport hatte **null** Integrationsabdeckung — die bestehenden Tests fassen nur die API an. Ein neuer Subtest `GitTransportOverHTTPS` klont ein Projekt und pusht es über HTTPS+PAT in ein zweites, dann liest er die Datei über die API zurück. Läuft grün gegen GitLab CE (`--- PASS: GitTransportOverHTTPS (3.64s)`). Der Test-Token-Scope bekommt `write_repository`, das echte Tokens jetzt auch brauchen.

Zusätzlich in der Praxis bestätigt: `go run . generate mpd blatt12 oliver.braun` gegen echtes GitLab hat funktioniert.

## Nebenbei mit drin

- **`$HOME`-Regression gefixt** (aus dem Config-Umbau in #79): Kursdateien liefen nicht mehr durch vipers Config-Path-Loader, der `$HOME`/`~` implizit expandierte — ein `coursesfilepath: $HOME/courses` wurde wörtlich genommen. `findCourseFile` expandiert es jetzt, mit Regressionstest.
- **Seeder deprecated**: stderr-Warnung beim Ausführen, `lint`-Finding, und Fix seines In-place-Bugs (die `%s`-Substitution überschrieb `Seeder.Args`, fraß den Platzhalter beim zweiten Repo der Schleife).

## Der `/v3`-Modulpfad

go verlangt für v2+ den Major-Suffix im Modulpfad; go-semantic-release taggt nur, es fasst `go.mod` nicht an. Deshalb hier: `go.mod` → `/v3`, alle internen Importe (54 Dateien), README + Doku-Installationspfad.

## Verifikation

- `go test ./...` grün; `gofmt`, `go vet`, `golangci-lint` sauber
- Integration gegen GitLab CE: `GitTransportOverHTTPS` PASS
- host-aware Auth: Unit-Tests für GitLab-Host (PAT) vs. Fremdhost (nil, kein Leak)
- `$HOME`/`~`/env-Expansion: Test + am echten CLI verifiziert
- `golang.org/x/crypto` von direkter zu indirekter Dependency (SSH raus)

**BREAKING CHANGE** — Migrationsschritte in `docs/migration.md`:
1. Token braucht Scope `write_repository` zusätzlich zu `api`
2. `sshprivatekey` aus der Config entfernen (wird ignoriert)
3. Reinstall: `go install github.com/obcode/glabs/v3@latest`
4. Privater Startercode auf Fremdhost → in die GitLab-Instanz spiegeln

🤖 Generated with [Claude Code](https://claude.com/claude-code)