### PR TITLE
fix(release): attach binaries again by splitting goreleaser archives per build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,3 @@ jobs:
           hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Commit and push CHANGELOG.md
-        if: steps.semrel.outputs.version != ''
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "update changelog for v${{ steps.semrel.outputs.version }} [skip ci]"
-          git push

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,10 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+version: 2
+
 before:
     hooks:
-        # You may remove this if you don't use go modules.
         - go mod download
-        # you may remove this if you don't need go generate
         - go generate ./...
+
 builds:
     - id: glabs
       binary: glabs
@@ -23,17 +22,27 @@ builds:
           - CGO_ENABLED=0
       goos:
           - linux
-# archives:
-#   - replacements:
-#       darwin: Darwin
-#       linux: Linux
-#       windows: Windows
-#       386: i386
-#       amd64: x86_64
+
+# One archive per build. glabs ships for all platforms, glabs-web only for
+# linux (it is the server) — bundling both into one archive per platform would
+# leave linux archives with two binaries and the rest with one, which goreleaser
+# rejects. Separate archives keep each binary's archive self-consistent.
+archives:
+    - id: glabs
+      ids:
+          - glabs
+      name_template: "glabs_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    - id: glabs-web
+      ids:
+          - glabs-web
+      name_template: "glabs-web_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
 checksum:
     name_template: "checksums.txt"
+
 snapshot:
-    name_template: "{{ .Tag }}-next"
+    version_template: "{{ .Tag }}-next"
+
 changelog:
     sort: asc
     filters:


### PR DESCRIPTION
## Problem
Since `glabs-web` was added as a second goreleaser build (linux-only) next to `glabs` (all platforms), goreleaser bundled all binaries of a build into a single archive per platform. Linux archives then held two binaries while macOS/Windows held one, and goreleaser v2 rejects that mismatch:

> archive has different count of binaries for each platform

The release job failed at the archive step every time, so **v3.1.0, v3.2.0 and v3.3.0 were tagged with zero release assets** (v3.0.0, the last single-build release, still has its 9). `go install …@latest` kept working; only the pre-built binary downloads were missing.

## Fix
- One archive per build: `glabs` for all platforms, `glabs-web` for linux — each archive is self-consistent.
- Declare `version: 2` (the config was being read as version 0 with a warning).
- `snapshot.name_template` → `version_template` (v2 deprecation).
- Remove the dead "Commit and push CHANGELOG.md" release step left behind when CHANGELOG.md was dropped in #86.

## Verification
`goreleaser check` passes and a full `goreleaser release --snapshot --clean --skip=publish` produces the expected split archives:
```
glabs_…_{linux,windows,darwin}_{amd64,arm64,386}.tar.gz
glabs-web_…_linux_{amd64,arm64,386}.tar.gz
```
This is a `fix:` → cuts v3.3.1, whose release will attach the binaries that v3.1.0–v3.3.0 are missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)