### PR TITLE
feat(web): startercode fields in the assignment editor schema

### DIFF
--- a/web/app/assignment_schema.go
+++ b/web/app/assignment_schema.go
@@ -33,11 +33,15 @@ type FieldMeta struct {
 	Key         string
 	Label       string
 	Description string
-	Kind        FieldKind
-	Required    bool
-	Deprecated  bool
-	Example     string
-	Options     []FieldOption
+	// Group is the section the field belongs to ("" for the top-level group,
+	// e.g. "Startercode" for the startercode block), so the GUI can render
+	// grouped sections. Nested keys are dotted, e.g. "startercode.url".
+	Group      string
+	Kind       FieldKind
+	Required   bool
+	Deprecated bool
+	Example    string
+	Options    []FieldOption
 }
 
 // AssignmentSchema returns the metadata for the assignment editor's fields.
@@ -100,5 +104,60 @@ var assignmentFields = []FieldMeta{
 		Label:       "Container-Registry",
 		Description: "Container-Registry für die erzeugten Projekte aktivieren.",
 		Kind:        KindBool,
+	},
+
+	// --- Startercode: aus welchem Repo/Branch die Studi-Repos befüllt werden ---
+	{
+		Key:         "startercode.url",
+		Label:       "Startercode-URL",
+		Description: "Git-URL des Startercode-Repos. SSH-Notation (git@host:pfad.git) ist erlaubt und wird zu HTTPS aufgelöst.",
+		Group:       "Startercode",
+		Kind:        KindString,
+		Example:     "git@gitlab.lrz.de:kurs/startercode/blatt-01.git",
+	},
+	{
+		Key:         "startercode.fromBranch",
+		Label:       "Von Branch",
+		Description: "Branch im Startercode, aus dem befüllt wird (Standard: der Default-Branch).",
+		Group:       "Startercode",
+		Kind:        KindString,
+		Example:     "main",
+	},
+	{
+		Key:         "startercode.tag",
+		Label:       "Tag",
+		Description: "Statt eines Branches einen bestimmten Tag verwenden.",
+		Group:       "Startercode",
+		Kind:        KindString,
+	},
+	{
+		Key:         "startercode.toBranch",
+		Label:       "Nach Branch",
+		Description: "Zielbranch im Studi-Repo, in den der Startercode gelegt wird (Standard: main).",
+		Group:       "Startercode",
+		Kind:        KindString,
+		Example:     "main",
+	},
+	{
+		Key:         "startercode.template",
+		Label:       "Als Template",
+		Description: "Den ersten Commit als Vorlage-Commit markieren.",
+		Group:       "Startercode",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "startercode.templateMessage",
+		Label:       "Template-Commit-Nachricht",
+		Description: "Commit-Nachricht für den Vorlage-Commit.",
+		Group:       "Startercode",
+		Kind:        KindString,
+	},
+	{
+		Key:         "startercode.additionalBranches",
+		Label:       "Zusätzliche Branches",
+		Description: "Weitere Branches, die zusätzlich angelegt werden. Kommagetrennt.",
+		Group:       "Startercode",
+		Kind:        KindStringList,
+		Example:     "dev, test",
 	},
 }

--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -17,9 +17,28 @@ type FieldValue struct {
 	Value string
 }
 
-// assignmentOwn extracts the source values of the schema's core fields from an
-// AssignmentSource, keyed by FieldMeta.key. Booleans become "true"/"false".
+// assignmentOwn extracts the source values of the schema's fields from an
+// AssignmentSource, keyed by FieldMeta.key. Booleans become "true"/"false",
+// string lists become comma-separated, and nested blocks use dotted keys.
 func assignmentOwn(src *config.AssignmentSource) []FieldValue {
+	sc := src.Startercode
+	scStr := func(f func(*config.StartercodeSource) string) string {
+		if sc == nil {
+			return ""
+		}
+		return f(sc)
+	}
+	scBool := func(f func(*config.StartercodeSource) bool) string {
+		if sc == nil {
+			return "false"
+		}
+		return strconv.FormatBool(f(sc))
+	}
+	var addBranches string
+	if sc != nil {
+		addBranches = strings.Join(sc.AdditionalBranches, ", ")
+	}
+
 	return []FieldValue{
 		{Key: "extends", Value: src.Extends},
 		{Key: "abstract", Value: strconv.FormatBool(src.Abstract)},
@@ -28,6 +47,13 @@ func assignmentOwn(src *config.AssignmentSource) []FieldValue {
 		{Key: "description", Value: src.Description},
 		{Key: "assignmentpath", Value: src.AssignmentPath},
 		{Key: "containerRegistry", Value: strconv.FormatBool(src.ContainerRegistry)},
+		{Key: "startercode.url", Value: scStr(func(s *config.StartercodeSource) string { return s.URL })},
+		{Key: "startercode.fromBranch", Value: scStr(func(s *config.StartercodeSource) string { return s.FromBranch })},
+		{Key: "startercode.tag", Value: scStr(func(s *config.StartercodeSource) string { return s.Tag })},
+		{Key: "startercode.toBranch", Value: scStr(func(s *config.StartercodeSource) string { return s.ToBranch })},
+		{Key: "startercode.template", Value: scBool(func(s *config.StartercodeSource) bool { return s.Template })},
+		{Key: "startercode.templateMessage", Value: scStr(func(s *config.StartercodeSource) string { return s.TemplateMessage })},
+		{Key: "startercode.additionalBranches", Value: addBranches},
 	}
 }
 
@@ -125,7 +151,80 @@ func applyDraft(src *config.AssignmentSource, draft map[string]string) *config.A
 			c.ContainerRegistry = val == "true"
 		}
 	}
