### PR TITLE
feat(web): validate and persist assignment drafts

### DIFF
--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -2,7 +2,10 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/obcode/glabs/v3/config"
 )
@@ -87,4 +90,130 @@ func (a *App) Assignment(ctx context.Context, course, name string) (*AssignmentV
 	}
 	view.Resolved = cfg.Show()
 	return view, nil
+}
+
+// ValidationResult reports whether a draft assignment is saveable and — when it
+// resolves — its preview.
+type ValidationResult struct {
+	OK           bool
+	Errors       []string
+	Resolved     string
+	ResolveError string
+}
+
+// applyDraft returns a copy of src with the draft's core-field values applied.
+// An empty value unsets a field (so it inherits). Only the schema's core fields
+// are editable here; nested blocks (mergeRequest, branches, …) are carried over
+// untouched.
+func applyDraft(src *config.AssignmentSource, draft map[string]string) *config.AssignmentSource {
+	c := *src
+	for key, val := range draft {
+		switch key {
+		case "extends":
+			c.Extends = val
+		case "abstract":
+			c.Abstract = val == "true"
+		case "per":
+			c.Per = val
+		case "accesslevel":
+			c.AccessLevel = val
+		case "description":
+			c.Description = val
+		case "assignmentpath":
+			c.AssignmentPath = val
+		case "containerRegistry":
+			c.ContainerRegistry = val == "true"
+		}
+	}
+	return &c
+}
+
+// courseWithDraft returns a shallow copy of the stored course source with the
+// named assignment replaced by the drafted version, without mutating the stored
+// source (its Assignments map is copied before the swap).
+func courseWithDraft(src *config.CourseSource, name string, drafted *config.AssignmentSource) *config.CourseSource {
+	newCourse := *src
+	assignments := make(map[string]*config.AssignmentSource, len(src.Assignments))
+	for k, v := range src.Assignments {
+		assignments[k] = v
+	}
+	assignments[name] = drafted
+	newCourse.Assignments = assignments
+	return &newCourse
+}
+
+// validateDrafted runs the drafted course through the real resolver. An abstract
+// draft is valid but has no preview; a concrete draft that does not resolve is a
+// hard error.
+func (a *App) validateDrafted(newCourse *config.CourseSource, course, name string, drafted *config.AssignmentSource) *ValidationResult {
+	if drafted.Abstract {
+		return &ValidationResult{OK: true, ResolveError: "abstrakte Basis — keine aufgelöste Vorschau"}
+	}
+	bytes, err := config.EncodeCourse(newCourse)
+	if err != nil {
+		return &ValidationResult{OK: false, Errors: []string{err.Error()}}
+	}
+	cfg, err := config.ResolveAssignmentFromBytes(bytes, course, name, config.Globals{GitlabHost: a.gitlabHost})
+	if err != nil {
+		return &ValidationResult{OK: false, Errors: []string{err.Error()}, ResolveError: err.Error()}
+	}
+	return &ValidationResult{OK: true, Resolved: cfg.Show()}
+}
+
+// draftedAssignment loads the caller's course and applies the draft to a copy of
+// the named assignment, returning the new (unsaved) course source and the drafted
+// assignment.
+func (a *App) draftedAssignment(ctx context.Context, course, name string, draft map[string]string) (*config.CourseSource, *config.AssignmentSource, error) {
+	stored, err := a.Course(ctx, course)
+	if err != nil {
+		return nil, nil, err
+	}
+	orig, ok := stored.Source.Assignments[name]
+	if !ok || orig == nil {
+		return nil, nil, fmt.Errorf("assignment %q not found in course %q", name, course)
+	}
+	drafted := applyDraft(orig, draft)
+	return courseWithDraft(stored.Source, name, drafted), drafted, nil
+}
+
+// ValidateAssignmentDraft validates a draft against the real resolver without
+// saving.
+func (a *App) ValidateAssignmentDraft(ctx context.Context, course, name string, draft map[string]string) (*ValidationResult, error) {
+	newCourse, drafted, err := a.draftedAssignment(ctx, course, name, draft)
+	if err != nil {
+		return nil, err
+	}
+	return a.validateDrafted(newCourse, course, name, drafted), nil
+}
+
+// SetAssignment applies a draft to one of the caller's assignments: it validates,
+// rejects a concrete draft that does not resolve, then persists — re-marshalling
+// the whole course YAML (a real edit gives up the verbatim original bytes).
+func (a *App) SetAssignment(ctx context.Context, course, name string, draft map[string]string) (*AssignmentView, error) {
+	stored, err := a.Course(ctx, course)
+	if err != nil {
+		return nil, err
+	}
+	orig, ok := stored.Source.Assignments[name]
+	if !ok || orig == nil {
+		return nil, fmt.Errorf("assignment %q not found in course %q", name, course)
+	}
+	drafted := applyDraft(orig, draft)
+	newCourse := courseWithDraft(stored.Source, name, drafted)
+
+	if vr := a.validateDrafted(newCourse, course, name, drafted); !vr.OK {
+		return nil, fmt.Errorf("assignment %q is not valid: %s", name, strings.Join(vr.Errors, "; "))
+	}
+
+	raw, err := config.EncodeCourse(newCourse)
+	if err != nil {
+		return nil, err
+	}
+	stored.Source = newCourse
+	stored.RawYAML = raw
+	stored.UpdatedAt = time.Now()
+	if err := a.db.SaveCourse(ctx, stored); err != nil {
+		return nil, err
+	}
+	return a.Assignment(ctx, course, name)
 }

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"errors"
 	"strings"
 	"testing"
