### PR TITLE
feat(web): expose an assignment's own source values for the editor form

### DIFF
--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -2,9 +2,31 @@ package app
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/obcode/glabs/v3/config"
 )
+
+// FieldValue is one field's own (source) value, stringified and keyed by the
+// same key as FieldMeta so the GUI can pre-fill the schema-driven form.
+type FieldValue struct {
+	Key   string
+	Value string
+}
+
+// assignmentOwn extracts the source values of the schema's core fields from an
+// AssignmentSource, keyed by FieldMeta.key. Booleans become "true"/"false".
+func assignmentOwn(src *config.AssignmentSource) []FieldValue {
+	return []FieldValue{
+		{Key: "extends", Value: src.Extends},
+		{Key: "abstract", Value: strconv.FormatBool(src.Abstract)},
+		{Key: "per", Value: src.Per},
+		{Key: "accesslevel", Value: src.AccessLevel},
+		{Key: "description", Value: src.Description},
+		{Key: "assignmentpath", Value: src.AssignmentPath},
+		{Key: "containerRegistry", Value: strconv.FormatBool(src.ContainerRegistry)},
+	}
+}
 
 // AssignmentView is one assignment in source (own) form plus its resolved
 // preview — the same rendering `glabs show` produces. It makes the inheritance
@@ -14,6 +36,9 @@ type AssignmentView struct {
 	Name     string
 	Extends  string
 	Abstract bool
+	// Own holds the assignment's own (source) field values, keyed by
+	// FieldMeta.key, for pre-filling the editor form.
+	Own []FieldValue
 	// Resolved is the Show() rendering (may contain ANSI). Empty when the
 	// assignment cannot be resolved (then ResolveError explains why).
 	Resolved string
@@ -43,6 +68,7 @@ func (a *App) Assignment(ctx context.Context, course, name string) (*AssignmentV
 		Name:     name,
 		Extends:  src.Extends,
 		Abstract: src.Abstract,
+		Own:      assignmentOwn(src),
 	}
 
 	// Resolve from the stored bytes so the preview matches the CLI exactly

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -88,6 +88,25 @@ func TestAssignment_resolvesWithInheritance(t *testing.T) {
 	if !strings.Contains(v.Resolved, "student") {
 		t.Errorf("resolved preview should reflect inherited per=student:\n%s", v.Resolved)
 	}
+
+	// Own holds the source values (what the user wrote), not the inherited ones:
+	// blatt1 sets description and extends but NOT per (that comes from base).
+	own := map[string]string{}
+	for _, fv := range v.Own {
+		own[fv.Key] = fv.Value
+	}
+	if own["extends"] != "base" {
+		t.Errorf("own[extends] = %q, want base", own["extends"])
+	}
+	if own["description"] != "First sheet" {
+		t.Errorf("own[description] = %q, want 'First sheet'", own["description"])
+	}
+	if own["per"] != "" {
+		t.Errorf("own[per] = %q, want empty (per is inherited, not set on blatt1)", own["per"])
+	}
+	if own["abstract"] != "false" {
+		t.Errorf("own[abstract] = %q, want false", own["abstract"])
+	}
 }
 
 func TestAssignment_abstractBaseReportsResolveError(t *testing.T) {

--- a/web/graph/assignment_mapping.go
+++ b/web/graph/assignment_mapping.go
@@ -1,0 +1,57 @@
+package graph
+
+import (
+	"github.com/obcode/glabs/v3/web/app"
+	"github.com/obcode/glabs/v3/web/graph/model"
+)
+
+// Mappers for the assignment-editor types. They live here, not in a
+// *.resolvers.go file, so gqlgen (which owns those) leaves them alone.
+
+// emptyToNil maps an empty string to nil, for nullable GraphQL String fields.
+func emptyToNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// toGraphAssignmentSchema projects the server-authoritative field metadata onto
+// the GraphQL model.
+func toGraphAssignmentSchema(fields []app.FieldMeta) []*model.FieldMeta {
+	out := make([]*model.FieldMeta, 0, len(fields))
+	for _, f := range fields {
+		opts := make([]*model.FieldOption, 0, len(f.Options))
+		for _, o := range f.Options {
+			opts = append(opts, &model.FieldOption{Value: o.Value, Label: o.Label, Description: o.Description})
+		}
+		out = append(out, &model.FieldMeta{
+			Key:         f.Key,
+			Label:       f.Label,
+			Description: f.Description,
+			Kind:        model.FieldKind(f.Kind),
+			Required:    f.Required,
+			Deprecated:  f.Deprecated,
+			Example:     emptyToNil(f.Example),
+			Options:     opts,
+		})
+	}
+	return out
+}
+
+// toGraphAssignmentView projects an assignment view onto the GraphQL model.
+func toGraphAssignmentView(view *app.AssignmentView) *model.AssignmentView {
+	own := make([]*model.FieldValue, 0, len(view.Own))
+	for _, v := range view.Own {
+		own = append(own, &model.FieldValue{Key: v.Key, Value: v.Value})
+	}
+	return &model.AssignmentView{
+		Course:       view.Course,
+		Name:         view.Name,
+		Extends:      emptyToNil(view.Extends),
+		Abstract:     view.Abstract,
+		Own:          own,
+		Resolved:     view.Resolved,
+		ResolveError: emptyToNil(view.ResolveError),
+	}
+}

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -29,6 +29,16 @@ type FieldOption {
   description: String!
 }
 
+"""
+One field's own (source) value for an assignment — what the user wrote, before
+inheritance. Values are stringified (booleans as `true`/`false`) and keyed by the
+same `key` as FieldMeta, so the GUI can pre-fill each schema field generically.
+"""
+type FieldValue {
+  key: String!
+  value: String!
+}
+
 "The input shape the GUI should render for a field."
 enum FieldKind {
   STRING
@@ -49,6 +59,8 @@ type AssignmentView {
   extends: String
   "Whether this is an abstract base (a template for `extends`)."
   abstract: Boolean!
+  "The assignment's own (source) field values, keyed by FieldMeta.key, for pre-filling the editor form."
+  own: [FieldValue!]!
   "The resolved config rendered as text (may contain ANSI); empty when resolveError is set."
   resolved: String!
   "Why the assignment could not be resolved (e.g. abstract base, missing parent) — not an error."

--- a/web/graph/assignments.resolvers.go
+++ b/web/graph/assignments.resolvers.go
@@ -16,25 +16,7 @@ import (
 
 // AssignmentSchema is the resolver for the assignmentSchema field.
 func (r *queryResolver) AssignmentSchema(ctx context.Context) ([]*model.FieldMeta, error) {
-	fields := app.AssignmentSchema()
-	out := make([]*model.FieldMeta, 0, len(fields))
-	for _, f := range fields {
-		opts := make([]*model.FieldOption, 0, len(f.Options))
-		for _, o := range f.Options {
-			opts = append(opts, &model.FieldOption{Value: o.Value, Label: o.Label, Description: o.Description})
-		}
-		out = append(out, &model.FieldMeta{
-			Key:         f.Key,
-			Label:       f.Label,
-			Description: f.Description,
-			Kind:        model.FieldKind(f.Kind),
-			Required:    f.Required,
-			Deprecated:  f.Deprecated,
-			Example:     emptyToNil(f.Example),
-			Options:     opts,
-		})
-	}
-	return out, nil
+	return toGraphAssignmentSchema(app.AssignmentSchema()), nil
 }
 
 // Assignment is the resolver for the assignment field.
@@ -49,20 +31,5 @@ func (r *queryResolver) Assignment(ctx context.Context, course string, name stri
 	if view == nil {
 		return nil, nil
 	}
-	return &model.AssignmentView{
-		Course:       view.Course,
-		Name:         view.Name,
-		Extends:      emptyToNil(view.Extends),
-		Abstract:     view.Abstract,
-		Resolved:     view.Resolved,
-		ResolveError: emptyToNil(view.ResolveError),
-	}, nil
-}
-
-// emptyToNil maps an empty string to nil, for nullable GraphQL String fields.
-func emptyToNil(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
+	return toGraphAssignmentView(view), nil
 }

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -42,6 +42,7 @@ type ComplexityRoot struct {
 		Course       func(childComplexity int) int
 		Extends      func(childComplexity int) int
 		Name         func(childComplexity int) int
+		Own          func(childComplexity int) int
 		ResolveError func(childComplexity int) int
 		Resolved     func(childComplexity int) int
 	}
@@ -72,6 +73,11 @@ type ComplexityRoot struct {
 		Description func(childComplexity int) int
 		Label       func(childComplexity int) int
 		Value       func(childComplexity int) int
+	}
+
+	FieldValue struct {
+		Key   func(childComplexity int) int
+		Value func(childComplexity int) int
 	}
 
 	Finding struct {
@@ -180,6 +186,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.AssignmentView.Name(childComplexity), true
+	case "AssignmentView.own":
+		if e.ComplexityRoot.AssignmentView.Own == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AssignmentView.Own(childComplexity), true
 	case "AssignmentView.resolveError":
 		if e.ComplexityRoot.AssignmentView.ResolveError == nil {
 			break
@@ -309,6 +321,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.FieldOption.Value(childComplexity), true
+
+	case "FieldValue.key":
+		if e.ComplexityRoot.FieldValue.Key == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FieldValue.Key(childComplexity), true
+	case "FieldValue.value":
+		if e.ComplexityRoot.FieldValue.Value == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FieldValue.Value(childComplexity), true
 
 	case "Finding.message":
 		if e.ComplexityRoot.Finding.Message == nil {
@@ -603,6 +628,16 @@ type FieldOption {
   description: String!
 }
 
+"""
+One field's own (source) value for an assignment — what the user wrote, before
+inheritance. Values are stringified (booleans as ` + "`" + `true` + "`" + `/` + "`" + `false` + "`" + `) and keyed by the
+same ` + "`" + `key` + "`" + ` as FieldMeta, so the GUI can pre-fill each schema field generically.
+"""
+type FieldValue {
+  key: String!
+  value: String!
+}
+
 "The input shape the GUI should render for a field."
 enum FieldKind {
   STRING
@@ -623,6 +658,8 @@ type AssignmentView {
   extends: String
   "Whether this is an abstract base (a template for ` + "`" + `extends` + "`" + `)."
   abstract: Boolean!
+  "The assignment's own (source) field values, keyed by FieldMeta.key, for pre-filling the editor form."
+  own: [FieldValue!]!
   "The resolved config rendered as text (may contain ANSI); empty when resolveError is set."
   resolved: String!
   "Why the assignment could not be resolved (e.g. abstract base, missing parent) — not an error."
@@ -751,6 +788,8 @@ func (ec *executionContext) childFields_AssignmentView(ctx context.Context, fiel
 		return ec.fieldContext_AssignmentView_extends(ctx, field)
 	case "abstract":
 		return ec.fieldContext_AssignmentView_abstract(ctx, field)
+	case "own":
+		return ec.fieldContext_AssignmentView_own(ctx, field)
 	case "resolved":
 		return ec.fieldContext_AssignmentView_resolved(ctx, field)
 	case "resolveError":
@@ -813,6 +852,16 @@ func (ec *executionContext) childFields_FieldOption(ctx context.Context, field g
 		return ec.fieldContext_FieldOption_description(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type FieldOption", field.Name)
+}
+
+func (ec *executionContext) childFields_FieldValue(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "key":
+		return ec.fieldContext_FieldValue_key(ctx, field)
+	case "value":
+		return ec.fieldContext_FieldValue_value(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type FieldValue", field.Name)
 }
 
 func (ec *executionContext) childFields_Finding(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -1245,6 +1294,38 @@ func (ec *executionContext) _AssignmentView_abstract(ctx context.Context, field 
 }
 func (ec *executionContext) fieldContext_AssignmentView_abstract(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("AssignmentView", field, false, false, errors.New("field of type Boolean does not have child fields"))
+}
+
+func (ec *executionContext) _AssignmentView_own(ctx context.Context, field graphql.CollectedField, obj *model.AssignmentView) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_AssignmentView_own(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Own, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.FieldValue) graphql.Marshaler {
+			return ec.marshalNFieldValue2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValueᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_AssignmentView_own(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AssignmentView",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_FieldValue(ctx, field)
+		},
+	}
+	return fc, nil
 }
 
 func (ec *executionContext) _AssignmentView_resolved(ctx context.Context, field graphql.CollectedField, obj *model.AssignmentView) (ret graphql.Marshaler) {
@@ -1737,6 +1818,52 @@ func (ec *executionContext) _FieldOption_description(ctx context.Context, field 
 }
 func (ec *executionContext) fieldContext_FieldOption_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("FieldOption", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _FieldValue_key(ctx context.Context, field graphql.CollectedField, obj *model.FieldValue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_FieldValue_key(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Key, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_FieldValue_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("FieldValue", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _FieldValue_value(ctx context.Context, field graphql.CollectedField, obj *model.FieldValue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_FieldValue_value(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Value, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_FieldValue_value(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("FieldValue", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _Finding_path(ctx context.Context, field graphql.CollectedField, obj *model.Finding) (ret graphql.Marshaler) {
@@ -3644,6 +3771,11 @@ func (ec *executionContext) _AssignmentView(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "own":
+			out.Values[i] = ec._AssignmentView_own(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "resolved":
 			out.Values[i] = ec._AssignmentView_resolved(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -3845,6 +3977,49 @@ func (ec *executionContext) _FieldOption(ctx context.Context, sel ast.SelectionS
 			}
 		case "description":
 			out.Values[i] = ec._FieldOption_description(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferLabelToView), math.MaxInt32)))
+
+	ec.ProcessDeferredGroup(graphql.DeferredGroup{
+		Defers:   deferLabelToView,
+		Path:     graphql.GetPath(ctx),
+		FieldSet: deferredFieldSet,
+		Context:  ctx,
+	})
+
+	return out
+}
+
+var fieldValueImplementors = []string{"FieldValue"}
+
+func (ec *executionContext) _FieldValue(ctx context.Context, sel ast.SelectionSet, obj *model.FieldValue) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, fieldValueImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferredFieldSet := graphql.NewFieldSet(nil)
+	deferLabelToView := make(map[string]*graphql.FieldSetView)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("FieldValue")
+		case "key":
+			out.Values[i] = ec._FieldValue_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "value":
+			out.Values[i] = ec._FieldValue_value(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -4871,6 +5046,32 @@ func (ec *executionContext) marshalNFieldOption2ᚖgithubᚗcomᚋobcodeᚋglabs
 		return graphql.Null
 	}
 	return ec._FieldOption(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNFieldValue2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValueᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.FieldValue) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNFieldValue2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValue(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNFieldValue2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValue(ctx context.Context, sel ast.SelectionSet, v *model.FieldValue) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._FieldValue(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNFinding2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFindingᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Finding) graphql.Marshaler {

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -19,6 +19,8 @@ type AssignmentView struct {
 	Extends *string `json:"extends,omitempty"`
 	// Whether this is an abstract base (a template for `extends`).
 	Abstract bool `json:"abstract"`
+	// The assignment's own (source) field values, keyed by FieldMeta.key, for pre-filling the editor form.
+	Own []*FieldValue `json:"own"`
 	// The resolved config rendered as text (may contain ANSI); empty when resolveError is set.
 	Resolved string `json:"resolved"`
 	// Why the assignment could not be resolved (e.g. abstract base, missing parent) — not an error.
@@ -66,6 +68,14 @@ type FieldOption struct {
 	Value       string `json:"value"`
 	Label       string `json:"label"`
 	Description string `json:"description"`
+}
+
+// One field's own (source) value for an assignment — what the user wrote, before
+// inheritance. Values are stringified (booleans as `true`/`false`) and keyed by the
+// same `key` as FieldMeta, so the GUI can pre-fill each schema field generically.
+type FieldValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // One lint finding: configuration that does not do what it looks like it does.


### PR DESCRIPTION
Kleiner Backend-Schritt (B1) für das GUI-Editor-Formular: `AssignmentView` bekommt **`own: [FieldValue!]!`** — die eigenen (Source-)Werte eines Assignments, gekeyed nach `FieldMeta.key`, stringifiziert (Booleans als `true`/`false`).

Das GUI-Formular befüllt daraus seine Felder vor, während die aufgelöste `Show()`-Vorschau weiterhin die **geerbten/effektiven** Werte zeigt. So sieht man beides: was man selbst gesetzt hat vs. was durch `extends` wirksam wird.

Refactor: die Assignment-Mapper wandern nach `web/graph/assignment_mapping.go`, damit die gqlgen-eigene Resolver-Datei sauber bleibt.

## Verifiziert
`go test ./web/...` (own-Assertions in `assignments_test.go`) · `go vet` (beide Tags) · `golangci-lint` · live gegen glabs-web: `blatt01` own-Werte = `extends=defaults`, `description` gesetzt, `assignmentpath=blatt-01`, `per`/`accesslevel` leer (weil geerbt).

Nächster Schritt: das schema-getriebene Formular im GUI (B2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)