+	c.Startercode = applyStartercodeDraft(src.Startercode, draft)
 	return &c
+}
+
+// applyStartercodeDraft rebuilds the startercode block from the draft's
+// startercode.* keys. It always returns a NEW struct (never mutates the shared
+// original) when the draft touches startercode, and nil when every startercode
+// field ends up empty (so the block is unset and inherits). When the draft does
+// not touch startercode at all, the original is returned unchanged.
+func applyStartercodeDraft(orig *config.StartercodeSource, draft map[string]string) *config.StartercodeSource {
+	touched := false
+	for k := range draft {
+		if strings.HasPrefix(k, "startercode.") {
+			touched = true
+			break
+		}
+	}
+	if !touched {
+		return orig
+	}
+
+	var sc config.StartercodeSource
+	if orig != nil {
+		sc = *orig
+	}
+	for k, v := range draft {
+		switch k {
+		case "startercode.url":
+			sc.URL = v
+		case "startercode.fromBranch":
+			sc.FromBranch = v
+		case "startercode.tag":
+			sc.Tag = v
+		case "startercode.toBranch":
+			sc.ToBranch = v
+		case "startercode.template":
+			sc.Template = v == "true"
+		case "startercode.templateMessage":
+			sc.TemplateMessage = v
+		case "startercode.additionalBranches":
+			sc.AdditionalBranches = splitList(v)
+		}
+	}
+	if startercodeEmpty(&sc) {
+		return nil
+	}
+	return &sc
+}
+
+// splitList parses a comma- or newline-separated list into trimmed, non-empty
+// entries.
+func splitList(s string) []string {
+	fields := strings.FieldsFunc(s, func(r rune) bool { return r == ',' || r == '\n' })
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if t := strings.TrimSpace(f); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func startercodeEmpty(s *config.StartercodeSource) bool {
+	// Legacy fields are not editable here, but they must still keep a block
+	// alive so saving never silently drops them (glabs config migrate is what
+	// removes them). staticcheck flags the deprecated reads; that is intentional.
+	//nolint:staticcheck // deprecated legacy fields are read only to preserve them
+	legacy := s.DevBranch != "" || s.ProtectToBranch || s.ProtectDevBranchMergeOnly ||
+		s.ReplicateIssue || len(s.IssueNumbers) > 0
+	return s.URL == "" && s.FromBranch == "" && s.Tag == "" && s.ToBranch == "" &&
+		!s.Template && s.TemplateMessage == "" && len(s.AdditionalBranches) == 0 && !legacy
 }
 
 // courseWithDraft returns a shallow copy of the stored course source with the

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -233,6 +233,50 @@ func TestSetAssignment_persists(t *testing.T) {
 	}
 }
 