@@ -8,6 +9,14 @@ import (
 	"github.com/obcode/glabs/v3/config"
 	"github.com/obcode/glabs/v3/web/db"
 )
+
+func ownMap(fvs []FieldValue) map[string]string {
+	m := map[string]string{}
+	for _, fv := range fvs {
+		m[fv.Key] = fv.Value
+	}
+	return m
+}
 
 func TestAssignmentSchema(t *testing.T) {
 	fields := AssignmentSchema()
@@ -153,5 +162,88 @@ func TestAssignment_unknownAssignmentAndCourse(t *testing.T) {
 	// Course not the caller's → ErrCourseNotFound propagates.
 	if _, err := a.Assignment(ctx, "other", "x"); !errors.Is(err, db.ErrCourseNotFound) {
 		t.Errorf("expected ErrCourseNotFound, got %v", err)
+	}
+}
+
+func TestValidateAssignmentDraft(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	// A valid draft resolves: ok, preview present, no errors.
+	vr, err := a.ValidateAssignmentDraft(ctx, "tc", "blatt1", map[string]string{"description": "Changed"})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !vr.OK || vr.Resolved == "" || len(vr.Errors) != 0 {
+		t.Errorf("valid draft: ok=%v resolvedLen=%d errors=%v", vr.OK, len(vr.Resolved), vr.Errors)
+	}
+
+	// A concrete draft that cannot resolve (missing parent) is a hard error.
+	bad, err := a.ValidateAssignmentDraft(ctx, "tc", "blatt1", map[string]string{"extends": "nope"})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if bad.OK || len(bad.Errors) == 0 {
+		t.Errorf("unresolvable draft should be not-ok with errors, got ok=%v errors=%v", bad.OK, bad.Errors)
+	}
+
+	// Validation is read-only: nothing persisted, stored source unchanged.
+	if fs.saved != nil {
+		t.Error("validate must not persist")
+	}
+	if got := fs.courses[owner+"/tc"].Source.Assignments["blatt1"].Description; got != "First sheet" {
+		t.Errorf("validate mutated the stored source: description = %q", got)
+	}
+}
+
+func TestSetAssignment_persists(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	view, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{"description": "Changed sheet"})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	// The returned view reflects the new own value and still resolves (per is
+	// still inherited from base).
+	if own := ownMap(view.Own); own["description"] != "Changed sheet" {
+		t.Errorf("own[description] = %q, want 'Changed sheet'", own["description"])
+	}
+	if !strings.Contains(view.Resolved, "student") {
+		t.Errorf("resolved preview lost the inherited per=student:\n%s", view.Resolved)
+	}
+
+	// Persisted: SaveCourse was called, the source is updated, and rawYAML was
+	// re-marshalled to reflect the edit.
+	if fs.saved == nil {
+		t.Fatal("SetAssignment did not persist")
+	}
+	if got := fs.saved.Source.Assignments["blatt1"].Description; got != "Changed sheet" {
+		t.Errorf("stored source description = %q", got)
+	}
+	if !bytes.Contains(fs.saved.RawYAML, []byte("Changed sheet")) {
+		t.Errorf("rawYAML was not re-marshalled with the edit:\n%s", fs.saved.RawYAML)
+	}
+}
+
+func TestSetAssignment_rejectsUnresolvable(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	if _, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{"extends": "nope"}); err == nil {
+		t.Error("expected SetAssignment to reject an unresolvable concrete draft")
+	}
+	if fs.saved != nil {
+		t.Error("an invalid draft must not be persisted")
 	}
 }

