### PR TITLE
refactor(reporter): route CLI output through a reporter, methods return errors

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -32,7 +32,9 @@ var (
 			if err != nil {
 				er(err)
 			}
-			c.Archive(assignmentConfig, unarchive)
+			if err := c.Archive(assignmentConfig, unarchive); err != nil {
+				er(err)
+			}
 		},
 	}
 	unarchive bool

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -25,7 +25,7 @@ var (
 			if err != nil {
 				er(err)
 			}
-			assignmentConfig.Show()
+			fmt.Println(assignmentConfig.Show())
 			fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 			fmt.Scanln() //nolint:errcheck
 			c, err := gitlab.NewClientFromViper()

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -6,6 +6,7 @@ import (
 	"github.com/logrusorgru/aurora/v4"
 	"github.com/obcode/glabs/v3/config"
 	"github.com/obcode/glabs/v3/git"
+	"github.com/obcode/glabs/v3/reporter"
 	"github.com/spf13/cobra"
 )
 
@@ -31,12 +32,17 @@ var (
 				assignmentConfig.SetForce()
 			}
 			if !Suppress {
-				assignmentConfig.Show()
+				fmt.Println(assignmentConfig.Show())
 				fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 				fmt.Scanln() //nolint:errcheck
 			}
 
-			git.Clone(assignmentConfig, Suppress)
+			// --suppress: no spinners, only the machine-readable paths for piping.
+			var rep reporter.Reporter = reporter.NewConsoleReporter()
+			if Suppress {
+				rep = reporter.NewDiscardReporter()
+			}
+			git.Clone(rep, assignmentConfig)
 		},
 	}
 	Localpath string

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -31,6 +31,8 @@ You can specify students or groups in order to delete only for these.`,
 		if err != nil {
 			er(err)
 		}
-		c.Delete(assignmentConfig)
+		if err := c.Delete(assignmentConfig); err != nil {
+			er(err)
+		}
 	},
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -24,7 +24,7 @@ You can specify students or groups in order to delete only for these.`,
 		if err != nil {
 			er(err)
 		}
-		assignmentConfig.Show()
+		fmt.Println(assignmentConfig.Show())
 		fmt.Println(aurora.Magenta("Do you really want to delete the repos? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck
 		c, err := gitlab.NewClientFromViper()

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -32,6 +32,8 @@ A student needs to exist on GitLab, a group needs to exist in the configuration 
 		if err != nil {
 			er(err)
 		}
-		c.Generate(assignmentConfig)
+		if err := c.Generate(assignmentConfig); err != nil {
+			er(err)
+		}
 	},
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -25,7 +25,7 @@ A student needs to exist on GitLab, a group needs to exist in the configuration 
 		if err != nil {
 			er(err)
 		}
-		assignmentConfig.Show()
+		fmt.Println(assignmentConfig.Show())
 		fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck
 		c, err := gitlab.NewClientFromViper()

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -28,7 +28,7 @@ var (
 			if len(ProtectBranch) > 0 {
 				assignmentConfig.SetProtectToBranch(ProtectBranch)
 			}
-			assignmentConfig.Show()
+			fmt.Println(assignmentConfig.Show())
 			fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 			fmt.Scanln() //nolint:errcheck
 			c, err := gitlab.NewClientFromViper()

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -35,7 +35,9 @@ var (
 			if err != nil {
 				er(err)
 			}
-			c.ProtectToBranch(assignmentConfig)
+			if err := c.ProtectToBranch(assignmentConfig); err != nil {
+				er(err)
+			}
 		},
 	}
 	ProtectBranch string

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -24,7 +24,7 @@ var pushCmd = &cobra.Command{
 		if err != nil {
 			er(err)
 		}
-		assignmentConfig.Show()
+		fmt.Println(assignmentConfig.Show())
 		fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck
 		c, err := gitlab.NewClientFromViper()

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -72,11 +72,17 @@ var (
 				er(err)
 			}
 			if Json {
-				c.ReportJSON(assignmentConfig, output)
+				if err := c.ReportJSON(assignmentConfig, output); err != nil {
+					er(err)
+				}
 			} else if Html {
-				c.ReportHTML(assignmentConfig, template, output)
+				if err := c.ReportHTML(assignmentConfig, template, output); err != nil {
+					er(err)
+				}
 			} else {
-				c.Report(assignmentConfig, template, output)
+				if err := c.Report(assignmentConfig, template, output); err != nil {
+					er(err)
+				}
 			}
 		}}
 	Html           bool

--- a/cmd/setaccess.go
+++ b/cmd/setaccess.go
@@ -28,7 +28,7 @@ var (
 			if len(Level) > 0 {
 				assignmentConfig.SetAccessLevel(Level)
 			}
-			assignmentConfig.Show()
+			fmt.Println(assignmentConfig.Show())
 			fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 			fmt.Scanln() //nolint:errcheck
 			c, err := gitlab.NewClientFromViper()

--- a/cmd/setaccess.go
+++ b/cmd/setaccess.go
@@ -35,7 +35,9 @@ var (
 			if err != nil {
 				er(err)
 			}
-			c.Setaccess(assignmentConfig)
+			if err := c.Setaccess(assignmentConfig); err != nil {
+				er(err)
+			}
 		},
 	}
 	Level string

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/obcode/glabs/v3/config"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +21,6 @@ var showConfigCmd = &cobra.Command{
 		if err != nil {
 			er(err)
 		}
-		cfg.Show()
+		fmt.Println(cfg.Show())
 	},
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -26,7 +26,7 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			er(err)
 		}
-		assignmentConfig.Show()
+		fmt.Println(assignmentConfig.Show())
 		fmt.Println(aurora.Red("Heads up! Use only with untouched projects."))
 		fmt.Println(aurora.Magenta("Config okay? Press 'Enter' to continue or 'Ctrl-C' to stop ..."))
 		fmt.Scanln() //nolint:errcheck

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -34,6 +34,8 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			er(err)
 		}
-		c.Update(assignmentConfig)
+		if err := c.Update(assignmentConfig); err != nil {
+			er(err)
+		}
 	},
 }

--- a/config/show.go
+++ b/config/show.go
@@ -7,7 +7,11 @@ import (
 	"github.com/logrusorgru/aurora/v4"
 )
 
-func (cfg *AssignmentConfig) Show() {
+// Show renders the resolved assignment configuration as a colored, human-
+// readable document and returns it. It returns the string rather than printing,
+// so the CLI writes it to stdout while the web server can send the same rendering
+// to the browser; config stays free of any opinion about where output goes.
+func (cfg *AssignmentConfig) Show() string {
 	var out strings.Builder
 
 	maxLabelWidth := func(labels ...string) int {
@@ -367,5 +371,5 @@ func (cfg *AssignmentConfig) Show() {
 		}
 	}
 
-	fmt.Println(out.String())
+	return out.String()
 }

--- a/config/urls_show_test.go
+++ b/config/urls_show_test.go
@@ -116,7 +116,7 @@ func TestShow_WithStartercode_AdditionalBranches(t *testing.T) {
 			AdditionalBranches: []string{"solution", "startercode"},
 		},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "AdditionalBranches") || !strings.Contains(out, "solution") {
 		t.Fatalf("Show() output does not contain startercode additional branches: %q", out)
 	}
@@ -157,7 +157,7 @@ func TestShow_WithBranches(t *testing.T) {
 	cfg := &AssignmentConfig{
 		Branches: []BranchRule{{Name: "main", Protect: true, Default: true, AllowForcePush: true}, {Name: "develop", MergeOnly: true, CodeOwnerApprovalRequired: true}},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	plain := ansiPattern.ReplaceAllString(out, "")
 	if !strings.Contains(out, "Branches:") || !strings.Contains(out, "develop") {
@@ -235,7 +235,7 @@ func TestShow_OutputContainsCourseName(t *testing.T) {
 		Course: "mpd",
 		Name:   "blatt01",
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "mpd") {
 		t.Fatalf("Show() output does not contain course name %q: %q", "mpd", out)
 	}
@@ -253,7 +253,7 @@ func TestShow_PerStudent_ListsStudents(t *testing.T) {
 			{Username: &bob, Raw: "bob"},
 		},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "alice") {
 		t.Fatalf("Show(PerStudent) output does not contain student alice: %q", out)
 	}
@@ -274,7 +274,7 @@ func TestShow_PerGroup_ListsGroups(t *testing.T) {
 			{Name: "team2", Members: []*Student{{Username: &alice, Raw: "carol"}}},
 		},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "team1") {
 		t.Fatalf("Show(PerGroup) output does not contain team1: %q", out)
 	}
@@ -292,7 +292,7 @@ func TestShow_WithMergeMethod(t *testing.T) {
 	cfg := &AssignmentConfig{
 		MergeRequest: &MergeRequest{MergeMethod: SemiLinearHistory},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "MergeRequest:") {
 		t.Fatalf("Show() output does not contain MergeRequest header: %q", out)
 	}
@@ -308,7 +308,7 @@ func TestShow_WithSquashOption(t *testing.T) {
 	cfg := &AssignmentConfig{
 		MergeRequest: &MergeRequest{MergeMethod: MergeCommit, SquashOption: SquashAlways},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "SquashOption:") {
 		t.Fatalf("Show() output does not contain SquashOption key: %q", out)
 	}
@@ -328,7 +328,7 @@ func TestShow_WithMergeChecks(t *testing.T) {
 			StatusChecksMustSucceed:       true,
 		},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "PipelineMustSucceed:") || !strings.Contains(out, "true") {
 		t.Fatalf("Show() output does not contain PipelineMustSucceed=true: %q", out)
 	}
@@ -356,7 +356,7 @@ func TestShow_WithMergeRequestApprovals(t *testing.T) {
 			}},
 		},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	plain := ansiPattern.ReplaceAllString(out, "")
 	if !strings.Contains(out, "Approvals:") {
@@ -400,7 +400,7 @@ func TestShow_WithMergeRequestApprovals_OmitsEmptyUsersAndGroups(t *testing.T) {
 			}},
 		},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if strings.Contains(out, "usernames") {
 		t.Fatalf("Show() output should omit empty usernames field for approval rule: %q", out)
 	}
@@ -430,7 +430,7 @@ func TestShow_WithMergeRequestApprovalSettings(t *testing.T) {
 			},
 		},
 	}
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "Approvals:") || !strings.Contains(out, "Settings:") {
 		t.Fatalf("Show() output does not contain nested approvals settings block: %q", out)
 	}
@@ -447,7 +447,7 @@ func TestShow_WithUndefinedApprovalsBlocks(t *testing.T) {
 		MergeRequest: &MergeRequest{},
 	}
 
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if !strings.Contains(out, "Approvals:") || !strings.Contains(out, "Settings:") || !strings.Contains(out, "Rules:") {
 		t.Fatalf("Show() output does not contain nested approvals headers: %q", out)
 	}
@@ -468,7 +468,7 @@ func TestShow_MergeRequestValuesAlign(t *testing.T) {
 		},
 	}
 
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	plain := ansiPattern.ReplaceAllString(out, "")
 	lines := strings.Split(plain, "\n")
@@ -527,7 +527,7 @@ func TestShow_NoFmtArtifacts(t *testing.T) {
 		Clone: &Clone{LocalPath: ".", Branch: "main", Force: false},
 	}
 
-	out := captureStdout(t, func() { cfg.Show() })
+	out := cfg.Show()
 	if strings.Contains(out, "%!") {
 		t.Fatalf("Show() output contains fmt artifacts: %q", out)
 	}

--- a/git/clone.go
+++ b/git/clone.go
@@ -3,21 +3,22 @@ package git
 import (
 	"fmt"
 	"os"
-	"time"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
-	"github.com/rs/zerolog/log"
-	"github.com/theckman/yacspin"
+	"github.com/obcode/glabs/v3/reporter"
 )
 
