### PR TITLE
refactor(gitlab): construct the client via options instead of global viper

### DIFF
--- a/cmd/addgroupguests.go
+++ b/cmd/addgroupguests.go
@@ -66,7 +66,10 @@ Example:
 		fmt.Println(aurora.Magenta("Add these students as guests to the subgroup? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck
 
-		c := gitlab.NewClient()
+		c, err := gitlab.NewClientFromViper()
+		if err != nil {
+			er(err)
+		}
 		err = c.AddGroupGuests(courseName)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -28,7 +28,10 @@ var (
 			assignmentConfig.Show()
 			fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 			fmt.Scanln() //nolint:errcheck
-			c := gitlab.NewClient()
+			c, err := gitlab.NewClientFromViper()
+			if err != nil {
+				er(err)
+			}
 			c.Archive(assignmentConfig, unarchive)
 		},
 	}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -18,7 +18,10 @@ var checkCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		viper.Set("show-success", true)
-		c := gitlab.NewClient()
+		c, err := gitlab.NewClientFromViper()
+		if err != nil {
+			er(err)
+		}
 		if len(args) == 1 {
 			cfg, err := config.GetCourseConfig(args[0])
 			if err != nil {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,7 +27,10 @@ You can specify students or groups in order to delete only for these.`,
 		assignmentConfig.Show()
 		fmt.Println(aurora.Magenta("Do you really want to delete the repos? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck
-		c := gitlab.NewClient()
+		c, err := gitlab.NewClientFromViper()
+		if err != nil {
+			er(err)
+		}
 		c.Delete(assignmentConfig)
 	},
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -28,7 +28,10 @@ A student needs to exist on GitLab, a group needs to exist in the configuration 
 		assignmentConfig.Show()
 		fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck
-		c := gitlab.NewClient()
+		c, err := gitlab.NewClientFromViper()
+		if err != nil {
+			er(err)
+		}
 		c.Generate(assignmentConfig)
 	},
 }

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -31,7 +31,10 @@ var (
 			assignmentConfig.Show()
 			fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 			fmt.Scanln() //nolint:errcheck
-			c := gitlab.NewClient()
+			c, err := gitlab.NewClientFromViper()
+			if err != nil {
+				er(err)
+			}
 			c.ProtectToBranch(assignmentConfig)
 		},
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -27,7 +27,10 @@ var pushCmd = &cobra.Command{
 		assignmentConfig.Show()
 		fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck
-		c := gitlab.NewClient()
+		c, err := gitlab.NewClientFromViper()
+		if err != nil {
+			er(err)
+		}
 		err = c.Push(assignmentConfig, branchname)
 		if err != nil {
 			fmt.Printf("error: %s", err.Error())

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -67,7 +67,10 @@ var (
 			if err != nil {
 				er(err)
 			}
-			c := gitlab.NewClient()
+			c, err := gitlab.NewClientFromViper()
+			if err != nil {
+				er(err)
+			}
 			if Json {
 				c.ReportJSON(assignmentConfig, output)
 			} else if Html {

--- a/cmd/setaccess.go
+++ b/cmd/setaccess.go
@@ -31,7 +31,10 @@ var (
 			assignmentConfig.Show()
 			fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 			fmt.Scanln() //nolint:errcheck
-			c := gitlab.NewClient()
+			c, err := gitlab.NewClientFromViper()
+			if err != nil {
+				er(err)
+			}
 			c.Setaccess(assignmentConfig)
 		},
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -30,7 +30,10 @@ var updateCmd = &cobra.Command{
 		fmt.Println(aurora.Red("Heads up! Use only with untouched projects."))
 		fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck
-		c := gitlab.NewClient()
+		c, err := gitlab.NewClientFromViper()
+		if err != nil {
+			er(err)
+		}
 		c.Update(assignmentConfig)
 	},
 }

--- a/gitlab/contract_test_helpers_test.go
+++ b/gitlab/contract_test_helpers_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
 func newContractClient(t *testing.T, handler http.HandlerFunc) *Client {
@@ -14,16 +12,18 @@ func newContractClient(t *testing.T, handler http.HandlerFunc) *Client {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	// Use a plain http.Client without the retryable wrapper so that 5xx
-	// responses from mock servers do not trigger retries and cause test hangs.
-	apiClient, err := gitlabapi.NewClient("token",
-		gitlabapi.WithBaseURL(server.URL+"/api/v4"),
-		gitlabapi.WithHTTPClient(&http.Client{}),
-		gitlabapi.WithoutRetries(),
+	// Disable retries so a mocked 5xx returns immediately instead of retrying
+	// with backoff. This goes through the real constructor now — driving it with
+	// injected options is exactly why the DI exists.
+	client, err := NewClient(
+		WithHost(server.URL+"/api/v4"),
+		WithToken("token"),
+		WithHTTPClient(&http.Client{}),
+		WithoutRetries(),
 	)
 	if err != nil {
 		t.Fatalf("creating gitlab test client failed: %v", err)
 	}
 
-	return &Client{apiClient}
+	return client
 }

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -1,6 +1,9 @@
 package gitlab
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
@@ -10,15 +13,72 @@ type Client struct {
 	*gitlab.Client
 }
 
-func NewClient() *Client {
-	log.Debug().Str("gitlab.host", viper.GetString("gitlab.host")).Msg("connecting to gitlab server")
+// clientOptions holds what a Client needs to reach GitLab. They are injected
+// rather than read from the global viper config, so the web server can build one
+// client per user with that user's token — a package-global token cannot serve
+// multiple users. The CLI keeps its single-token behaviour via NewClientFromViper.
+type clientOptions struct {
+	host           string
+	token          string
+	httpClient     *http.Client
+	withoutRetries bool
+}
 
-	client, err := gitlab.NewClient(viper.GetString("gitlab.token"),
-		gitlab.WithBaseURL(viper.GetString("gitlab.host")))
+type Option func(*clientOptions)
 
-	if err != nil {
-		panicFunc("cannot create a gitlab client")
+func WithHost(host string) Option   { return func(o *clientOptions) { o.host = host } }
+func WithToken(token string) Option { return func(o *clientOptions) { o.token = token } }
+
+// WithHTTPClient injects the underlying HTTP client.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(o *clientOptions) { o.httpClient = hc }
+}
+
+// WithoutRetries disables the client's retry-on-5xx wrapper. The contract tests
+// use it so a mocked 5xx returns immediately instead of retrying with backoff.
+func WithoutRetries() Option {
+	return func(o *clientOptions) { o.withoutRetries = true }
+}
+
+// NewClient builds a GitLab client from the given options. host and token are
+// required; a bad configuration is an error rather than a panic, so a server can
+// report it instead of dying.
+func NewClient(opts ...Option) (*Client, error) {
+	o := &clientOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	if o.host == "" {
+		return nil, fmt.Errorf("gitlab host is required")
+	}
+	if o.token == "" {
+		return nil, fmt.Errorf("gitlab token is required")
 	}
 
-	return &Client{client}
+	log.Debug().Str("gitlab.host", o.host).Msg("connecting to gitlab server")
+
+	clientOpts := []gitlab.ClientOptionFunc{gitlab.WithBaseURL(o.host)}
+	if o.httpClient != nil {
+		clientOpts = append(clientOpts, gitlab.WithHTTPClient(o.httpClient))
+	}
+	if o.withoutRetries {
+		clientOpts = append(clientOpts, gitlab.WithoutRetries())
+	}
+
+	client, err := gitlab.NewClient(o.token, clientOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create a gitlab client: %w", err)
+	}
+
+	return &Client{client}, nil
+}
+
+// NewClientFromViper builds a client from the global config. It is the CLI's
+// entry point, keeping the single-token model; the web server uses NewClient
+// with a per-user token instead.
+func NewClientFromViper() (*Client, error) {
+	return NewClient(
+		WithHost(viper.GetString("gitlab.host")),
+		WithToken(viper.GetString("gitlab.token")),
+	)
 }

--- a/gitlab/runtime_test.go
+++ b/gitlab/runtime_test.go
@@ -28,15 +28,6 @@ func withExitCapture(t *testing.T) func() {
 	}
 }
 
-func withPanicCapture(t *testing.T, fn func(v interface{})) func() {
-	t.Helper()
-	origPanic := panicFunc
-	panicFunc = fn
-	return func() {
-		panicFunc = origPanic
-	}
-}
-
 func assertExitCode(t *testing.T, expected int, fn func()) {
 	t.Helper()
 	defer func() {
@@ -102,26 +93,33 @@ func TestProtectToBranch_UsesExitSeamForInvalidPer(t *testing.T) {
 	})
 }
 
-func TestNewClient_UsesPanicSeamOnInvalidBaseURL(t *testing.T) {
-	triggered := false
-	defer withPanicCapture(t, func(v interface{}) {
-		triggered = true
-		panic(v)
-	})()
+func TestNewClientReturnsErrorOnInvalidBaseURL(t *testing.T) {
+	_, err := NewClient(WithHost("://invalid-base-url"), WithToken("token"))
+	if err == nil {
+		t.Fatal("expected an error for an invalid GitLab base URL")
+	}
+}
+
+func TestNewClientRequiresHostAndToken(t *testing.T) {
+	if _, err := NewClient(WithToken("token")); err == nil {
+		t.Error("NewClient without a host succeeded, want an error")
+	}
+	if _, err := NewClient(WithHost("https://gitlab.example.org")); err == nil {
+		t.Error("NewClient without a token succeeded, want an error")
+	}
+}
+
+func TestNewClientFromViper(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()
-	viper.Set("gitlab.host", "://invalid-base-url")
-	viper.Set("gitlab.token", "token")
+	viper.Set("gitlab.host", "https://gitlab.example.org")
+	viper.Set("gitlab.token", "glpat-secret")
 
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected panic on invalid GitLab base URL")
-		}
-		if !triggered {
-			t.Fatal("expected panic to pass through panicFunc seam")
-		}
-	}()
-
-	_ = NewClient()
+	c, err := NewClientFromViper()
+	if err != nil {
+		t.Fatalf("NewClientFromViper: %v", err)
+	}
+	if c == nil || c.Client == nil {
+		t.Fatal("NewClientFromViper returned an empty client")
+	}
 }


### PR DESCRIPTION
Schritt 4 des glabs-web-Plans. Vorletzter interner Schritt — `refactor:`, also **kein Release-Bump**.

## Warum

`NewClient()` las Host und Token direkt aus dem globalen viper und panickte bei Fehlern. Für ein Single-Token-CLI in Ordnung, für den Web-Server unmöglich: dort handelt jeder Request als anderer Nutzer mit anderem Token — ein paket-globaler Token kann die nicht bedienen.

## Was sich ändert

`NewClient` nimmt jetzt funktionale Options (`WithHost`, `WithToken`, `WithHTTPClient`, `WithoutRetries`) und gibt einen **error** zurück. Das CLI behält sein Verhalten über `NewClientFromViper` — die einzige Stelle, die noch viper liest. Jeder der 11 Befehle ruft die und meldet den Fehler über `er()` statt zu panicken:

```
$ glabs check mpd   # ohne Token
Error: gitlab token is required
```

statt eines Stacktraces.

## Der Contract-Helper beweist die DI

`newContractClient` baute den `*Client` bisher von Hand neben dem echten Konstruktor. Jetzt geht er durch `NewClient`, getrieben von `WithHTTPClient` + `WithoutRetries`. Genau dieser injizierte HTTP-Client ist der Daseinsgrund der DI — die Tests exerzieren jetzt den Produktivpfad.

`WithoutRetries` ist dabei nicht kosmetisch: ohne es retryt ein gemocktes 5xx mit Backoff, und das gitlab-Paket ging von ~1s auf **~36s**. Mit der Option wieder 0,7s.

## Bewusster Schnitt

Nur der Konstruktor. Die exit/panic-Seams *innerhalb* der Operations-Methoden (`report.go` nutzt noch `panicFunc`, ein Dutzend Methoden rufen `exitFunc`) bleiben Schritt 5 (Reporter) vorbehalten — dort werden Ausgabe und Terminierung einer Methode *gemeinsam* umgebaut, statt hier stückweise.

## Verifikation

- `go test ./...` grün (inkl. `-race` im config-Paket); `gofmt`, `go vet`, `golangci-lint` sauber
- gitlab-Paket wieder bei 0,7s statt 36s (Retries in Tests aus)
- CLI: fehlender Token → sauberer Fehler statt Panic
- Unit-Tests für `NewClient` (Host/Token erforderlich, ungültige URL → Fehler) und `NewClientFromViper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)