--- a/web/graph/assignment_mapping.go
+++ b/web/graph/assignment_mapping.go
@@ -39,6 +39,31 @@ func toGraphAssignmentSchema(fields []app.FieldMeta) []*model.FieldMeta {
 	return out
 }
 
+// draftToMap turns the GraphQL draft input into the key→value map the app uses.
+func draftToMap(draft []*model.FieldValueInput) map[string]string {
+	m := make(map[string]string, len(draft))
+	for _, d := range draft {
+		if d != nil {
+			m[d.Key] = d.Value
+		}
+	}
+	return m
+}
+
+// toGraphValidationResult projects a validation result onto the GraphQL model.
+func toGraphValidationResult(vr *app.ValidationResult) *model.ValidationResult {
+	errs := vr.Errors
+	if errs == nil {
+		errs = []string{}
+	}
+	return &model.ValidationResult{
+		Ok:           vr.OK,
+		Errors:       errs,
+		Resolved:     emptyToNil(vr.Resolved),
+		ResolveError: emptyToNil(vr.ResolveError),
+	}
+}
+
 // toGraphAssignmentView projects an assignment view onto the GraphQL model.
 func toGraphAssignmentView(view *app.AssignmentView) *model.AssignmentView {
 	own := make([]*model.FieldValue, 0, len(view.Own))

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -67,9 +67,37 @@ type AssignmentView {
   resolveError: String
 }
 
+"One field's drafted value, keyed by FieldMeta.key. Booleans as `true`/`false`; empty string unsets the field (so it inherits)."
+input FieldValueInput {
+  key: String!
+  value: String!
+}
+
+"""
+Result of validating a draft assignment against the real resolver (the same one
+the CLI uses), without saving.
+"""
+type ValidationResult {
+  "Whether the draft is structurally sound and could be saved."
+  ok: Boolean!
+  "Hard errors that make the draft unsaveable (empty when ok)."
+  errors: [String!]!
+  "The resolved config preview (Show() output, may contain ANSI) when the draft resolves."
+  resolved: String
+  "Why there is no preview though the draft is ok — e.g. an abstract base."
+  resolveError: String
+}
+
 extend type Query {
   "Field metadata for the assignment editor (server-authoritative labels, descriptions, dropdown options)."
   assignmentSchema: [FieldMeta!]!
   "One assignment of one of the caller's courses: source values, resolved preview. Null when there is no such assignment."
   assignment(course: String!, name: String!): AssignmentView
+  "Validate a draft assignment against the real resolver without saving."
+  validateAssignmentDraft(course: String!, name: String!, draft: [FieldValueInput!]!): ValidationResult!
+}
+
+extend type Mutation {
+  "Apply a draft to one of the caller's assignments: validate, then persist (re-marshals the course YAML). Rejects a concrete draft that does not resolve."
+  setAssignment(course: String!, name: String!, draft: [FieldValueInput!]!): AssignmentView!
 }

--- a/web/graph/assignments.resolvers.go
+++ b/web/graph/assignments.resolvers.go
@@ -14,6 +14,15 @@ import (
 	"github.com/obcode/glabs/v3/web/graph/model"
 )
 
+// SetAssignment is the resolver for the setAssignment field.
+func (r *mutationResolver) SetAssignment(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.AssignmentView, error) {
+	view, err := r.app.SetAssignment(ctx, course, name, draftToMap(draft))
+	if err != nil {
+		return nil, err
+	}
+	return toGraphAssignmentView(view), nil
+}
+
 // AssignmentSchema is the resolver for the assignmentSchema field.
 func (r *queryResolver) AssignmentSchema(ctx context.Context) ([]*model.FieldMeta, error) {
 	return toGraphAssignmentSchema(app.AssignmentSchema()), nil
@@ -32,4 +41,13 @@ func (r *queryResolver) Assignment(ctx context.Context, course string, name stri
 		return nil, nil
 	}
 	return toGraphAssignmentView(view), nil
+}
+
+// ValidateAssignmentDraft is the resolver for the validateAssignmentDraft field.
+func (r *queryResolver) ValidateAssignmentDraft(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.ValidationResult, error) {
+	vr, err := r.app.ValidateAssignmentDraft(ctx, course, name, draftToMap(draft))
+	if err != nil {
+		return nil, err
+	}
+	return toGraphValidationResult(vr), nil
 }

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -95,19 +95,21 @@ type ComplexityRoot struct {
 		DeleteCourse      func(childComplexity int, name string) int
 		ImportCourseYaml  func(childComplexity int, yaml string) int
 		RemoveGitlabToken func(childComplexity int) int
+		SetAssignment     func(childComplexity int, course string, name string, draft []*model.FieldValueInput) int
 		SetGitlabToken    func(childComplexity int, token string) int
 	}
 
 	Query struct {
-		Assignment       func(childComplexity int, course string, name string) int
-		AssignmentSchema func(childComplexity int) int
-		Course           func(childComplexity int, name string) int
-		CourseLint       func(childComplexity int, name string) int
-		CourseYaml       func(childComplexity int, name string) int
-		Courses          func(childComplexity int) int
-		GitlabToken      func(childComplexity int) int
-		Me               func(childComplexity int) int
-		ServerInfo       func(childComplexity int) int
+		Assignment              func(childComplexity int, course string, name string) int
+		AssignmentSchema        func(childComplexity int) int
+		Course                  func(childComplexity int, name string) int
+		CourseLint              func(childComplexity int, name string) int
+		CourseYaml              func(childComplexity int, name string) int
+		Courses                 func(childComplexity int) int
+		GitlabToken             func(childComplexity int) int
+		Me                      func(childComplexity int) int
+		ServerInfo              func(childComplexity int) int
+		ValidateAssignmentDraft func(childComplexity int, course string, name string, draft []*model.FieldValueInput) int
 	}
 
 	ServerInfo struct {
@@ -120,6 +122,13 @@ type ComplexityRoot struct {
 		Email func(childComplexity int) int
 		Name  func(childComplexity int) int
 	}
+
+	ValidationResult struct {
+		Errors       func(childComplexity int) int
+		Ok           func(childComplexity int) int
+		ResolveError func(childComplexity int) int
+		Resolved     func(childComplexity int) int
+	}
 }
 
 // endregion ***************************** api!.gotpl *****************************
@@ -129,6 +138,7 @@ type ComplexityRoot struct {
 type MutationResolver interface {
 	ImportCourseYaml(ctx context.Context, yaml string) (*model.Course, error)
 	DeleteCourse(ctx context.Context, name string) (bool, error)
+	SetAssignment(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.AssignmentView, error)
 	SetGitlabToken(ctx context.Context, token string) (*model.GitLabTokenStatus, error)
 	RemoveGitlabToken(ctx context.Context) (*model.GitLabTokenStatus, error)
 }
@@ -137,6 +147,7 @@ type QueryResolver interface {
 	ServerInfo(ctx context.Context) (*model.ServerInfo, error)
 	AssignmentSchema(ctx context.Context) ([]*model.FieldMeta, error)
 	Assignment(ctx context.Context, course string, name string) (*model.AssignmentView, error)
+	ValidateAssignmentDraft(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.ValidationResult, error)
 	Courses(ctx context.Context) ([]*model.Course, error)
 	Course(ctx context.Context, name string) (*model.Course, error)
 	CourseYaml(ctx context.Context, name string) (string, error)
@@ -395,6 +406,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.RemoveGitlabToken(childComplexity), true
+	case "Mutation.setAssignment":
+		if e.ComplexityRoot.Mutation.SetAssignment == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_setAssignment_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.SetAssignment(childComplexity, args["course"].(string), args["name"].(string), args["draft"].([]*model.FieldValueInput)), true
 	case "Mutation.setGitlabToken":
 		if e.ComplexityRoot.Mutation.SetGitlabToken == nil {
 			break
@@ -482,6 +504,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.ServerInfo(childComplexity), true
+	case "Query.validateAssignmentDraft":
+		if e.ComplexityRoot.Query.ValidateAssignmentDraft == nil {
+			break
+		}
+
+		args, err := ec.field_Query_validateAssignmentDraft_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.ValidateAssignmentDraft(childComplexity, args["course"].(string), args["name"].(string), args["draft"].([]*model.FieldValueInput)), true
 
 	case "ServerInfo.commit":
 		if e.ComplexityRoot.ServerInfo.Commit == nil {
@@ -515,6 +548,31 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.User.Name(childComplexity), true
 
+	case "ValidationResult.errors":
+		if e.ComplexityRoot.ValidationResult.Errors == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ValidationResult.Errors(childComplexity), true
+	case "ValidationResult.ok":
+		if e.ComplexityRoot.ValidationResult.Ok == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ValidationResult.Ok(childComplexity), true
+	case "ValidationResult.resolveError":
+		if e.ComplexityRoot.ValidationResult.ResolveError == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ValidationResult.ResolveError(childComplexity), true
+	case "ValidationResult.resolved":
+		if e.ComplexityRoot.ValidationResult.Resolved == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ValidationResult.Resolved(childComplexity), true
+
 	}
 	return 0, false
 }
@@ -522,7 +580,9 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	opCtx := graphql.GetOperationContext(ctx)
 	ec := newExecutionContext(opCtx, e, make(chan graphql.DeferredResult))
-	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+		ec.unmarshalInputFieldValueInput,
+	)
 	first := true
 
 	switch opCtx.Operation.Operation {
@@ -666,11 +726,39 @@ type AssignmentView {
   resolveError: String
 }
 
+"One field's drafted value, keyed by FieldMeta.key. Booleans as ` + "`" + `true` + "`" + `/` + "`" + `false` + "`" + `; empty string unsets the field (so it inherits)."
+input FieldValueInput {
+  key: String!
+  value: String!
+}
+
+"""
+Result of validating a draft assignment against the real resolver (the same one
+the CLI uses), without saving.
+"""
+type ValidationResult {
+  "Whether the draft is structurally sound and could be saved."
+  ok: Boolean!
+  "Hard errors that make the draft unsaveable (empty when ok)."
+  errors: [String!]!
+  "The resolved config preview (Show() output, may contain ANSI) when the draft resolves."
+  resolved: String
+  "Why there is no preview though the draft is ok — e.g. an abstract base."
+  resolveError: String
+}
+
 extend type Query {
   "Field metadata for the assignment editor (server-authoritative labels, descriptions, dropdown options)."
   assignmentSchema: [FieldMeta!]!
   "One assignment of one of the caller's courses: source values, resolved preview. Null when there is no such assignment."
   assignment(course: String!, name: String!): AssignmentView
+  "Validate a draft assignment against the real resolver without saving."
+  validateAssignmentDraft(course: String!, name: String!, draft: [FieldValueInput!]!): ValidationResult!
+}
+
+extend type Mutation {
+  "Apply a draft to one of the caller's assignments: validate, then persist (re-marshals the course YAML). Rejects a concrete draft that does not resolve."
+  setAssignment(course: String!, name: String!, draft: [FieldValueInput!]!): AssignmentView!
 }
 `, BuiltIn: false},
 	{Name: "../courses.graphqls", Input: `"""
@@ -908,6 +996,20 @@ func (ec *executionContext) childFields_User(ctx context.Context, field graphql.
 	return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 }
 
+func (ec *executionContext) childFields_ValidationResult(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "ok":
+		return ec.fieldContext_ValidationResult_ok(ctx, field)
+	case "errors":
+		return ec.fieldContext_ValidationResult_errors(ctx, field)
+	case "resolved":
+		return ec.fieldContext_ValidationResult_resolved(ctx, field)
+	case "resolveError":
+		return ec.fieldContext_ValidationResult_resolveError(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type ValidationResult", field.Name)
+}
+
 func (ec *executionContext) childFields___Directive(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "name":
@@ -1052,6 +1154,36 @@ func (ec *executionContext) field_Mutation_importCourseYAML_args(ctx context.Con
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_setAssignment_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "course",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["course"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "name",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["name"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "draft",
+		func(ctx context.Context, v any) ([]*model.FieldValueInput, error) {
+			return ec.unmarshalNFieldValueInput2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValueInputᚄ(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["draft"] = arg2
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_setGitlabToken_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -1141,6 +1273,36 @@ func (ec *executionContext) field_Query_course_args(ctx context.Context, rawArgs
 		return nil, err
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_validateAssignmentDraft_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "course",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["course"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "name",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["name"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "draft",
+		func(ctx context.Context, v any) ([]*model.FieldValueInput, error) {
+			return ec.unmarshalNFieldValueInput2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValueInputᚄ(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["draft"] = arg2
 	return args, nil
 }
 
@@ -2069,6 +2231,50 @@ func (ec *executionContext) fieldContext_Mutation_deleteCourse(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_setAssignment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_setAssignment(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().SetAssignment(ctx, fc.Args["course"].(string), fc.Args["name"].(string), fc.Args["draft"].([]*model.FieldValueInput))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.AssignmentView) graphql.Marshaler {
+			return ec.marshalNAssignmentView2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentView(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_setAssignment(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_AssignmentView(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_setAssignment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_setGitlabToken(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2279,6 +2485,50 @@ func (ec *executionContext) fieldContext_Query_assignment(ctx context.Context, f
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_assignment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_validateAssignmentDraft(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_validateAssignmentDraft(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().ValidateAssignmentDraft(ctx, fc.Args["course"].(string), fc.Args["name"].(string), fc.Args["draft"].([]*model.FieldValueInput))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.ValidationResult) graphql.Marshaler {
+			return ec.marshalNValidationResult2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐValidationResult(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_validateAssignmentDraft(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_ValidationResult(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_validateAssignmentDraft_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -2670,6 +2920,98 @@ func (ec *executionContext) _User_name(ctx context.Context, field graphql.Collec
 }
 func (ec *executionContext) fieldContext_User_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("User", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _ValidationResult_ok(ctx context.Context, field graphql.CollectedField, obj *model.ValidationResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ValidationResult_ok(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Ok, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v bool) graphql.Marshaler {
+			return ec.marshalNBoolean2bool(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_ValidationResult_ok(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ValidationResult", field, false, false, errors.New("field of type Boolean does not have child fields"))
+}
+
+func (ec *executionContext) _ValidationResult_errors(ctx context.Context, field graphql.CollectedField, obj *model.ValidationResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ValidationResult_errors(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Errors, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []string) graphql.Marshaler {
+			return ec.marshalNString2ᚕstringᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_ValidationResult_errors(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ValidationResult", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _ValidationResult_resolved(ctx context.Context, field graphql.CollectedField, obj *model.ValidationResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ValidationResult_resolved(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Resolved, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_ValidationResult_resolved(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ValidationResult", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _ValidationResult_resolveError(ctx context.Context, field graphql.CollectedField, obj *model.ValidationResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ValidationResult_resolveError(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ResolveError, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_ValidationResult_resolveError(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ValidationResult", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql.CollectedField, obj *introspection.Directive) (ret graphql.Marshaler) {
@@ -3731,6 +4073,43 @@ func (ec *executionContext) fieldContext___Type_isOneOf(_ context.Context, field
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputFieldValueInput(ctx context.Context, obj any) (model.FieldValueInput, error) {
+	var it model.FieldValueInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"key", "value"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Key = data
+		case "value":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Value = data
+		}
+	}
+	return it, nil
+}
+
 // endregion **************************** input.gotpl *****************************
 
 // region    ************************** interface.gotpl ***************************
@@ -4169,6 +4548,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "setAssignment":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_setAssignment(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "setGitlabToken":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_setGitlabToken(ctx, field)
@@ -4301,6 +4687,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				}()
 				res = ec._Query_assignment(ctx, field)
 				if res == graphql.RequiredNull {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "validateAssignmentDraft":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_validateAssignmentDraft(ctx, field)
+				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
 				return res
@@ -4525,6 +4933,59 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 		case "name":
 			out.Values[i] = ec._User_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferLabelToView), math.MaxInt32)))
+
+	ec.ProcessDeferredGroup(graphql.DeferredGroup{
+		Defers:   deferLabelToView,
+		Path:     graphql.GetPath(ctx),
+		FieldSet: deferredFieldSet,
+		Context:  ctx,
+	})
+
+	return out
+}
+
+var validationResultImplementors = []string{"ValidationResult"}
+
+func (ec *executionContext) _ValidationResult(ctx context.Context, sel ast.SelectionSet, obj *model.ValidationResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, validationResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferredFieldSet := graphql.NewFieldSet(nil)
+	deferLabelToView := make(map[string]*graphql.FieldSetView)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ValidationResult")
+		case "ok":
+			out.Values[i] = ec._ValidationResult_ok(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "errors":
+			out.Values[i] = ec._ValidationResult_errors(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "resolved":
+			out.Values[i] = ec._ValidationResult_resolved(ctx, field, obj)
+			if out.Values[i] == graphql.RequiredNull {
+				out.Invalids++
+			}
+		case "resolveError":
+			out.Values[i] = ec._ValidationResult_resolveError(ctx, field, obj)
+			if out.Values[i] == graphql.RequiredNull {
 				out.Invalids++
 			}
 		default:
@@ -4940,6 +5401,20 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalNAssignmentView2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentView(ctx context.Context, sel ast.SelectionSet, v model.AssignmentView) graphql.Marshaler {
+	return ec._AssignmentView(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAssignmentView2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentView(ctx context.Context, sel ast.SelectionSet, v *model.AssignmentView) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AssignmentView(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -5072,6 +5547,25 @@ func (ec *executionContext) marshalNFieldValue2ᚖgithubᚗcomᚋobcodeᚋglabs�
 		return graphql.Null
 	}
 	return ec._FieldValue(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNFieldValueInput2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValueInputᚄ(ctx context.Context, v any) ([]*model.FieldValueInput, error) {
+	vSlice := graphql.CoerceList(v)
+	var err error
+	res := make([]*model.FieldValueInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNFieldValueInput2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValueInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNFieldValueInput2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldValueInput(ctx context.Context, v any) (*model.FieldValueInput, error) {
+	res, err := ec.unmarshalInputFieldValueInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNFinding2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFindingᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Finding) graphql.Marshaler {
@@ -5227,6 +5721,20 @@ func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3�
 		return graphql.Null
 	}
 	return ec._User(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNValidationResult2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐValidationResult(ctx context.Context, sel ast.SelectionSet, v model.ValidationResult) graphql.Marshaler {
+	return ec._ValidationResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNValidationResult2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐValidationResult(ctx context.Context, sel ast.SelectionSet, v *model.ValidationResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ValidationResult(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -78,6 +78,12 @@ type FieldValue struct {
 	Value string `json:"value"`
 }
 
+// One field's drafted value, keyed by FieldMeta.key. Booleans as `true`/`false`; empty string unsets the field (so it inherits).
+type FieldValueInput struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
 // One lint finding: configuration that does not do what it looks like it does.
 type Finding struct {
 	Path     string          `json:"path"`
@@ -103,6 +109,19 @@ type ServerInfo struct {
 	Version string `json:"version"`
 	Commit  string `json:"commit"`
 	Date    string `json:"date"`
+}
+
+// Result of validating a draft assignment against the real resolver (the same one
+// the CLI uses), without saving.
+type ValidationResult struct {
+	// Whether the draft is structurally sound and could be saved.
+	Ok bool `json:"ok"`
+	// Hard errors that make the draft unsaveable (empty when ok).
+	Errors []string `json:"errors"`
+	// The resolved config preview (Show() output, may contain ANSI) when the draft resolves.
+	Resolved *string `json:"resolved,omitempty"`
+	// Why there is no preview though the draft is ok — e.g. an abstract base.
+	ResolveError *string `json:"resolveError,omitempty"`
 }
 
 // The input shape the GUI should render for a field.


### PR DESCRIPTION
Der **Schreibpfad** des Editors (C1) — validiert durch den **echten** Resolver, damit „valide" wirklich valide heißt.

## Was drin ist
- **Query `validateAssignmentDraft(course, name, draft)`** — wendet den Entwurf auf eine Kopie des Kurses an, jagt ihn durch dasselbe `ResolveAssignment` wie das CLI und liefert `ok`/`errors` + die aufgelöste Vorschau — **ohne zu speichern**. Abstrakter Entwurf = valide, aber ohne Vorschau; ein konkreter Entwurf, der nicht auflöst, ist ein harter Fehler.
- **Mutation `setAssignment(course, name, draft)`** — validiert, **lehnt einen nicht-auflösbaren konkreten Entwurf ab**, persistiert dann: Source aktualisieren + Kurs-YAML neu marshallen (eine echte Änderung gibt die verbatim Original-Bytes auf, wie geplant).
- Nur die Kernfelder des Schemas sind editierbar; verschachtelte Blöcke bleiben unangetastet. Die gespeicherte Source wird bei der Validierung **nie** mutiert (Entwurf wird auf eine Kopie angewandt).

## Verifiziert
`go test ./web/...` (validate ok/reject, persist + re-marshal, keine Mutation bei validate) · `go vet` (beide Tags) · `golangci-lint` · **live gegen glabs-web:** schlechter Entwurf → `ok:false`+Fehler; guter Entwurf → **Live-Vorschau** der Änderung; `setAssignment` persistiert, `courseYAML` enthält danach die Änderung.

Nächster Schritt: C2 — das GUI-Formular scharf schalten (Validieren/Live-Vorschau + Speichern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)