### PR TITLE
fix(release): use archives.builds so the bundled goreleaser accepts the config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,11 +29,11 @@ builds:
 # rejects. Separate archives keep each binary's archive self-consistent.
 archives:
     - id: glabs
-      ids:
+      builds:
           - glabs
       name_template: "glabs_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     - id: glabs-web
-      ids:
+      builds:
           - glabs-web
       name_template: "glabs-web_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 


### PR DESCRIPTION
Follow-up to #88. The archive split there used `archives.ids`, but go-semantic-release/action@v1 bundles an **older** `GoReleaser@dev` (v2.31.0) that doesn't know that field:

```
GoReleaser hook has failed: yaml: unmarshal errors:
  line 32: field ids not found in type config.Archive
  line 36: field ids not found in type config.Archive
```

So the release hook failed before building and **v3.3.1 was tagged with zero assets again**.

`archives.builds` is the classic field the bundled version wants; recent goreleaser still accepts it (as a deprecated alias), so it works on both CI and locally. Switched `ids:` → `builds:`.

Verified with a full `goreleaser release --snapshot --clean --skip=publish`: split archives build cleanly (`glabs_…` for all platforms, `glabs-web_…` for linux). `fix:` → cuts v3.3.2, which should finally attach the binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)