-func Clone(cfg *config.AssignmentConfig, noSpinner bool) {
+// Clone clones every student/group repository to disk. It is CLI-only — the web
+// server never writes to a local working directory. --suppress passes a discard
+// reporter so only the machine-readable paths are printed.
+func Clone(rep reporter.Reporter, cfg *config.AssignmentConfig) {
 	auth, err := GetAuth()
 	if err != nil {
-		fmt.Printf("error: %v", err)
+		rep.Printf("error: %v", err)
 		return
 	}
 
@@ -25,11 +26,11 @@ func Clone(cfg *config.AssignmentConfig, noSpinner bool) {
 	case config.PerStudent:
 		for _, stud := range cfg.Students {
 			suffix := cfg.RepoSuffix(stud)
-			clone(localpath(cfg, suffix), cfg.Clone.Branch, ProjectRepoUrl(cfg, suffix), auth, cfg.Clone.Force, noSpinner)
+			clone(rep, localpath(cfg, suffix), cfg.Clone.Branch, ProjectRepoUrl(cfg, suffix), auth, cfg.Clone.Force)
 		}
 	case config.PerGroup:
 		for _, grp := range cfg.Groups {
-			clone(localpath(cfg, grp.Name), cfg.Clone.Branch, ProjectRepoUrl(cfg, grp.Name), auth, cfg.Clone.Force, noSpinner)
+			clone(rep, localpath(cfg, grp.Name), cfg.Clone.Branch, ProjectRepoUrl(cfg, grp.Name), auth, cfg.Clone.Force)
 		}
 	}
 }
@@ -45,83 +46,34 @@ func localpath(cfg *config.AssignmentConfig, suffix string) string {
 	return fmt.Sprintf("%s/%s", cfg.Clone.LocalPath, cfg.RepoNameWithSuffix(suffix))
 }
 
-func clone(localpath, branch, cloneurl string, auth transport.AuthMethod, force bool, noSpinner bool) {
-	cfg := yacspin.Config{
-		Frequency: 100 * time.Millisecond,
-		CharSet:   yacspin.CharSets[69],
-		Suffix: aurora.Sprintf(aurora.Cyan(" cloning %s to %s branch %s"),
-			aurora.Yellow(cloneurl),
-			aurora.Yellow(localpath),
-			aurora.Yellow(branch),
-		),
-		SuffixAutoColon:   true,
-		StopCharacter:     "✓",
-		StopColors:        []string{"fgGreen"},
-		StopFailMessage:   "error",
-		StopFailCharacter: "✗",
-		StopFailColors:    []string{"fgRed"},
-	}
-
-	var spinner *yacspin.Spinner
-	var err error
-
-	if !noSpinner {
-		spinner, err = yacspin.New(cfg)
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot create spinner")
-		}
-		err = spinner.Start()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot start spinner")
-		}
-	}
+func clone(rep reporter.Reporter, localpath, branch, cloneurl string, auth transport.AuthMethod, force bool) {
+	task := rep.Task(aurora.Sprintf(aurora.Cyan(" cloning %s to %s branch %s"),
+		aurora.Yellow(cloneurl),
+		aurora.Yellow(localpath),
+		aurora.Yellow(branch),
+	))
 
 	if force {
-		if !noSpinner {
-			spinner.Message(" trying to remove folder if it exists")
-		}
-
-		err := os.RemoveAll(localpath)
-		if err != nil {
-			if !noSpinner {
-				spinner.StopFailMessage(fmt.Sprintf("error when trying to remove %s: %v", localpath, err))
-
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
-			}
+		task.Update(" trying to remove folder if it exists")
+		if err := os.RemoveAll(localpath); err != nil {
+			task.Fail(fmt.Sprintf("error when trying to remove %s: %v", localpath, err))
 			return
 		}
-		if !noSpinner {
-			spinner.Message(" cloning")
-		}
+		task.Update(" cloning")
 	}
 
-	_, err = git.PlainClone(localpath, false, &git.CloneOptions{
+	_, err := git.PlainClone(localpath, false, &git.CloneOptions{
 		Auth:          auth,
 		URL:           cloneurl,
 		ReferenceName: plumbing.ReferenceName("refs/heads/" + branch),
 	})
-
 	if err != nil {
-		if !noSpinner {
-			spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-			err := spinner.StopFail()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
-			}
-		}
+		task.Fail(fmt.Sprintf("problem: %v", err))
 		return
 	}
 
+	task.Done("")
+	// Always printed, even under --suppress: this is the machine-readable output
+	// meant for piping.
 	fmt.Println(localpath)
-
-	if !noSpinner {
-		errs := spinner.Stop()
-		if errs != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
-	}
 }

--- a/git/clone_runtime_test.go
+++ b/git/clone_runtime_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/reporter"
 )
 
 func TestClone_NoSpinner_CloneErrorNoPanic(t *testing.T) {
 	resetViper(t)
 
 	local := filepath.Join(t.TempDir(), "repo")
-	clone(local, "main", "http://127.0.0.1:1/does-not-exist.git", nil, false, true)
+	clone(reporter.NewDiscardReporter(), local, "main", "http://127.0.0.1:1/does-not-exist.git", nil, false)
 }
 
 func TestClone_Force_RemovesExistingPath(t *testing.T) {
@@ -27,7 +28,7 @@ func TestClone_Force_RemovesExistingPath(t *testing.T) {
 		t.Fatalf("writing marker file failed: %v", err)
 	}
 
-	clone(local, "main", "http://127.0.0.1:1/does-not-exist.git", nil, true, true)
+	clone(reporter.NewDiscardReporter(), local, "main", "http://127.0.0.1:1/does-not-exist.git", nil, true)
 
 	if _, err := os.Stat(marker); err == nil {
 		t.Fatal("expected marker file to be removed by force clone")
@@ -49,7 +50,7 @@ func TestClone_PerStudent_PathAndDispatch(t *testing.T) {
 		Clone: &config.Clone{LocalPath: t.TempDir(), Branch: "main", Force: false},
 	}
 
-	Clone(cfg, true)
+	Clone(reporter.NewDiscardReporter(), cfg)
 }
 
 func TestClone_PerGroup_PathAndDispatch(t *testing.T) {
@@ -66,5 +67,5 @@ func TestClone_PerGroup_PathAndDispatch(t *testing.T) {
 		Clone: &config.Clone{LocalPath: t.TempDir(), Branch: "main", Force: false},
 	}
 
-	Clone(cfg, true)
+	Clone(reporter.NewDiscardReporter(), cfg)
 }

--- a/git/push.go
+++ b/git/push.go
@@ -2,43 +2,23 @@ package git
 
 import (
 	"fmt"
-	"time"
 
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/reporter"
 	"github.com/rs/zerolog/log"
-	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func Push(assignmentCfg *config.AssignmentConfig, projectname string, sourceRepo *SourceRepo, toBranch string, force bool, project *gitlab.Project) error {
-	cfg := yacspin.Config{
-		Frequency: 100 * time.Millisecond,
-		CharSet:   yacspin.CharSets[69],
-		Suffix: aurora.Sprintf(aurora.Cyan(" pushing branch %s to project %s / branch %s"),
-			aurora.Yellow(sourceRepo.Ref.Short()),
-			aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
-			aurora.Magenta(toBranch),
-		),
-		SuffixAutoColon:   true,
-		StopCharacter:     "✓",
-		StopColors:        []string{"fgGreen"},
-		StopFailMessage:   "error",
-		StopFailCharacter: "✗",
-		StopFailColors:    []string{"fgRed"},
-	}
-
-	spinner, err := yacspin.New(cfg)
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot create spinner")
-	}
-	err = spinner.Start()
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot start spinner")
-	}
+func Push(rep reporter.Reporter, assignmentCfg *config.AssignmentConfig, projectname string, sourceRepo *SourceRepo, toBranch string, force bool, project *gitlab.Project) error {
+	task := rep.Task(aurora.Sprintf(aurora.Cyan(" pushing branch %s to project %s / branch %s"),
+		aurora.Yellow(sourceRepo.Ref.Short()),
+		aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
+		aurora.Magenta(toBranch),
+	))
 
 	conf := &gitconfig.RemoteConfig{
 		Name: project.Name,
@@ -47,12 +27,7 @@ func Push(assignmentCfg *config.AssignmentConfig, projectname string, sourceRepo
 
 	remote, err := sourceRepo.Repo.CreateRemote(conf)
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-		err := spinner.StopFail()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
+		task.Fail(fmt.Sprintf("problem: %v", err))
 		log.Debug().Err(err).
 			Str("name", project.Name).Str("url", project.HTTPURLToRepo).
 			Msg("cannot create remote")
@@ -70,19 +45,10 @@ func Push(assignmentCfg *config.AssignmentConfig, projectname string, sourceRepo
 		Auth:       sourceRepo.Auth,
 	}
 
-	err = sourceRepo.Repo.Push(pushOpts)
-	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-		err := spinner.StopFail()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
+	if err := sourceRepo.Repo.Push(pushOpts); err != nil {
+		task.Fail(fmt.Sprintf("problem: %v", err))
 		return err
 	}
-	err = spinner.Stop()
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot stop spinner")
-	}
+	task.Done("")
 	return nil
 }

--- a/git/sourcerepo.go
+++ b/git/sourcerepo.go
@@ -12,71 +12,31 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
-	"github.com/rs/zerolog/log"
+	"github.com/obcode/glabs/v3/reporter"
 	"github.com/spf13/viper"
-	"github.com/theckman/yacspin"
 )
 
-func PrepareSourceRepo(url, fromBranch string, singleCommit bool, commitMessage string) (*SourceRepo, error) {
-
-	cfg := yacspin.Config{
-		Frequency: 100 * time.Millisecond,
-		CharSet:   yacspin.CharSets[69],
-		Suffix: aurora.Sprintf(aurora.Cyan(" cloning source code from %s, branch %s"),
-			aurora.Yellow(url),
-			aurora.Yellow(fromBranch),
-		),
-		SuffixAutoColon:   true,
-		StopCharacter:     "✓",
-		StopColors:        []string{"fgGreen"},
-		StopFailMessage:   "error",
-		StopFailCharacter: "✗",
-		StopFailColors:    []string{"fgRed"},
+func PrepareSourceRepo(rep reporter.Reporter, url, fromBranch string, singleCommit bool, commitMessage string) (*SourceRepo, error) {
+	task := rep.Task(aurora.Sprintf(aurora.Cyan(" cloning source code from %s, branch %s"),
+		aurora.Yellow(url),
+		aurora.Yellow(fromBranch),
+	))
+	fail := func(err error) (*SourceRepo, error) {
+		task.Fail(fmt.Sprintf("problem: %v", err))
+		return nil, err
 	}
-
-	spinner, err := yacspin.New(cfg)
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot create spinner")
-	}
-	err = spinner.Start()
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot start spinner")
-	}
-
-	cloneSucceeded := false
-	defer func() {
-		if spinner == nil {
-			return
-		}
-
-		if cloneSucceeded {
-			errs := spinner.Stop()
-			if errs != nil {
-				log.Debug().Err(errs).Msg("cannot stop spinner")
-			}
-			return
-		}
-
-		err := spinner.StopFail()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
-	}()
 
 	// The starter-code (or deferred-branch) URL may be written in SSH notation
 	// (git@host:path.git); glabs clones over HTTPS with the token, so normalize
 	// it first, then pick the credential based on its host.
 	cloneURL, err := config.HTTPSCloneURL(url)
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	auth, err := AuthForURL(cloneURL)
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		fmt.Printf("error: %v", err)
-		return nil, err
+		return fail(err)
 	}
 
 	storer := memory.NewStorage()
@@ -91,26 +51,23 @@ func PrepareSourceRepo(url, fromBranch string, singleCommit bool, commitMessage 
 		Auth:          auth,
 	})
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	wt, err := repo.Worktree()
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	if err := wt.Checkout(&git.CheckoutOptions{
 		Branch: sourceRef,
 		Force:  true,
 	}); err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	if !singleCommit {
-		cloneSucceeded = true
+		task.Done("")
 		return &SourceRepo{
 			Repo: repo,
 			Ref:  sourceRef,
@@ -120,20 +77,17 @@ func PrepareSourceRepo(url, fromBranch string, singleCommit bool, commitMessage 
 
 	headRef, err := repo.Head()
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	headCommit, err := repo.CommitObject(headRef.Hash())
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	tree, err := headCommit.Tree()
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	singleCommitBranchName := fmt.Sprintf("orphan-%s-%d", sourceRef.Short(), time.Now().UnixNano())
@@ -165,41 +119,33 @@ func PrepareSourceRepo(url, fromBranch string, singleCommit bool, commitMessage 
 
 	encoded := repo.Storer.NewEncodedObject()
 	if err := commit.Encode(encoded); err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	commitHash, err := repo.Storer.SetEncodedObject(encoded)
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)); err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	if err := repo.CreateBranch(&gitconfig.Branch{
 		Name:  refName.Short(),
 		Merge: refName,
 	}); err != nil && err != git.ErrBranchExists {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
 	if err := wt.Checkout(&git.CheckoutOptions{
 		Branch: refName,
 		Force:  true,
 	}); err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-		return nil, err
+		return fail(err)
 	}
 
-	if singleCommit {
-		spinner.StopMessage(fmt.Sprintf("using branch '%s' with single commit '%s'", refName.Short(), commitMessage))
-	}
-	cloneSucceeded = true
+	task.Done(fmt.Sprintf("using branch '%s' with single commit '%s'", refName.Short(), commitMessage))
 
 	return &SourceRepo{
 		Repo: repo,

--- a/gitlab/archive.go
+++ b/gitlab/archive.go
@@ -2,20 +2,18 @@ package gitlab
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/reporter"
 	"github.com/rs/zerolog/log"
-	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) Archive(assignmentCfg *config.AssignmentConfig, unarchive bool) {
+func (c *Client) Archive(assignmentCfg *config.AssignmentConfig, unarchive bool) error {
 	_, err := c.getGroupID(assignmentCfg)
 	if err != nil {
-		fmt.Printf("error: GitLab group for assignment does not exist, please create the group %s\n", assignmentCfg.URL)
-		exitFunc(1)
+		return fmt.Errorf("GitLab group for assignment does not exist, please create the group %s", assignmentCfg.URL)
 	}
 
 	switch per := assignmentCfg.Per; per {
@@ -24,14 +22,14 @@ func (c *Client) Archive(assignmentCfg *config.AssignmentConfig, unarchive bool)
 	case config.PerStudent:
 		c.archivePerStudent(assignmentCfg, unarchive)
 	default:
-		fmt.Printf("it is only possible to set access levels for students oder groups, not for %v", per)
-		exitFunc(1)
+		return fmt.Errorf("it is only possible to archive projects for students or groups, not for %v", per)
 	}
+	return nil
 }
 
 func (c *Client) archivePerStudent(assignmentCfg *config.AssignmentConfig, unarchive bool) {
 	if len(assignmentCfg.Students) == 0 {
-		fmt.Println("no students in config for assignment found")
+		c.rep.Println("no students in config for assignment found")
 		return
 	}
 
@@ -42,7 +40,7 @@ func (c *Client) archivePerStudent(assignmentCfg *config.AssignmentConfig, unarc
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
-			fmt.Printf("cannot archive project %s failed with %s", projectname, err)
+			c.rep.Printf("cannot archive project %s failed with %s", projectname, err)
 			return
 		}
 		if err := c.archive(assignmentCfg, project, true, unarchive); err != nil {
@@ -64,7 +62,7 @@ func (c *Client) archivePerGroup(assignmentCfg *config.AssignmentConfig, unarchi
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
-			fmt.Printf("cannot archive project %s failed with %s", projectname, err)
+			c.rep.Printf("cannot archive project %s failed with %s", projectname, err)
 			return
 		}
 		if err := c.archive(assignmentCfg, project, true, unarchive); err != nil {
@@ -73,93 +71,41 @@ func (c *Client) archivePerGroup(assignmentCfg *config.AssignmentConfig, unarchi
 	}
 }
 
+// archive (un)archives a project. spin reports its own progress; callers that
+// already run a task pass false to avoid a nested spinner.
 func (c *Client) archive(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, spin bool, unarchive bool) error {
-	// var cfg yacspin.Config
-	var spinner *yacspin.Spinner
+	task := reporter.NopTask()
 	if spin {
 		un := ""
 		if unarchive {
 			un = "un"
 		}
-		cfg := yacspin.Config{
-			Frequency: 100 * time.Millisecond,
-			CharSet:   yacspin.CharSets[69],
-			Suffix: aurora.Sprintf(aurora.Cyan(" %sarchiving project %s at %s"),
-				un,
-				aurora.Yellow(project.Name),
-				aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
-			),
-			SuffixAutoColon:   true,
-			StopCharacter:     "✓",
-			StopColors:        []string{"fgGreen"},
-			StopFailMessage:   "error",
-			StopFailCharacter: "✗",
-			StopFailColors:    []string{"fgRed"},
-		}
-		var err error
-		spinner, err = yacspin.New(cfg)
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot create spinner")
-		}
-		err = spinner.Start()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot start spinner")
-		}
+		task = c.rep.Task(aurora.Sprintf(aurora.Cyan(" %sarchiving project %s at %s"),
+			un,
+			aurora.Yellow(project.Name),
+			aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
+		))
 	}
-
-	log.Debug().
-		Str("branch", func() string {
-			if assignmentCfg.Startercode != nil {
-				return assignmentCfg.Startercode.ToBranch
-			}
-			return ""
-		}()).
-		Str("name", project.Name).
-		Str("toURL", project.HTTPURLToRepo).
-		Msg("protecting branch")
 
 	var err error
 	if unarchive {
 		_, _, err = c.Projects.UnarchiveProject(project.ID)
-		if err != nil {
-			log.Debug().Err(err).
-				Str("name", project.Name).
-				Str("toURL", project.HTTPURLToRepo).
-				Msg("cannot unarchive project")
-
-			if spin {
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
-			}
-			return fmt.Errorf("error while trying to unarchive project: %w", err)
-		}
 	} else {
 		_, _, err = c.Projects.ArchiveProject(project.ID)
-		if err != nil {
-			log.Debug().Err(err).
-				Str("name", project.Name).
-				Str("toURL", project.HTTPURLToRepo).
-				Msg("cannot archive project")
-
-			if spin {
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
-			}
-			return fmt.Errorf("error while trying to archive project: %w", err)
+	}
+	if err != nil {
+		log.Debug().Err(err).
+			Str("name", project.Name).
+			Str("toURL", project.HTTPURLToRepo).
+			Msg("cannot archive project")
+		task.Fail("")
+		verb := "archive"
+		if unarchive {
+			verb = "unarchive"
 		}
+		return fmt.Errorf("error while trying to %s project: %w", verb, err)
 	}
 
-	if spin {
-		spinner.StopMessage(aurora.Sprintf(aurora.Green("ok")))
-		err = spinner.Stop()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
-	}
-
+	task.Done(aurora.Sprintf(aurora.Green("ok")))
 	return nil
 }

--- a/gitlab/archive_contract_test.go
+++ b/gitlab/archive_contract_test.go
@@ -19,7 +19,6 @@ func projectJSONStr(id int64, name, pathNS string) string {
 // -- Archive ------------------------------------------------------------------
 
 func TestArchive_GroupNotFound_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -33,11 +32,12 @@ func TestArchive_GroupNotFound_Exits(t *testing.T) {
 		Per:         config.PerStudent,
 		Startercode: &config.Startercode{ToBranch: "main"},
 	}
-	assertExitCode(t, 1, func() { client.Archive(cfg, false) })
+	if err := client.Archive(cfg, false); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 func TestArchive_InvalidPer_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups" {
@@ -53,7 +53,9 @@ func TestArchive_InvalidPer_Exits(t *testing.T) {
 		Per:         config.PerFailed,
 		Startercode: &config.Startercode{ToBranch: "main"},
 	}
-	assertExitCode(t, 1, func() { client.Archive(cfg, false) })
+	if err := client.Archive(cfg, false); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 // -- archivePerStudent --------------------------------------------------------

--- a/gitlab/check.go
+++ b/gitlab/check.go
@@ -8,10 +8,10 @@ import (
 
 func (c *Client) CheckCourse(cfg *config.CourseConfig) bool {
 	noOfErrors := 0
-	color.Cyan.Printf("%s:\n", cfg.Course)
+	c.rep.Printf("%s", color.Cyan.Sprintf("%s:\n", cfg.Course))
 
 	if len(cfg.Students) > 0 {
-		color.Cyan.Println("  - students:")
+		c.rep.Println(color.Cyan.Sprint("  - students:"))
 
 		for _, student := range cfg.Students {
 			log.Debug().Interface("student", *student).Msg("checking student")
@@ -22,10 +22,10 @@ func (c *Client) CheckCourse(cfg *config.CourseConfig) bool {
 	}
 
 	if len(cfg.Groups) > 0 {
-		color.Cyan.Println("  - groups:")
+		c.rep.Println(color.Cyan.Sprint("  - groups:"))
 
 		for _, grp := range cfg.Groups {
-			color.Cyan.Printf("    - %s:\n", grp.Name)
+			c.rep.Printf("%s", color.Cyan.Sprintf("    - %s:\n", grp.Name))
 			for _, student := range grp.Members {
 				log.Debug().Interface("student", *student).Msg("checking student")
 				if !c.checkStudent(student, "  ") {
@@ -34,30 +34,28 @@ func (c *Client) CheckCourse(cfg *config.CourseConfig) bool {
 			}
 		}
 
-		color.Cyan.Print("  # checking duplicates in groups")
+		c.rep.Printf("%s", color.Cyan.Sprint("  # checking duplicates in groups"))
 		foundDup := false
 
 		if studsInMoreGroups := checkDupsInGroups(cfg.Groups); len(studsInMoreGroups) > 0 {
-
 			for student, inGroups := range studsInMoreGroups {
-				color.Red.Printf("\n  # %s is in more than one group: %v", student, inGroups)
+				c.rep.Printf("%s", color.Red.Sprintf("\n  # %s is in more than one group: %v", student, inGroups))
 				foundDup = true
 				noOfErrors++
 			}
-
 		}
 
 		if !foundDup {
-			color.Green.Println("... no duplicate found (but checked only the raw input)")
+			c.rep.Println(color.Green.Sprint("... no duplicate found (but checked only the raw input)"))
 		}
 	}
 
 	if noOfErrors > 0 {
-		color.Red.Printf("\n# ===> %d error", noOfErrors)
+		c.rep.Printf("%s", color.Red.Sprintf("\n# ===> %d error", noOfErrors))
 		if noOfErrors == 1 {
-			color.Red.Println()
+			c.rep.Println()
 		} else {
-			color.Red.Println("s")
+			c.rep.Println(color.Red.Sprint("s"))
 		}
 		return false
 	}
@@ -68,20 +66,19 @@ func (c *Client) checkStudent(student *config.Student, prefix string) bool {
 	user, err := c.getUser(student)
 	if err != nil {
 		if student.Email != nil {
-			color.Yellow.Printf("%s     - %s # cannot get user info, inviting via email\n", prefix, *student.Email)
+			c.rep.Printf("%s", color.Yellow.Sprintf("%s     - %s # cannot get user info, inviting via email\n", prefix, *student.Email))
 			return true
-		} else {
-			color.Red.Printf("    # %+v, error: %v\n", student, err)
-			return false
 		}
+		c.rep.Printf("%s", color.Red.Sprintf("    # %+v, error: %v\n", student, err))
+		return false
 	}
 
 	if student.Id != nil {
-		color.Green.Printf("%s     - %d # %s (@%s) specified via ID\n", prefix, user.ID, user.Name, user.Username)
+		c.rep.Printf("%s", color.Green.Sprintf("%s     - %d # %s (@%s) specified via ID\n", prefix, user.ID, user.Name, user.Username))
 	}
 	if student.Username != nil {
-		color.Red.Printf("%s     # please consider changing to UserID:\n", prefix)
-		color.Red.Printf("%s     - %d # %s (@%s) specified via Username\n", prefix, user.ID, user.Name, user.Username)
+		c.rep.Printf("%s", color.Red.Sprintf("%s     # please consider changing to UserID:\n", prefix))
+		c.rep.Printf("%s", color.Red.Sprintf("%s     - %d # %s (@%s) specified via Username\n", prefix, user.ID, user.Name, user.Username))
 	}
 	return true
 }

--- a/gitlab/check_test.go
+++ b/gitlab/check_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/reporter"
 	gitlabapi "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
@@ -58,7 +59,7 @@ func newTestClient(t *testing.T, idUsers map[int]string, searchUsers map[string]
 		t.Fatalf("creating gitlab test client failed: %v", err)
 	}
 
-	return &Client{apiClient}
+	return &Client{Client: apiClient, rep: reporter.NewDiscardReporter()}
 }
 
 func TestCheckDupsInGroups_NoDuplicates(t *testing.T) {

--- a/gitlab/delete.go
+++ b/gitlab/delete.go
@@ -8,11 +8,10 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) Delete(assignmentCfg *config.AssignmentConfig) {
+func (c *Client) Delete(assignmentCfg *config.AssignmentConfig) error {
 	assignmentGitLabGroupID, err := c.getGroupID(assignmentCfg)
 	if err != nil {
-		fmt.Printf("error: GitLab group for assignment does not exist, please create the group %s\n", assignmentCfg.URL)
-		exitFunc(1)
+		return fmt.Errorf("GitLab group for assignment does not exist, please create the group %s", assignmentCfg.URL)
 	}
 
 	switch per := assignmentCfg.Per; per {
@@ -21,14 +20,14 @@ func (c *Client) Delete(assignmentCfg *config.AssignmentConfig) {
 	case config.PerStudent:
 		c.deletePerStudent(assignmentCfg, assignmentGitLabGroupID)
 	default:
-		fmt.Printf("it is only possible to delete projects for students or groups, not for %v", per)
-		exitFunc(1)
+		return fmt.Errorf("it is only possible to delete projects for students or groups, not for %v", per)
 	}
+	return nil
 }
 
 func (c *Client) deletePerStudent(assignmentCfg *config.AssignmentConfig, assignmentGroupID int64) {
 	if len(assignmentCfg.Students) == 0 {
-		fmt.Println("no students in config for assignment found")
+		c.rep.Println("no students in config for assignment found")
 		return
 	}
 

--- a/gitlab/delete_contract_test.go
+++ b/gitlab/delete_contract_test.go
@@ -41,7 +41,6 @@ func makeDeleteHandler(groupID, projectID int64, projectName string) http.Handle
 // ---- Delete (top-level) -----------------------------------------------------
 
 func TestDelete_GroupNotFound_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -53,11 +52,12 @@ func TestDelete_GroupNotFound_Exits(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		Per:    config.PerStudent,
 	}
-	assertExitCode(t, 1, func() { client.Delete(cfg) })
+	if err := client.Delete(cfg); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 func TestDelete_InvalidPer_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups" {
@@ -72,7 +72,9 @@ func TestDelete_InvalidPer_Exits(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		Per:    config.PerFailed,
 	}
-	assertExitCode(t, 1, func() { client.Delete(cfg) })
+	if err := client.Delete(cfg); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 // ---- deletePerStudent -------------------------------------------------------

--- a/gitlab/generate.go
+++ b/gitlab/generate.go
@@ -29,7 +29,7 @@ func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) {
 	var starterrepo *git.SourceRepo
 
 	if assignmentCfg.Startercode != nil {
-		starterrepo, err = git.PrepareSourceRepo(
+		starterrepo, err = git.PrepareSourceRepo(c.rep,
 			assignmentCfg.Startercode.URL,
 			assignmentCfg.Startercode.FromBranch,
 			assignmentCfg.Startercode.Template,

--- a/gitlab/generate.go
+++ b/gitlab/generate.go
@@ -2,27 +2,24 @@ package gitlab
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
 	"github.com/obcode/glabs/v3/git"
 	"github.com/rs/zerolog/log"
-	"github.com/theckman/yacspin"
 )
 
-func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) {
+func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) error {
 	assignmentGitLabGroupID, err := c.getGroupID(assignmentCfg)
 	if err != nil {
-		// try to create group if it does not exist, otherwise exit with error
+		// try to create group if it does not exist, otherwise return an error
 		assignmentGitLabGroupID, err = c.createGroup(assignmentCfg)
 		if err != nil {
 			log.Error().Err(err).
 				Str("course", assignmentCfg.Course).
 				Str("assignmentpath", assignmentCfg.Path).
 				Msg("error while creating group for assignment")
-			fmt.Printf("error: cannot create GitLab group for assignment, please create the group %s\n", assignmentCfg.URL)
-			exitFunc(1)
+			return fmt.Errorf("cannot create GitLab group for assignment, please create the group %s", assignmentCfg.URL)
 		}
 	}
 
@@ -35,10 +32,8 @@ func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) {
 			assignmentCfg.Startercode.Template,
 			assignmentCfg.Startercode.TemplateMessage,
 		)
-
 		if err != nil {
-			fmt.Println(err)
-			exitFunc(1)
+			return err
 		}
 	}
 
@@ -48,121 +43,55 @@ func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) {
 	case config.PerStudent:
 		c.generatePerStudent(assignmentCfg, assignmentGitLabGroupID, starterrepo)
 	default:
-		fmt.Printf("it is only possible to generate for students oder groups, not for %v", per)
-		exitFunc(1)
+		return fmt.Errorf("it is only possible to generate for students or groups, not for %v", per)
 	}
+	return nil
 }
 
 func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGroupID int64,
 	projectname string, members []*config.Student, starterrepo *git.SourceRepo) {
 
-	cfg := yacspin.Config{
-		Frequency: 100 * time.Millisecond,
-		CharSet:   yacspin.CharSets[69],
-		Suffix: aurora.Sprintf(aurora.Cyan(" generating project %s at %s"),
-			aurora.Yellow(projectname),
-			aurora.Magenta(assignmentCfg.URL+"/"+projectname),
-		),
-		SuffixAutoColon:   true,
-		StopCharacter:     "✓",
-		StopColors:        []string{"fgGreen"},
-		StopFailMessage:   "error",
-		StopFailCharacter: "✗",
-		StopFailColors:    []string{"fgRed"},
-	}
+	task := c.rep.Task(aurora.Sprintf(aurora.Cyan(" generating project %s at %s"),
+		aurora.Yellow(projectname),
+		aurora.Magenta(assignmentCfg.URL+"/"+projectname),
+	))
+	task.Update("generating project on host")
 
-	spinner, err := yacspin.New(cfg)
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot create spinner")
-	}
-	err = spinner.Start()
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot start spinner")
-	}
-
-	spinner.Message("generating project on host")
 	project, generated, err := c.generateProject(assignmentCfg, projectname, assignmentGroupID)
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-		err := spinner.StopFail()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
+		task.Fail(fmt.Sprintf("problem: %v", err))
 		return
+	}
+	if !generated {
+		task.Done(aurora.Sprintf(aurora.Red("project already exists")))
 	} else {
-		if !generated {
-			spinner.StopMessage(aurora.Sprintf(aurora.Red("project already exists")))
-		}
-
-		err = spinner.Stop()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
+		task.Done("")
 	}
 
 	if starterrepo != nil {
 		if !generated {
-			fmt.Println(aurora.Red("    ↪ not trying to push startercode to existing project"))
+			c.rep.Println(aurora.Red("    ↪ not trying to push startercode to existing project"))
 		} else {
-			cfg.Suffix = aurora.Sprintf(aurora.Cyan(" ↪ pushing startercode"))
-			spinner, err := yacspin.New(cfg)
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot create spinner")
-			}
-			err = spinner.Start()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot start spinner")
-			}
-
-			err = c.pushStartercode(assignmentCfg, starterrepo, project)
-			if err != nil {
-				spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
+			task := c.rep.Task(aurora.Sprintf(aurora.Cyan(" ↪ pushing startercode")))
+			if err := c.pushStartercode(assignmentCfg, starterrepo, project); err != nil {
+				task.Fail(fmt.Sprintf("problem: %v", err))
 				return
 			}
-
-			err = spinner.Stop()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
-			}
+			task.Done("")
 		}
 	} else if assignmentCfg.Seeder != nil {
 		if !generated {
-			fmt.Println(aurora.Red("    ↪ not running seeder for existing project"))
+			c.rep.Println(aurora.Red("    ↪ not running seeder for existing project"))
 		} else {
-			cfg.Suffix = aurora.Sprintf(aurora.Cyan(" ↪ seeding project %s using %s"),
+			task := c.rep.Task(aurora.Sprintf(aurora.Cyan(" ↪ seeding project %s using %s"),
 				aurora.Magenta(projectname),
 				aurora.Magenta(assignmentCfg.Seeder.Command),
-			)
-			spinner, err := yacspin.New(cfg)
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot create spinner")
-			}
-			err = spinner.Start()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot start spinner")
-			}
-
-			err = c.runSeeder(assignmentCfg, project)
-			if err != nil {
-				spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
+			))
+			if err := c.runSeeder(assignmentCfg, project); err != nil {
+				task.Fail(fmt.Sprintf("problem: %v", err))
 				return
 			}
-
-			err = spinner.Stop()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
-			}
+			task.Done("")
 		}
 	}
 
@@ -176,7 +105,7 @@ func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGrou
 
 		if err := c.syncConfiguredBranches(assignmentCfg, project, baseBranch, len(members)); err != nil {
 			log.Error().Err(err).Str("project", project.Name).Msg("cannot apply configured branch rules")
-			fmt.Printf("error: cannot apply branch/approval rules for project %s: %v\n", project.Name, err)
+			c.rep.Printf("error: cannot apply branch/approval rules for project %s: %v\n", project.Name, err)
 		}
 	}
 
@@ -203,48 +132,25 @@ func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGrou
 		createdIssueMap := make(map[int]int, len(issueNumbers))
 
 		for _, issueNumber := range issueNumbers {
-			cfg.Suffix = aurora.Sprintf(
+			task := c.rep.Task(aurora.Sprintf(
 				aurora.Cyan(" ↪ replicating issue #%d from startercode"),
 				aurora.Yellow(issueNumber),
-			)
-			spinner, err := yacspin.New(cfg)
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot create spinner")
-			}
-			err = spinner.Start()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot start spinner")
-			}
+			))
 
 			if starterProjectErr != nil {
-				spinner.StopFailMessage(fmt.Sprintf("problem: %v", starterProjectErr))
-
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
+				task.Fail(fmt.Sprintf("problem: %v", starterProjectErr))
 				continue
 			}
 
 			_, isChildTask := parentByChild[issueNumber]
 			createdIssueIID, replicateErr := c.replicateIssue(starterProject, project, issueNumber, isChildTask)
-			err = replicateErr
-			if err != nil {
-				spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
+			if replicateErr != nil {
+				task.Fail(fmt.Sprintf("problem: %v", replicateErr))
 				continue
 			}
 
 			createdIssueMap[issueNumber] = createdIssueIID
-
-			err = spinner.Stop()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
-			}
+			task.Done("")
 		}
 
 		if starterProjectErr == nil && assignmentCfg.Issues.IncludeChildTasks {
@@ -267,7 +173,7 @@ func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGrou
 		}
 	}
 
-	c.setaccess(assignmentCfg, project, members, &cfg)
+	c.setaccess(assignmentCfg, project, members)
 }
 
 func (c *Client) generatePerStudent(assignmentCfg *config.AssignmentConfig, assignmentGroupID int64,

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/obcode/glabs/v3/reporter"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
@@ -11,6 +12,11 @@ import (
 
 type Client struct {
 	*gitlab.Client
+	// rep receives progress. It is a field rather than a per-call parameter
+	// because the operation methods and their ~20 helpers all report, and
+	// because a per-user web request builds its own Client anyway (per-user
+	// token), so the reporter is naturally request-scoped and never shared.
+	rep reporter.Reporter
 }
 
 // clientOptions holds what a Client needs to reach GitLab. They are injected
@@ -22,6 +28,7 @@ type clientOptions struct {
 	token          string
 	httpClient     *http.Client
 	withoutRetries bool
+	reporter       reporter.Reporter
 }
 
 type Option func(*clientOptions)
@@ -32,6 +39,12 @@ func WithToken(token string) Option { return func(o *clientOptions) { o.token = 
 // WithHTTPClient injects the underlying HTTP client.
 func WithHTTPClient(hc *http.Client) Option {
 	return func(o *clientOptions) { o.httpClient = hc }
+}
+
+// WithReporter sets where the client's progress goes. Defaults to a
+// ConsoleReporter (spinners on stdout); the web server passes a streaming one.
+func WithReporter(r reporter.Reporter) Option {
+	return func(o *clientOptions) { o.reporter = r }
 }
 
 // WithoutRetries disables the client's retry-on-5xx wrapper. The contract tests
@@ -70,7 +83,12 @@ func NewClient(opts ...Option) (*Client, error) {
 		return nil, fmt.Errorf("cannot create a gitlab client: %w", err)
 	}
 
-	return &Client{client}, nil
+	rep := o.reporter
+	if rep == nil {
+		rep = reporter.NewConsoleReporter()
+	}
+
+	return &Client{Client: client, rep: rep}, nil
 }
 
 // NewClientFromViper builds a client from the global config. It is the CLI's

--- a/gitlab/protect.go
+++ b/gitlab/protect.go
@@ -3,20 +3,18 @@ package gitlab
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/reporter"
 	"github.com/rs/zerolog/log"
-	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) ProtectToBranch(assignmentCfg *config.AssignmentConfig) {
+func (c *Client) ProtectToBranch(assignmentCfg *config.AssignmentConfig) error {
 	_, err := c.getGroupID(assignmentCfg)
 	if err != nil {
-		fmt.Printf("error: GitLab group for assignment does not exist, please create the group %s\n", assignmentCfg.URL)
-		exitFunc(1)
+		return fmt.Errorf("GitLab group for assignment does not exist, please create the group %s", assignmentCfg.URL)
 	}
 
 	switch per := assignmentCfg.Per; per {
@@ -25,9 +23,9 @@ func (c *Client) ProtectToBranch(assignmentCfg *config.AssignmentConfig) {
 	case config.PerStudent:
 		c.protectToBranchPerStudent(assignmentCfg)
 	default:
-		fmt.Printf("it is only possible to protect the branch for students oder groups, not for %v", per)
-		exitFunc(1)
+		return fmt.Errorf("it is only possible to protect the branch for students or groups, not for %v", per)
 	}
+	return nil
 }
 
 func (c *Client) protectBranch(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, spin bool) error {
@@ -39,31 +37,12 @@ func (c *Client) protectBranchForMemberCount(assignmentCfg *config.AssignmentCon
 		return nil
 	}
 
-	var spinner *yacspin.Spinner
+	task := reporter.NopTask()
 	if spin {
-		cfg := yacspin.Config{
-			Frequency: 100 * time.Millisecond,
-			CharSet:   yacspin.CharSets[69],
-			Suffix: aurora.Sprintf(aurora.Cyan(" protect branch for project %s at %s"),
-				aurora.Yellow(project.Name),
-				aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
-			),
-			SuffixAutoColon:   true,
-			StopCharacter:     "✓",
-			StopColors:        []string{"fgGreen"},
-			StopFailMessage:   "error",
-			StopFailCharacter: "✗",
-			StopFailColors:    []string{"fgRed"},
-		}
-		var err error
-		spinner, err = yacspin.New(cfg)
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot create spinner")
-		}
-		err = spinner.Start()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot start spinner")
-		}
+		task = c.rep.Task(aurora.Sprintf(aurora.Cyan(" protect branch for project %s at %s"),
+			aurora.Yellow(project.Name),
+			aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
+		))
 	}
 
 	log.Debug().
@@ -84,35 +63,18 @@ func (c *Client) protectBranchForMemberCount(assignmentCfg *config.AssignmentCon
 			mergeLevel = gitlab.DeveloperPermissions
 		}
 
-		err := c.protectSingleBranch(project, branch, pushLevel, mergeLevel)
-		if err != nil {
-			if spin {
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
-			}
+		if err := c.protectSingleBranch(project, branch, pushLevel, mergeLevel); err != nil {
+			task.Fail("")
 			return err
 		}
 	}
 
 	if err := c.applyMergeRequestApprovalRulesForMemberCount(assignmentCfg, project, memberCount); err != nil {
-		if spin {
-			err := spinner.StopFail()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
-			}
-		}
+		task.Fail("")
 		return err
 	}
 
-	if spin {
-		spinner.StopMessage(aurora.Sprintf(aurora.Green("ok")))
-		if err := spinner.Stop(); err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
-	}
-
+	task.Done(aurora.Sprintf(aurora.Green("ok")))
 	return nil
 }
 
@@ -253,7 +215,7 @@ func isProtectedBranchNotFoundError(err error) bool {
 
 func (c *Client) protectToBranchPerStudent(assignmentCfg *config.AssignmentConfig) {
 	if len(assignmentCfg.Students) == 0 {
-		fmt.Println("no students in config for assignment found")
+		c.rep.Println("no students in config for assignment found")
 		return
 	}
 
@@ -264,7 +226,7 @@ func (c *Client) protectToBranchPerStudent(assignmentCfg *config.AssignmentConfi
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
-			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
+			c.rep.Printf("cannot protect branch for project %s failed with %s", projectname, err)
 			return
 		}
 		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, 1); err != nil {
@@ -286,7 +248,7 @@ func (c *Client) protectToBranchPerGroup(assignmentCfg *config.AssignmentConfig)
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
-			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
+			c.rep.Printf("cannot protect branch for project %s failed with %s", projectname, err)
 			return
 		}
 		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, len(grp.Members)); err != nil {

--- a/gitlab/protect_contract_test.go
+++ b/gitlab/protect_contract_test.go
@@ -13,7 +13,6 @@ import (
 // ---- ProtectToBranch (top-level) --------------------------------------------
 
 func TestProtectToBranch_GroupNotFound_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -26,11 +25,12 @@ func TestProtectToBranch_GroupNotFound_Exits(t *testing.T) {
 		Per:      config.PerStudent,
 		Branches: []config.BranchRule{{Name: "main", Protect: true}},
 	}
-	assertExitCode(t, 1, func() { client.ProtectToBranch(cfg) })
+	if err := client.ProtectToBranch(cfg); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 func TestProtectToBranch_InvalidPer_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups" {
@@ -46,7 +46,9 @@ func TestProtectToBranch_InvalidPer_Exits(t *testing.T) {
 		Per:      config.PerFailed,
 		Branches: []config.BranchRule{{Name: "main", Protect: true}},
 	}
-	assertExitCode(t, 1, func() { client.ProtectToBranch(cfg) })
+	if err := client.ProtectToBranch(cfg); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 // ---- protectToBranchPerStudent ----------------------------------------------

--- a/gitlab/push.go
+++ b/gitlab/push.go
@@ -13,7 +13,7 @@ func (c *Client) Push(assignmentCfg *config.AssignmentConfig, branchname string)
 		return fmt.Errorf("error: no config for deferred branch \"%s\" found\n", branchname)
 	}
 
-	sourceRepo, err := git.PrepareSourceRepo(branch.URL, branch.FromBranch, branch.Orphan, branch.OrphanMessage)
+	sourceRepo, err := git.PrepareSourceRepo(c.rep, branch.URL, branch.FromBranch, branch.Orphan, branch.OrphanMessage)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func (c *Client) Push(assignmentCfg *config.AssignmentConfig, branchname string)
 			return err
 		}
 
-		err = git.Push(assignmentCfg, projectname, sourceRepo, branch.ToBranch, true, project)
+		err = git.Push(c.rep, assignmentCfg, projectname, sourceRepo, branch.ToBranch, true, project)
 		if err != nil {
 			return err
 		}

--- a/gitlab/report.go
+++ b/gitlab/report.go
@@ -11,13 +11,13 @@ import (
 	r "github.com/obcode/glabs/v3/gitlab/report"
 )
 
-func (c *Client) Report(assignmentCfg *config.AssignmentConfig, templateFile *string, output *string) {
-	report := c.report(assignmentCfg)
+func (c *Client) Report(assignmentCfg *config.AssignmentConfig, templateFile *string, output *string) error {
+	report, err := c.report(assignmentCfg)
+	if err != nil {
+		return err
+	}
 
-	var (
-		tmpl *template.Template
-		err  error
-	)
+	var tmpl *template.Template
 	if templateFile != nil {
 		tmpl, err = template.ParseFiles(*templateFile)
 	} else {
@@ -25,78 +25,83 @@ func (c *Client) Report(assignmentCfg *config.AssignmentConfig, templateFile *st
 	}
 
 	if err != nil {
-		panicFunc(err)
+		return err
 	}
 
 	if output != nil {
 		os.Remove(*output) //nolint
 		f, err := os.Create(*output)
 		if err != nil {
-			panicFunc(err)
+			return err
 		}
 		defer f.Close() //nolint
 		err = tmpl.Execute(f, report)
 		if err != nil {
-			panicFunc(err)
+			return err
 		}
 	} else {
 		err = tmpl.Execute(os.Stdout, report)
 		if err != nil {
-			panicFunc(err)
+			return err
 		}
 	}
-
+	return nil
 }
 
-func (c *Client) ReportHTML(assignmentCfg *config.AssignmentConfig, templateFile *string, output *string) {
-	report := c.report(assignmentCfg)
+func (c *Client) ReportHTML(assignmentCfg *config.AssignmentConfig, templateFile *string, output *string) error {
+	report, err := c.report(assignmentCfg)
+	if err != nil {
+		return err
+	}
 
-	var (
-		tmpl *htmlTemplate.Template
-		err  error
-	)
+	var tmpl *htmlTemplate.Template
 	if templateFile != nil {
 		tmpl, err = htmlTemplate.ParseFiles(*templateFile)
 	} else {
 		tmpl, err = htmlTemplate.New("html").Parse(r.HTMLTemplate)
 	}
 	if err != nil {
-		panicFunc(err)
+		return err
 	}
 
 	if output != nil {
 		os.Remove(*output) //nolint
 		f, err := os.Create(*output)
 		if err != nil {
-			panicFunc(err)
+			return err
 		}
 		defer f.Close() //nolint
 		err = tmpl.Execute(f, report)
 		if err != nil {
-			panicFunc(err)
+			return err
 		}
 	} else {
 		err = tmpl.Execute(os.Stdout, report)
 		if err != nil {
-			panicFunc(err)
+			return err
 		}
 	}
+	return nil
 }
 
-func (c *Client) ReportJSON(assignmentCfg *config.AssignmentConfig, output *string) {
-	report := c.report(assignmentCfg)
+func (c *Client) ReportJSON(assignmentCfg *config.AssignmentConfig, output *string) error {
+	report, err := c.report(assignmentCfg)
+	if err != nil {
+		return err
+	}
 
 	json, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
-		panicFunc(err)
+		return err
 	}
 
 	if output != nil {
 		err := os.WriteFile(*output, json, 0644)
 		if err != nil {
-			panicFunc(err)
+			return err
 		}
 	} else {
 		fmt.Println(string(json))
 	}
+	return nil
 }

--- a/gitlab/report_contract_test.go
+++ b/gitlab/report_contract_test.go
@@ -73,7 +73,10 @@ func TestReport_GroupNotFound_ReturnsNil(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	result := client.report(cfg)
+	result, err := client.report(cfg)
+	if err == nil {
+		t.Fatal("report() returned no error, want one")
+	}
 	if result != nil {
 		t.Fatalf("report() = %#v, want nil", result)
 	}
@@ -96,7 +99,10 @@ func TestReport_ListGroupProjectsFails_ReturnsNil(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	result := client.report(cfg)
+	result, err := client.report(cfg)
+	if err == nil {
+		t.Fatal("report() returned no error, want one")
+	}
 	if result != nil {
 		t.Fatalf("report() = %#v, want nil after ListGroupProjects failure", result)
 	}
@@ -120,7 +126,10 @@ func TestReport_HappyPath_NoProjects(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	result := client.report(cfg)
+	result, err := client.report(cfg)
+	if err != nil {
+		t.Fatalf("report(): unexpected error: %v", err)
+	}
 	if result == nil {
 		t.Fatal("report() returned nil, want non-nil")
 	}
@@ -141,7 +150,10 @@ func TestReport_HappyPath_WithProject(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	result := client.report(cfg)
+	result, err := client.report(cfg)
+	if err != nil {
+		t.Fatalf("report(): unexpected error: %v", err)
+	}
 	if result == nil {
 		t.Fatal("report() returned nil, want non-nil")
 	}
@@ -163,7 +175,10 @@ func TestReport_HappyPath_WithRelease(t *testing.T) {
 			DockerImages: []string{"myimage:latest"},
 		},
 	}
-	result := client.report(cfg)
+	result, err := client.report(cfg)
+	if err != nil {
+		t.Fatalf("report(): unexpected error: %v", err)
+	}
 	if result == nil {
 		t.Fatal("report() returned nil, want non-nil")
 	}
@@ -187,7 +202,9 @@ func TestReport_TextTemplate_ToStdout(t *testing.T) {
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
 	// nil template → uses default text template; nil output → uses stdout
-	client.Report(cfg, nil, nil)
+	if err := client.Report(cfg, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestReport_TextTemplate_ToFile(t *testing.T) {
@@ -200,7 +217,9 @@ func TestReport_TextTemplate_ToFile(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	client.Report(cfg, nil, &outFile)
+	if err := client.Report(cfg, nil, &outFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	data, err := os.ReadFile(outFile)
 	if err != nil {
@@ -228,7 +247,9 @@ func TestReport_CustomTemplate_ToFile(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	client.Report(cfg, &tmplFile, &outFile)
+	if err := client.Report(cfg, &tmplFile, &outFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	data, err := os.ReadFile(outFile)
 	if err != nil {
@@ -250,7 +271,9 @@ func TestReportHTML_DefaultTemplate_ToStdout(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	client.ReportHTML(cfg, nil, nil)
+	if err := client.ReportHTML(cfg, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestReportHTML_DefaultTemplate_ToFile(t *testing.T) {
@@ -263,7 +286,9 @@ func TestReportHTML_DefaultTemplate_ToFile(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	client.ReportHTML(cfg, nil, &outFile)
+	if err := client.ReportHTML(cfg, nil, &outFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	data, err := os.ReadFile(outFile)
 	if err != nil {
@@ -285,7 +310,9 @@ func TestReportJSON_ToStdout(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	client.ReportJSON(cfg, nil)
+	if err := client.ReportJSON(cfg, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestReportJSON_ToFile(t *testing.T) {
@@ -298,7 +325,9 @@ func TestReportJSON_ToFile(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		URL:    "https://gitlab.example.org/mpd/ss26/blatt-01",
 	}
-	client.ReportJSON(cfg, &outFile)
+	if err := client.ReportJSON(cfg, &outFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	data, err := os.ReadFile(outFile)
 	if err != nil {

--- a/gitlab/report_helper.go
+++ b/gitlab/report_helper.go
@@ -10,45 +10,20 @@ import (
 	"github.com/obcode/glabs/v3/config"
 	"github.com/obcode/glabs/v3/gitlab/report"
 	"github.com/rs/zerolog/log"
-	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) report(assignmentCfg *config.AssignmentConfig) *report.Reports {
-	cfg := yacspin.Config{
-		Frequency: 100 * time.Millisecond,
-		CharSet:   yacspin.CharSets[69],
-		Suffix: aurora.Sprintf(aurora.Cyan(" fetching info for  %s / %s"),
-			aurora.Yellow(assignmentCfg.Course),
-			aurora.Magenta(assignmentCfg.Name),
-		),
-		SuffixAutoColon:   true,
-		StopCharacter:     "✓",
-		StopColors:        []string{"fgGreen"},
-		StopFailMessage:   "error",
-		StopFailCharacter: "✗",
-		StopFailColors:    []string{"fgRed"},
-	}
+func (c *Client) report(assignmentCfg *config.AssignmentConfig) (*report.Reports, error) {
+	task := c.rep.Task(aurora.Sprintf(aurora.Cyan(" fetching info for  %s / %s"),
+		aurora.Yellow(assignmentCfg.Course),
+		aurora.Magenta(assignmentCfg.Name),
+	))
 
-	spinner, err := yacspin.New(cfg)
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot create spinner")
-	}
-	err = spinner.Start()
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot start spinner")
-	}
-
-	spinner.Message(aurora.Sprintf(aurora.Green("get group info")))
+	task.Update(aurora.Sprintf(aurora.Green("get group info")))
 	groupID, err := c.getGroupID(assignmentCfg)
 	if err != nil {
-		spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-		err := spinner.StopFail()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
-		return nil
+		task.Fail(fmt.Sprintf("problem: %v", err))
+		return nil, err
 	}
 	log.Debug().Int64("groupID", groupID).Msg("found group id")
 
@@ -57,13 +32,8 @@ func (c *Client) report(assignmentCfg *config.AssignmentConfig) *report.Reports 
 	for {
 		someProjects, response, err := c.Groups.ListGroupProjects(groupID, opts)
 		if err != nil {
-			spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-			err := spinner.StopFail()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
-			}
-			return nil
+			task.Fail(fmt.Sprintf("problem: %v", err))
+			return nil, err
 		}
 		projects = append(projects, someProjects...)
 
@@ -88,13 +58,13 @@ func (c *Client) report(assignmentCfg *config.AssignmentConfig) *report.Reports 
 
 	projectReportsMap := make(map[string]*report.ProjectReport)
 	for _, project := range projects {
-		spinner.Message(aurora.Sprintf(aurora.Green(fmt.Sprintf("get info for %s", project.Name))))
+		task.Update(aurora.Sprintf(aurora.Green(fmt.Sprintf("get info for %s", project.Name))))
 
 		pojectName, projectReport := c.projectReport(assignmentCfg, project)
 		projectReportsMap[pojectName] = projectReport
 	}
 
-	spinner.Message(aurora.Sprintf(aurora.Green("sorting projects")))
+	task.Update(aurora.Sprintf(aurora.Green("sorting projects")))
 	keys := make([]string, 0, len(projects))
 	for k := range projectReportsMap {
 		keys = append(keys, k)
@@ -105,10 +75,7 @@ func (c *Client) report(assignmentCfg *config.AssignmentConfig) *report.Reports 
 		projectReports = append(projectReports, projectReportsMap[projectName])
 	}
 
-	err = spinner.Stop()
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot stop spinner")
-	}
+	task.Done("")
 
 	now := time.Now()
 
@@ -129,7 +96,7 @@ func (c *Client) report(assignmentCfg *config.AssignmentConfig) *report.Reports 
 		Generated:              &now,
 		HasReleaseMergeRequest: hasReleaseMergeRequest,
 		HasReleaseDockerImages: hasReleaseDockerImages,
-	}
+	}, nil
 }
 
 func (c *Client) projectReport(assignmentCfg *config.AssignmentConfig, project *gitlab.Project) (string, *report.ProjectReport) {

--- a/gitlab/runtime.go
+++ b/gitlab/runtime.go
@@ -1,9 +1,0 @@
-package gitlab
-
-import "os"
-
-var exitFunc = os.Exit
-
-var panicFunc = func(v interface{}) {
-	panic(v)
-}

--- a/gitlab/runtime_test.go
+++ b/gitlab/runtime_test.go
@@ -1,7 +1,6 @@
 package gitlab
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -9,46 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-type exitTriggered struct {
-	code int
-}
-
-func (e exitTriggered) Error() string {
-	return fmt.Sprintf("exit called with code %d", e.code)
-}
-
-func withExitCapture(t *testing.T) func() {
-	t.Helper()
-	origExit := exitFunc
-	exitFunc = func(code int) {
-		panic(exitTriggered{code: code})
-	}
-	return func() {
-		exitFunc = origExit
-	}
-}
-
-func assertExitCode(t *testing.T, expected int, fn func()) {
-	t.Helper()
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatalf("expected exit with code %d, got no panic", expected)
-		}
-		e, ok := r.(exitTriggered)
-		if !ok {
-			t.Fatalf("expected exitTriggered panic, got %T", r)
-		}
-		if e.code != expected {
-			t.Fatalf("exit code = %d, want %d", e.code, expected)
-		}
-	}()
-	fn()
-}
-
-func TestGenerate_UsesExitSeamForInvalidPer(t *testing.T) {
-	defer withExitCapture(t)()
-
+func TestGenerateReturnsErrorForInvalidPer(t *testing.T) {
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups" {
 			_, _ = w.Write([]byte(`[{"id":1,"full_path":"mpd/ss26/blatt-01"}]`))
@@ -64,14 +24,12 @@ func TestGenerate_UsesExitSeamForInvalidPer(t *testing.T) {
 		Per:    config.PerFailed,
 	}
 
-	assertExitCode(t, 1, func() {
-		client.Generate(cfg)
-	})
+	if err := client.Generate(cfg); err == nil {
+		t.Fatal("Generate with an invalid per succeeded, want an error")
+	}
 }
 
-func TestProtectToBranch_UsesExitSeamForInvalidPer(t *testing.T) {
-	defer withExitCapture(t)()
-
+func TestProtectToBranchReturnsErrorForInvalidPer(t *testing.T) {
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups" {
 			_, _ = w.Write([]byte(`[{"id":1,"full_path":"mpd/ss26/blatt-01"}]`))
@@ -88,9 +46,9 @@ func TestProtectToBranch_UsesExitSeamForInvalidPer(t *testing.T) {
 		Branches: []config.BranchRule{{Name: "main", Protect: true}},
 	}
 
-	assertExitCode(t, 1, func() {
-		client.ProtectToBranch(cfg)
-	})
+	if err := client.ProtectToBranch(cfg); err == nil {
+		t.Fatal("ProtectToBranch with an invalid per succeeded, want an error")
+	}
 }
 
 func TestNewClientReturnsErrorOnInvalidBaseURL(t *testing.T) {

--- a/gitlab/setaccess.go
+++ b/gitlab/setaccess.go
@@ -2,20 +2,17 @@ package gitlab
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
 	"github.com/rs/zerolog/log"
-	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) Setaccess(assignmentCfg *config.AssignmentConfig) {
+func (c *Client) Setaccess(assignmentCfg *config.AssignmentConfig) error {
 	_, err := c.getGroupID(assignmentCfg)
 	if err != nil {
-		fmt.Printf("error: GitLab group for assignment does not exist, please create the group %s\n", assignmentCfg.URL)
-		exitFunc(1)
+		return fmt.Errorf("GitLab group for assignment does not exist, please create the group %s", assignmentCfg.URL)
 	}
 
 	switch per := assignmentCfg.Per; per {
@@ -24,59 +21,18 @@ func (c *Client) Setaccess(assignmentCfg *config.AssignmentConfig) {
 	case config.PerStudent:
 		c.setaccessPerStudent(assignmentCfg)
 	default:
-		fmt.Printf("it is only possible to set access levels for students oder groups, not for %v", per)
-		exitFunc(1)
+		return fmt.Errorf("it is only possible to set access levels for students or groups, not for %v", per)
 	}
+	return nil
 }
 
-func (c *Client) setaccess(assignmentCfg *config.AssignmentConfig,
-	project *gitlab.Project, members []*config.Student, cfgP *yacspin.Config) {
-	var cfg yacspin.Config
-	if cfgP == nil {
-		cfg = yacspin.Config{
-			Frequency: 100 * time.Millisecond,
-			CharSet:   yacspin.CharSets[69],
-			Suffix: aurora.Sprintf(aurora.Cyan(" setting access for project %s at %s"),
-				aurora.Yellow(project.Name),
-				aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
-			),
-			SuffixAutoColon:   true,
-			StopCharacter:     "✓",
-			StopColors:        []string{"fgGreen"},
-			StopFailMessage:   "error",
-			StopFailCharacter: "✗",
-			StopFailColors:    []string{"fgRed"},
-		}
-		spinner, err := yacspin.New(cfg)
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot create spinner")
-		}
-		err = spinner.Start()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot start spinner")
-		}
-		err = spinner.Stop()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
-	} else {
-		cfg = *cfgP
-	}
-
+func (c *Client) setaccess(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, members []*config.Student) {
 	for _, student := range members {
-		cfg.Suffix = aurora.Sprintf(aurora.Cyan(" ↪ adding member %s to %s as %s"),
+		task := c.rep.Task(aurora.Sprintf(aurora.Cyan(" ↪ adding member %s to %s as %s"),
 			aurora.Yellow(student.Raw),
 			aurora.Magenta(project.Name),
 			aurora.Magenta(assignmentCfg.AccessLevel.String()),
-		)
-		spinner, err := yacspin.New(cfg)
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot create spinner")
-		}
-		err = spinner.Start()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot start spinner")
-		}
+		))
 
 		userID, err := c.getUserID(student)
 		if err != nil {
@@ -84,29 +40,13 @@ func (c *Client) setaccess(assignmentCfg *config.AssignmentConfig,
 				log.Debug().Str("email", *student.Email).Msg("inviting via email")
 				info, err := c.inviteByEmail(assignmentCfg, project.ID, *student.Email)
 				if err != nil {
-					spinner.StopFailMessage(fmt.Sprintf("%v", err))
-
-					err := spinner.StopFail()
-					if err != nil {
-						log.Debug().Err(err).Msg("cannot stop spinner")
-					}
+					task.Fail(fmt.Sprintf("%v", err))
 				} else {
-					spinner.StopMessage(aurora.Sprintf(aurora.Green(info)))
-
-					err = spinner.Stop()
-					if err != nil {
-						log.Debug().Err(err).Msg("cannot stop spinner")
-					}
+					task.Done(aurora.Sprintf(aurora.Green(info)))
 				}
 				continue
-			} else {
-				spinner.StopFailMessage(fmt.Sprintf("cannot get user id: %v", err))
-
-				err := spinner.StopFail()
-				if err != nil {
-					log.Debug().Err(err).Msg("cannot stop spinner")
-				}
 			}
+			task.Fail(fmt.Sprintf("cannot get user id: %v", err))
 			continue
 		}
 
@@ -120,20 +60,11 @@ func (c *Client) setaccess(assignmentCfg *config.AssignmentConfig,
 				Str("assignment", assignmentCfg.Name).
 				Msg("error while adding member")
 
-			spinner.StopFailMessage(fmt.Sprintf("cannot add user %v: %v", student, err))
-
-			err := spinner.StopFail()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
-			}
+			task.Fail(fmt.Sprintf("cannot add user %v: %v", student, err))
 			continue
 		}
 
-		spinner.StopMessage(aurora.Sprintf(aurora.Green(info)))
-		err = spinner.Stop()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
+		task.Done(aurora.Sprintf(aurora.Green(info)))
 	}
 }
 
@@ -154,7 +85,7 @@ func (c *Client) inviteByEmail(cfg *config.AssignmentConfig, projectID int64, em
 
 func (c *Client) setaccessPerStudent(assignmentCfg *config.AssignmentConfig) {
 	if len(assignmentCfg.Students) == 0 {
-		fmt.Println("no students in config for assignment found")
+		c.rep.Println("no students in config for assignment found")
 		return
 	}
 
@@ -165,10 +96,10 @@ func (c *Client) setaccessPerStudent(assignmentCfg *config.AssignmentConfig) {
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
-			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
+			c.rep.Printf("cannot set access for project %s failed with %s", projectname, err)
 			return
 		}
-		c.setaccess(assignmentCfg, project, []*config.Student{student}, nil)
+		c.setaccess(assignmentCfg, project, []*config.Student{student})
 	}
 }
 
@@ -185,9 +116,9 @@ func (c *Client) setaccessPerGroup(assignmentCfg *config.AssignmentConfig) {
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
-			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
+			c.rep.Printf("cannot set access for project %s failed with %s", projectname, err)
 			return
 		}
-		c.setaccess(assignmentCfg, project, grp.Members, nil)
+		c.setaccess(assignmentCfg, project, grp.Members)
 	}
 }

--- a/gitlab/setaccess_contract_test.go
+++ b/gitlab/setaccess_contract_test.go
@@ -13,7 +13,6 @@ import (
 // ---- Setaccess (top-level) --------------------------------------------------
 
 func TestSetaccess_GroupNotFound_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -25,11 +24,12 @@ func TestSetaccess_GroupNotFound_Exits(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		Per:    config.PerStudent,
 	}
-	assertExitCode(t, 1, func() { client.Setaccess(cfg) })
+	if err := client.Setaccess(cfg); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 func TestSetaccess_InvalidPer_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups" {
@@ -44,7 +44,9 @@ func TestSetaccess_InvalidPer_Exits(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		Per:    config.PerFailed,
 	}
-	assertExitCode(t, 1, func() { client.Setaccess(cfg) })
+	if err := client.Setaccess(cfg); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 // ---- setaccessPerStudent ----------------------------------------------------

--- a/gitlab/update.go
+++ b/gitlab/update.go
@@ -2,21 +2,18 @@ package gitlab
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
 	"github.com/obcode/glabs/v3/git"
 	"github.com/rs/zerolog/log"
-	"github.com/theckman/yacspin"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) Update(assignmentCfg *config.AssignmentConfig) {
+func (c *Client) Update(assignmentCfg *config.AssignmentConfig) error {
 	_, err := c.getGroupID(assignmentCfg)
 	if err != nil {
-		fmt.Printf("error: GitLab group for assignment does not exist, please create the group %s\n", assignmentCfg.URL)
-		exitFunc(1)
+		return fmt.Errorf("GitLab group for assignment does not exist, please create the group %s", assignmentCfg.URL)
 	}
 
 	var starterrepo *git.SourceRepo
@@ -28,10 +25,8 @@ func (c *Client) Update(assignmentCfg *config.AssignmentConfig) {
 			assignmentCfg.Startercode.Template,
 			assignmentCfg.Startercode.TemplateMessage,
 		)
-
 		if err != nil {
-			fmt.Println(err)
-			exitFunc(1)
+			return err
 		}
 	}
 
@@ -41,56 +36,26 @@ func (c *Client) Update(assignmentCfg *config.AssignmentConfig) {
 	case config.PerStudent:
 		c.updatePerStudent(assignmentCfg, starterrepo)
 	default:
-		fmt.Printf("it is only possible to update for students oder groups, not for %v", per)
-		exitFunc(1)
+		return fmt.Errorf("it is only possible to update for students or groups, not for %v", per)
 	}
+	return nil
 }
 
 func (c *Client) update(assignmentCfg *config.AssignmentConfig, project *gitlab.Project, starterrepo *git.SourceRepo) {
-
-	cfg := yacspin.Config{
-		Frequency: 100 * time.Millisecond,
-		CharSet:   yacspin.CharSets[69],
-		Suffix: aurora.Sprintf(aurora.Cyan(" updating project %s at %s"),
-			aurora.Yellow(project.Name),
-			aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
-		),
-		SuffixAutoColon:   true,
-		StopCharacter:     "✓",
-		StopColors:        []string{"fgGreen"},
-		StopFailMessage:   "error",
-		StopFailCharacter: "✗",
-		StopFailColors:    []string{"fgRed"},
+	if starterrepo == nil {
+		return
 	}
 
-	spinner, err := yacspin.New(cfg)
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot create spinner")
+	task := c.rep.Task(aurora.Sprintf(aurora.Cyan(" updating project %s at %s"),
+		aurora.Yellow(project.Name),
+		aurora.Magenta(assignmentCfg.URL+"/"+project.Name),
+	))
+
+	if err := c.pushStartercode(assignmentCfg, starterrepo, project); err != nil {
+		task.Fail(fmt.Sprintf("problem: %v", err))
+		return
 	}
-	err = spinner.Start()
-	if err != nil {
-		log.Debug().Err(err).Msg("cannot start spinner")
-	}
-
-	if starterrepo != nil {
-		cfg.Suffix = aurora.Sprintf(aurora.Cyan(" ↪ pushing updates from startercode"))
-
-		err = c.pushStartercode(assignmentCfg, starterrepo, project)
-		if err != nil {
-			spinner.StopFailMessage(fmt.Sprintf("problem: %v", err))
-
-			err := spinner.StopFail()
-			if err != nil {
-				log.Debug().Err(err).Msg("cannot stop spinner")
-			}
-			return
-		}
-
-		err = spinner.Stop()
-		if err != nil {
-			log.Debug().Err(err).Msg("cannot stop spinner")
-		}
-	}
+	task.Done("")
 }
 
 func (c *Client) updatePerStudent(assignmentCfg *config.AssignmentConfig, starterrepo *git.SourceRepo) {
@@ -106,7 +71,7 @@ func (c *Client) updatePerStudent(assignmentCfg *config.AssignmentConfig, starte
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
-			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
+			c.rep.Printf("cannot update project %s failed with %s", projectname, err)
 			return
 		}
 		c.update(assignmentCfg, project, starterrepo)
@@ -126,7 +91,7 @@ func (c *Client) updatePerGroup(assignmentCfg *config.AssignmentConfig, starterr
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
-			fmt.Printf("cannot set access for project %s failed with %s", projectname, err)
+			c.rep.Printf("cannot update project %s failed with %s", projectname, err)
 			return
 		}
 		c.update(assignmentCfg, project, starterrepo)

--- a/gitlab/update.go
+++ b/gitlab/update.go
@@ -22,7 +22,7 @@ func (c *Client) Update(assignmentCfg *config.AssignmentConfig) {
 	var starterrepo *git.SourceRepo
 
 	if assignmentCfg.Startercode != nil {
-		starterrepo, err = git.PrepareSourceRepo(
+		starterrepo, err = git.PrepareSourceRepo(c.rep,
 			assignmentCfg.Startercode.URL,
 			assignmentCfg.Startercode.FromBranch,
 			assignmentCfg.Startercode.Template,

--- a/gitlab/update_contract_test.go
+++ b/gitlab/update_contract_test.go
@@ -11,7 +11,6 @@ import (
 // ---- Update (top-level) -----------------------------------------------------
 
 func TestUpdate_GroupNotFound_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -23,11 +22,12 @@ func TestUpdate_GroupNotFound_Exits(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		Per:    config.PerStudent,
 	}
-	assertExitCode(t, 1, func() { client.Update(cfg) })
+	if err := client.Update(cfg); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 func TestUpdate_InvalidPer_Exits(t *testing.T) {
-	defer withExitCapture(t)()
 
 	client := newContractClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/groups" {
@@ -42,7 +42,9 @@ func TestUpdate_InvalidPer_Exits(t *testing.T) {
 		Path:   "mpd/ss26/blatt-01",
 		Per:    config.PerFailed,
 	}
-	assertExitCode(t, 1, func() { client.Update(cfg) })
+	if err := client.Update(cfg); err == nil {
+		t.Fatal("expected an error")
+	}
 }
 
 // ---- updatePerStudent -------------------------------------------------------

--- a/reporter/console.go
+++ b/reporter/console.go
@@ -1,0 +1,81 @@
+package reporter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/theckman/yacspin"
+)
+
+// ConsoleReporter is the CLI reporter: spinners for tasks, stdout for lines. It
+// reproduces the terminal output glabs had before the reporter existed, so the
+// yacspin configuration here matches what the operation code used inline.
+type ConsoleReporter struct{}
+
+func NewConsoleReporter() *ConsoleReporter { return &ConsoleReporter{} }
+
+func (r *ConsoleReporter) Printf(format string, a ...any) { fmt.Printf(format, a...) }
+func (r *ConsoleReporter) Println(a ...any)               { fmt.Println(a...) }
+
+func (r *ConsoleReporter) Task(description string) Task {
+	cfg := yacspin.Config{
+		Frequency:         100 * time.Millisecond,
+		CharSet:           yacspin.CharSets[69],
+		Suffix:            description,
+		SuffixAutoColon:   true,
+		StopCharacter:     "✓",
+		StopColors:        []string{"fgGreen"},
+		StopFailMessage:   "error",
+		StopFailCharacter: "✗",
+		StopFailColors:    []string{"fgRed"},
+	}
+
+	spinner, err := yacspin.New(cfg)
+	if err != nil {
+		log.Debug().Err(err).Msg("cannot create spinner")
+		return &consoleTask{}
+	}
+	if err := spinner.Start(); err != nil {
+		log.Debug().Err(err).Msg("cannot start spinner")
+	}
+	return &consoleTask{spinner: spinner}
+}
+
+// consoleTask wraps a yacspin spinner. spinner may be nil if creation failed, in
+// which case the task degrades to no-ops — the same tolerance the inline spinner
+// code had.
+type consoleTask struct {
+	spinner *yacspin.Spinner
+}
+
+func (t *consoleTask) Update(message string) {
+	if t.spinner == nil {
+		return
+	}
+	t.spinner.Message(message)
+}
+
+func (t *consoleTask) Done(message string) {
+	if t.spinner == nil {
+		return
+	}
+	if message != "" {
+		t.spinner.StopMessage(message)
+	}
+	if err := t.spinner.Stop(); err != nil {
+		log.Debug().Err(err).Msg("cannot stop spinner")
+	}
+}
+
+func (t *consoleTask) Fail(message string) {
+	if t.spinner == nil {
+		return
+	}
+	if message != "" {
+		t.spinner.StopFailMessage(message)
+	}
+	if err := t.spinner.StopFail(); err != nil {
+		log.Debug().Err(err).Msg("cannot stop spinner")
+	}
+}

--- a/reporter/discard.go
+++ b/reporter/discard.go
@@ -1,0 +1,17 @@
+package reporter
+
+// DiscardReporter drops everything. It backs the CLI's --suppress mode (where
+// only machine-readable output is wanted) and keeps tests quiet.
+type DiscardReporter struct{}
+
+func NewDiscardReporter() *DiscardReporter { return &DiscardReporter{} }
+
+func (r *DiscardReporter) Printf(string, ...any) {}
+func (r *DiscardReporter) Println(...any)        {}
+func (r *DiscardReporter) Task(string) Task      { return discardTask{} }
+
+type discardTask struct{}
+
+func (discardTask) Update(string) {}
+func (discardTask) Done(string)   {}
+func (discardTask) Fail(string)   {}

--- a/reporter/discard.go
+++ b/reporter/discard.go
@@ -10,6 +10,11 @@ func (r *DiscardReporter) Printf(string, ...any) {}
 func (r *DiscardReporter) Println(...any)        {}
 func (r *DiscardReporter) Task(string) Task      { return discardTask{} }
 
+// NopTask is a task that does nothing. Operation helpers use it for the
+// "already inside a parent task, don't start my own spinner" case, so their body
+// can call Update/Done/Fail unconditionally instead of branching on a spin flag.
+func NopTask() Task { return discardTask{} }
+
 type discardTask struct{}
 
 func (discardTask) Update(string) {}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -1,0 +1,37 @@
+// Package reporter abstracts the progress output of long-running operations, so
+// the same gitlab and git code can drive a terminal spinner in the CLI and a
+// streamed log in the web server.
+//
+// It lives in its own package because config, git and gitlab all report
+// progress, and a shared type in any one of them would pull the others into an
+// import cycle. reporter imports nothing from the project.
+package reporter
+
+// Reporter receives the progress of an operation. The CLI's ConsoleReporter
+// renders it as spinners and colored lines; the web server will implement one
+// that streams LogLines to the browser.
+//
+// Callers keep coloring their own text (aurora.Sprintf(...)) and pass the result
+// through Printf/Println, so a console reporter reproduces today's output
+// verbatim and a stream reporter can forward the ANSI codes for the browser to
+// render.
+type Reporter interface {
+	// Printf writes a formatted line. The format may contain ANSI color codes.
+	Printf(format string, a ...any)
+	// Println writes its arguments as a line.
+	Println(a ...any)
+	// Task starts a unit of work shown with a spinner on the console. End it via
+	// the returned Task's Done or Fail; exactly one of those must be called.
+	Task(description string) Task
+}
+
+// Task is one unit of work in progress. It maps to a single spinner on the
+// console: a running description that ends in success or failure.
+type Task interface {
+	// Update changes the running message while the task is in progress.
+	Update(message string)
+	// Done ends the task successfully. An empty message keeps the description.
+	Done(message string)
+	// Fail ends the task as failed, showing message.
+	Fail(message string)
+}

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -1,0 +1,37 @@
+package reporter
+
+import "testing"
+
+// The discard reporter must absorb everything without panicking, including a
+// full task lifecycle — it backs --suppress and tests, where any output or a nil
+// task would be a bug.
+func TestDiscardReporter(t *testing.T) {
+	r := NewDiscardReporter()
+	r.Printf("%s", "ignored")
+	r.Println("ignored")
+
+	task := r.Task("work")
+	if task == nil {
+		t.Fatal("Task returned nil")
+	}
+	task.Update("still working")
+	task.Done("done")
+	task.Fail("also fine after done")
+}
+
+// The console reporter must tolerate a headless environment: creating a spinner
+// can fail with no TTY, and the task must degrade to no-ops rather than panic on
+// a nil spinner.
+func TestConsoleReporterTaskDoesNotPanicHeadless(t *testing.T) {
+	r := NewConsoleReporter()
+
+	task := r.Task("work")
+	if task == nil {
+		t.Fatal("Task returned nil")
+	}
+	task.Update("progress")
+	task.Done("")
+
+	// A fresh task ended via Fail must be fine too.
+	r.Task("other").Fail("nope")
+}


### PR DESCRIPTION
Schritt 5 des glabs-web-Plans — der letzte interne Refactor vor der Web-Arbeit. Zwei Commits (reporter-Fundament + gitlab-Methoden), `refactor:`, also **kein Release-Bump**. Danach ist der gesamte Kern aus einem Request-Handler benutzbar.

## Warum

Die gitlab-Methoden druckten Spinner auf stdout und riefen bei Fehlern `os.Exit`/`panic`. Beides ist für einen Server unmöglich: ein Config-Problem darf den Prozess nicht killen, und der Fortschritt muss an den Browser gestreamt werden statt auf ein stdout zu gehen, das niemand ansieht.

## Der Reporter

Neues Paket `reporter` (importiert nichts aus dem Projekt — sonst Import-Zyklus über config/git/gitlab):
- `Reporter`: `Printf`/`Println` für Zeilen, `Task(desc)` für eine Arbeitseinheit, die in `Done`/`Fail` endet.
- `ConsoleReporter`: rendert Tasks als die yacspin-Spinner, die glabs immer hatte.
- `DiscardReporter` + `NopTask()`: für `--suppress` und den „schon in einem Eltern-Task"-Fall (verschachtelte Spinner vermeiden).

Der Client hält den Reporter als **Feld** (`WithReporter`, Default Console) — die ~12 Methoden + ~20 Helfer reporten alle, und ein per-User-Web-Request baut ohnehin seinen eigenen Client, also ist der Reporter request-scoped und nie geteilt.

## Was konkret passiert

- **`Generate`, `Update`, `Delete`, `Archive`, `Setaccess`, `ProtectToBranch` geben error zurück** — die 14 `exitFunc(1)` werden Returns, `cmd/` meldet sie über `er()`.
- **`Report`/`ReportHTML`/`ReportJSON` geben error zurück**; `report()` liefert `(*Reports, error)` statt `nil`-bei-Fehler — das fixt den Nil-Deref, den die drei Report-Methoden riskierten.
- **`runtime.go`** und der exit/panic-Seam sind gelöscht.
- **Jeder yacspin-Spinner (6 Dateien) wird ein Task**; yacspin lebt jetzt nur noch im reporter-Paket. `gookit/color` in `check.go` rendert zu Strings, die durch `c.rep` gehen → check ist streambar.

## Zwei latente Bugs fielen dabei raus

- **`update`**: startete einen Spinner und kehrte bei fehlendem Startercode zurück, **ohne ihn zu stoppen** — Goroutine-Leak. Jetzt wird nur bei tatsächlicher Arbeit ein Task gestartet.
- **`setaccess`**: reichte eine `yacspin.Config` aus `generate` durch — diese Kopplung ist komplett weg.

## Verhalten unverändert

`ConsoleReporter` reproduziert die exakte yacspin-Config, und **`glabs show` ist byte-identisch** über mpd/vss. Terminal-Ausgabe hat keine Golden-Abdeckung, deshalb per Diff gegen das v3-Binary geprüft.

## Verifikation

- `go test ./...` grün; `-race` grün (config, reporter); `gofmt`, `go vet`, `golangci-lint` sauber
- yacspin nur noch im reporter-Paket importiert
- `glabs show` byte-identisch vor/nach
- Contract-Tests der 6 Methoden auf error-Rückgaben umgestellt

**Netto −311 Zeilen** — der Spinner-Boilerplate war größer als die Abstraktion, die ihn ersetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)