+func TestSetAssignment_startercodeBlock(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	// Set a startercode block on blatt1.
+	view, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{
+		"startercode.url":                "git@gl:tc/sc.git",
+		"startercode.fromBranch":         "main",
+		"startercode.additionalBranches": "dev, test",
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	own := ownMap(view.Own)
+	if own["startercode.url"] != "git@gl:tc/sc.git" {
+		t.Errorf("own[startercode.url] = %q", own["startercode.url"])
+	}
+	if own["startercode.additionalBranches"] != "dev, test" {
+		t.Errorf("own[startercode.additionalBranches] = %q", own["startercode.additionalBranches"])
+	}
+	if !bytes.Contains(fs.saved.RawYAML, []byte("tc/sc.git")) {
+		t.Errorf("rawYAML missing the startercode url:\n%s", fs.saved.RawYAML)
+	}
+
+	// Unsetting every startercode field removes the block entirely.
+	view2, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{
+		"startercode.url":                "",
+		"startercode.fromBranch":         "",
+		"startercode.additionalBranches": "",
+	})
+	if err != nil {
+		t.Fatalf("set (unset): %v", err)
+	}
+	if got := ownMap(view2.Own)["startercode.url"]; got != "" {
+		t.Errorf("startercode should be unset, own[startercode.url] = %q", got)
+	}
+	if fs.saved.Source.Assignments["blatt1"].Startercode != nil {
+		t.Error("an all-empty startercode block should be removed (nil), not persisted empty")
+	}
+}
+
 func TestSetAssignment_rejectsUnresolvable(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/graph/assignment_mapping.go
+++ b/web/graph/assignment_mapping.go
@@ -29,6 +29,7 @@ func toGraphAssignmentSchema(fields []app.FieldMeta) []*model.FieldMeta {
 			Key:         f.Key,
 			Label:       f.Label,
 			Description: f.Description,
+			Group:       f.Group,
 			Kind:        model.FieldKind(f.Kind),
 			Required:    f.Required,
 			Deprecated:  f.Deprecated,

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -10,6 +10,8 @@ type FieldMeta {
   label: String!
   "Short help text describing what the field does."
   description: String!
+  "Section this field belongs to (empty for the top-level group), e.g. `startercode`. Lets the GUI render grouped sections."
+  group: String!
   "The input shape the GUI should render."
   kind: FieldKind!
   "Whether the field must be set for a concrete (non-abstract) assignment."

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -62,6 +62,7 @@ type ComplexityRoot struct {
 		Deprecated  func(childComplexity int) int
 		Description func(childComplexity int) int
 		Example     func(childComplexity int) int
+		Group       func(childComplexity int) int
 		Key         func(childComplexity int) int
 		Kind        func(childComplexity int) int
 		Label       func(childComplexity int) int
@@ -283,6 +284,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.FieldMeta.Example(childComplexity), true
+	case "FieldMeta.group":
+		if e.ComplexityRoot.FieldMeta.Group == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FieldMeta.Group(childComplexity), true
 	case "FieldMeta.key":
 		if e.ComplexityRoot.FieldMeta.Key == nil {
 			break
@@ -669,6 +676,8 @@ type FieldMeta {
   label: String!
   "Short help text describing what the field does."
   description: String!
+  "Section this field belongs to (empty for the top-level group), e.g. ` + "`" + `startercode` + "`" + `. Lets the GUI render grouped sections."
+  group: String!
   "The input shape the GUI should render."
   kind: FieldKind!
   "Whether the field must be set for a concrete (non-abstract) assignment."
@@ -916,6 +925,8 @@ func (ec *executionContext) childFields_FieldMeta(ctx context.Context, field gra
 		return ec.fieldContext_FieldMeta_label(ctx, field)
 	case "description":
 		return ec.fieldContext_FieldMeta_description(ctx, field)
+	case "group":
+		return ec.fieldContext_FieldMeta_group(ctx, field)
 	case "kind":
 		return ec.fieldContext_FieldMeta_kind(ctx, field)
 	case "required":
@@ -1786,6 +1797,29 @@ func (ec *executionContext) _FieldMeta_description(ctx context.Context, field gr
 	)
 }
 func (ec *executionContext) fieldContext_FieldMeta_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("FieldMeta", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _FieldMeta_group(ctx context.Context, field graphql.CollectedField, obj *model.FieldMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_FieldMeta_group(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Group, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_FieldMeta_group(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("FieldMeta", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
@@ -4283,6 +4317,11 @@ func (ec *executionContext) _FieldMeta(ctx context.Context, sel ast.SelectionSet
 			}
 		case "description":
 			out.Values[i] = ec._FieldMeta_description(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "group":
+			out.Values[i] = ec._FieldMeta_group(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -51,6 +51,8 @@ type FieldMeta struct {
 	Label string `json:"label"`
 	// Short help text describing what the field does.
 	Description string `json:"description"`
+	// Section this field belongs to (empty for the top-level group), e.g. `startercode`. Lets the GUI render grouped sections.
+	Group string `json:"group"`
 	// The input shape the GUI should render.
 	Kind FieldKind `json:"kind"`
 	// Whether the field must be set for a concrete (non-abstract) assignment.


### PR DESCRIPTION
Erster **verschachtelter Block** für den geführten Editor (D1) — `startercode`.

## Was drin ist
- **`FieldMeta.group`** — Felder können jetzt einer Sektion zugeordnet werden, damit das GUI gruppierte Abschnitte rendert. Verschachtelte Felder nutzen Punkt-Schlüssel (`startercode.url`, …).
- **`assignmentSchema`** bekommt die Startercode-Gruppe: `url`, `fromBranch`, `tag`, `toBranch`, `template`, `templateMessage`, `additionalBranches` (eine `STRINGLIST`, kommagetrennt).
- **`assignmentOwn`** liefert die `startercode.*`-Werte (verschachtelte Source → Punkt-Schlüssel).
- **`applyDraft`** baut den Startercode-Block aus den `startercode.*`-Keys neu auf — immer in ein **neues** Struct (nie das geteilte Original mutieren) — und **nil**t den Block, wenn alle Felder leer sind (unset/geerbt). Deprecated Legacy-Startercode-Felder bleiben erhalten, damit ein Speichern sie nie stillschweigend verwirft.

## Verifiziert
`go test ./web/...` (Startercode set/unset-Roundtrip) · `go vet` (beide Tags) · `golangci-lint` · live gegen glabs-web (Schema listet die gruppierten Felder; `blatt01` own spiegelt den Startercode der Fixture).

Nächster Schritt: D2 — GUI rendert die Gruppen als Sektionen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)