### PR TITLE
fix(test): repair the integration test after the reporter refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         run: go mod download
       - name: Run fast tests
         run: go test -v ./...
+      - name: Vet integration-tagged code (compile only, does not run)
+        run: go vet -tags=integration ./...
 
   coverage:
     name: coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,10 @@ go test ./...                # all unit + contract tests (fast, no network)
 go test ./config/...         # tests for a single package
 go test ./config/ -run TestName   # a single test
 gofmt -w <file> && go vet ./... && golangci-lint run   # what pre-commit / CI enforce
+go vet -tags=integration ./...   # compile-check integration tests — plain go vet/test skip them
 ```
+
+> The `integration` build tag hides those tests from `go test ./...` and `go vet ./...`, so a signature change can break them invisibly and only surface on `main` (where the integration job runs). Always `go vet -tags=integration ./...` after changing a signature the integration tests call. CI's fast-test job now does this too.
 
 Integration tests spin up GitLab CE in Testcontainers and are **opt-in** (startup takes 5–25 min). They are gated by both the `integration` build tag and the `GLABS_RUN_GITLAB_TC=1` env var:
 

--- a/gitlab/integration_gitlab_test.go
+++ b/gitlab/integration_gitlab_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/obcode/glabs/v3/config"
 	g "github.com/obcode/glabs/v3/git"
+	"github.com/obcode/glabs/v3/reporter"
 	"github.com/spf13/viper"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -162,7 +163,7 @@ func startGitLabContainer(t *testing.T) (*Client, string) {
 		t.Fatalf("creating gitlab api client failed: %v", err)
 	}
 
-	return &Client{apiClient}, baseURL
+	return &Client{Client: apiClient, rep: reporter.NewDiscardReporter()}, baseURL
 }
 
 func isTransientRegistryStartupError(err error) bool {
@@ -272,7 +273,9 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 		cfg := createGroupAndProject(t, "archive-a1", "student1", false)
 		projectPath := cfg.Path + "/" + cfg.RepoNameWithSuffix("student1")
 
-		client.Archive(cfg, false)
+		if err := client.Archive(cfg, false); err != nil {
+			t.Fatalf("Archive failed: %v", err)
+		}
 
 		proj, _, err := client.Projects.GetProject(projectPath, &gitlabapi.GetProjectOptions{})
 		if err != nil {
@@ -282,7 +285,9 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 			t.Fatal("expected project to be archived")
 		}
 
-		client.Archive(cfg, true) // unarchive
+		if err := client.Archive(cfg, true); err != nil { // unarchive
+			t.Fatalf("Unarchive failed: %v", err)
+		}
 
 		proj, _, err = client.Projects.GetProject(projectPath, &gitlabapi.GetProjectOptions{})
 		if err != nil {
@@ -323,7 +328,7 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 		gitURL := func(p *gitlabapi.Project) string { return baseURL + "/" + p.PathWithNamespace + ".git" }
 
 		// Clone it over HTTPS+PAT — proves the clone side of the transport.
-		sourceRepo, err := g.PrepareSourceRepo(gitURL(srcProject), "main", false, "")
+		sourceRepo, err := g.PrepareSourceRepo(reporter.NewDiscardReporter(), gitURL(srcProject), "main", false, "")
 		if err != nil {
 			t.Fatalf("PrepareSourceRepo over HTTPS failed: %v", err)
 		}
@@ -347,7 +352,7 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 			Startercode: &config.Startercode{ToBranch: "main"},
 		}
 		// Push over HTTPS+PAT — proves the push side of the transport.
-		if err := g.Push(cfg, dstProject.Name, sourceRepo, "main", true, dstProject); err != nil {
+		if err := g.Push(reporter.NewDiscardReporter(), cfg, dstProject.Name, sourceRepo, "main", true, dstProject); err != nil {
 			t.Fatalf("Push over HTTPS failed: %v", err)
 		}
 
@@ -372,7 +377,9 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 			t.Fatalf("getGroupIDByFullPath before delete failed: %v", err)
 		}
 
-		client.Delete(cfg)
+		if err := client.Delete(cfg); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
 
 		projects, _, err := client.Search.ProjectsByGroup(groupID, repoName, &gitlabapi.SearchOptions{})
 		if err != nil {
@@ -391,7 +398,9 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 		cfg := createGroupAndProject(t, "protect-a1", "student1", true)
 		cfg.Branches = []config.BranchRule{{Name: "main", Protect: true, Default: true}}
 
-		client.ProtectToBranch(cfg)
+		if err := client.ProtectToBranch(cfg); err != nil {
+			t.Fatalf("ProtectToBranch failed: %v", err)
+		}
 
 		projectPath := cfg.Path + "/" + cfg.RepoNameWithSuffix("student1")
 		proj, _, err := client.Projects.GetProject(projectPath, &gitlabapi.GetProjectOptions{})
@@ -420,7 +429,9 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 		cfg := createGroupAndProject(t, "setaccess-a1", itUsername, false)
 		cfg.AccessLevel = config.AccessLevel(gitlabapi.DeveloperPermissions) // 30
 
-		client.Setaccess(cfg)
+		if err := client.Setaccess(cfg); err != nil {
+			t.Fatalf("Setaccess failed: %v", err)
+		}
 
 		projectPath := cfg.Path + "/" + cfg.RepoNameWithSuffix(itUsername)
 		proj, _, err := client.Projects.GetProject(projectPath, &gitlabapi.GetProjectOptions{})


### PR DESCRIPTION
**main ist rot.** Der Integrationstest kompiliert nicht mehr.

## Ursache — ein Prozessloch

Der Reporter-Refactor (#82) änderte `git.PrepareSourceRepo`/`Push` (Reporter-Parameter) und gab `gitlab.Client` ein Feld. Der Integrationstest steht hinter dem `integration`-Build-Tag, und **`go test ./...` / `go vet ./...` kompilieren getaggte Dateien nicht**. Also:
- lokal grün, in der PR-CI grün (die Integration überspringt),
- erst auf `main` rot, wo der Integrationsjob läuft.

Genau die Klasse Fehler, die unsichtbar durchrutscht.

## Fix

1. **Aufrufstellen korrigiert** — ein `DiscardReporter` für den getaggten Test; die Methoden, die jetzt Fehler zurückgeben, prüfen sie auch (statt zu verwerfen).
2. **Das eigentliche Loch geschlossen:** `go vet -tags=integration ./...` in den fast-test-Job und in CLAUDE.mds pre-commit-Liste. `vet` kompiliert die Dateien, ohne sie auszuführen — braucht also weder Docker noch `GLABS_RUN_GITLAB_TC`. Damit scheitert eine Signaturänderung, die getaggte Tests bricht, künftig an einer **normalen PR** statt erst auf main.

## Verifikation

- `go vet -tags=integration ./...` sauber
- `go test ./...` grün; `gofmt` sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)