### PR TITLE
feat(web): mergeRequest fields in the assignment editor schema

### DIFF
--- a/web/app/assignment_schema.go
+++ b/web/app/assignment_schema.go
@@ -160,4 +160,59 @@ var assignmentFields = []FieldMeta{
 		Kind:        KindStringList,
 		Example:     "dev, test",
 	},
+
+	// --- Merge-Request: Merge-Strategie und -Bedingungen der Studi-Repos ---
+	{
+		Key:         "mergeRequest.mergeMethod",
+		Label:       "Merge-Methode",
+		Description: "Wie Merge-Requests zusammengeführt werden.",
+		Group:       "Merge-Request",
+		Kind:        KindEnum,
+		Options: []FieldOption{
+			{Value: "merge", Label: "Merge-Commit", Description: "Klassischer Merge-Commit — erhält die Historie."},
+			{Value: "semi_linear", Label: "Semi-linear", Description: "Merge-Commit, aber nur bei aktuellem Zielbranch (Rebase nötig)."},
+			{Value: "ff", Label: "Fast-Forward", Description: "Keine Merge-Commits, streng lineare Historie."},
+		},
+	},
+	{
+		Key:         "mergeRequest.squashOption",
+		Label:       "Squash-Option",
+		Description: "Ob Commits beim Merge zu einem zusammengefasst werden.",
+		Group:       "Merge-Request",
+		Kind:        KindEnum,
+		Options: []FieldOption{
+			{Value: "never", Label: "Nie", Description: "Nie squashen."},
+			{Value: "always", Label: "Immer", Description: "Immer squashen."},
+			{Value: "default_off", Label: "Standard aus", Description: "Pro MR wählbar, vorausgewählt: aus."},
+			{Value: "default_on", Label: "Standard an", Description: "Pro MR wählbar, vorausgewählt: an."},
+		},
+	},
+	{
+		Key:         "mergeRequest.pipeline",
+		Label:       "Pipeline muss erfolgreich sein",
+		Description: "Merge nur erlauben, wenn die Pipeline durchläuft.",
+		Group:       "Merge-Request",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "mergeRequest.skippedPipelinesAreSuccessful",
+		Label:       "Übersprungene Pipelines gelten als erfolgreich",
+		Description: "Eine übersprungene Pipeline blockiert den Merge nicht.",
+		Group:       "Merge-Request",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "mergeRequest.allThreadsMustBeResolved",
+		Label:       "Alle Threads müssen aufgelöst sein",
+		Description: "Merge nur erlauben, wenn alle Diskussionen aufgelöst sind.",
+		Group:       "Merge-Request",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "mergeRequest.statusChecksMustSucceed",
+		Label:       "Status-Checks müssen erfolgreich sein",
+		Description: "Merge nur erlauben, wenn alle externen Status-Checks grün sind.",
+		Group:       "Merge-Request",
+		Kind:        KindBool,
+	},
 }

--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -54,7 +54,27 @@ func assignmentOwn(src *config.AssignmentSource) []FieldValue {
 		{Key: "startercode.template", Value: scBool(func(s *config.StartercodeSource) bool { return s.Template })},
 		{Key: "startercode.templateMessage", Value: scStr(func(s *config.StartercodeSource) string { return s.TemplateMessage })},
 		{Key: "startercode.additionalBranches", Value: addBranches},
+		{Key: "mergeRequest.mergeMethod", Value: mrStr(src.MergeRequest, func(m *config.MergeRequestSource) string { return m.MergeMethod })},
+		{Key: "mergeRequest.squashOption", Value: mrStr(src.MergeRequest, func(m *config.MergeRequestSource) string { return m.SquashOption })},
+		{Key: "mergeRequest.pipeline", Value: mrBool(src.MergeRequest, func(m *config.MergeRequestSource) bool { return m.Pipeline })},
+		{Key: "mergeRequest.skippedPipelinesAreSuccessful", Value: mrBool(src.MergeRequest, func(m *config.MergeRequestSource) bool { return m.SkippedPipelinesAreSuccessful })},
+		{Key: "mergeRequest.allThreadsMustBeResolved", Value: mrBool(src.MergeRequest, func(m *config.MergeRequestSource) bool { return m.AllThreadsMustBeResolved })},
+		{Key: "mergeRequest.statusChecksMustSucceed", Value: mrBool(src.MergeRequest, func(m *config.MergeRequestSource) bool { return m.StatusChecksMustSucceed })},
 	}
+}
+
+func mrStr(m *config.MergeRequestSource, f func(*config.MergeRequestSource) string) string {
+	if m == nil {
+		return ""
+	}
+	return f(m)
+}
+
+func mrBool(m *config.MergeRequestSource, f func(*config.MergeRequestSource) bool) string {
+	if m == nil {
+		return "false"
+	}
+	return strconv.FormatBool(f(m))
 }
 
 // AssignmentView is one assignment in source (own) form plus its resolved
@@ -152,7 +172,52 @@ func applyDraft(src *config.AssignmentSource, draft map[string]string) *config.A
 		}
 	}
 	c.Startercode = applyStartercodeDraft(src.Startercode, draft)
+	c.MergeRequest = applyMergeRequestDraft(src.MergeRequest, draft)
 	return &c
+}
+
+// applyMergeRequestDraft rebuilds the mergeRequest block from the draft's
+// mergeRequest.* keys into a NEW struct (never mutating the shared original) and
+// nils it when every editable field is empty AND there is no approvals block.
+// The (not-yet-editable) approvals block is carried over untouched.
+func applyMergeRequestDraft(orig *config.MergeRequestSource, draft map[string]string) *config.MergeRequestSource {
+	touched := false
+	for k := range draft {
+		if strings.HasPrefix(k, "mergeRequest.") {
+			touched = true
+			break
+		}
+	}
+	if !touched {
+		return orig
+	}
+
+	var mr config.MergeRequestSource
+	if orig != nil {
+		mr = *orig
+	}
+	for k, v := range draft {
+		switch k {
+		case "mergeRequest.mergeMethod":
+			mr.MergeMethod = v
+		case "mergeRequest.squashOption":
+			mr.SquashOption = v
+		case "mergeRequest.pipeline":
+			mr.Pipeline = v == "true"
+		case "mergeRequest.skippedPipelinesAreSuccessful":
+			mr.SkippedPipelinesAreSuccessful = v == "true"
+		case "mergeRequest.allThreadsMustBeResolved":
+			mr.AllThreadsMustBeResolved = v == "true"
+		case "mergeRequest.statusChecksMustSucceed":
+			mr.StatusChecksMustSucceed = v == "true"
+		}
+	}
+	if mr.MergeMethod == "" && mr.SquashOption == "" && !mr.Pipeline &&
+		!mr.SkippedPipelinesAreSuccessful && !mr.AllThreadsMustBeResolved &&
+		!mr.StatusChecksMustSucceed && mr.Approvals == nil {
+		return nil
+	}
+	return &mr
 }
 
 // applyStartercodeDraft rebuilds the startercode block from the draft's

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -277,6 +277,49 @@ func TestSetAssignment_startercodeBlock(t *testing.T) {
 	}
 }
 
+func TestSetAssignment_mergeRequestBlock(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	view, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{
+		"mergeRequest.mergeMethod":  "ff",
+		"mergeRequest.squashOption": "always",
+		"mergeRequest.pipeline":     "true",
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	own := ownMap(view.Own)
+	if own["mergeRequest.mergeMethod"] != "ff" || own["mergeRequest.squashOption"] != "always" {
+		t.Errorf("own merge fields = %q / %q", own["mergeRequest.mergeMethod"], own["mergeRequest.squashOption"])
+	}
+	if own["mergeRequest.pipeline"] != "true" {
+		t.Errorf("own[mergeRequest.pipeline] = %q", own["mergeRequest.pipeline"])
+	}
+	if !bytes.Contains(fs.saved.RawYAML, []byte("mergeMethod: ff")) {
+		t.Errorf("rawYAML missing the merge method:\n%s", fs.saved.RawYAML)
+	}
+
+	// Unsetting everything removes the block.
+	view2, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{
+		"mergeRequest.mergeMethod":  "",
+		"mergeRequest.squashOption": "",
+		"mergeRequest.pipeline":     "false",
+	})
+	if err != nil {
+		t.Fatalf("set (unset): %v", err)
+	}
+	if got := ownMap(view2.Own)["mergeRequest.mergeMethod"]; got != "" {
+		t.Errorf("mergeRequest should be unset, got %q", got)
+	}
+	if fs.saved.Source.Assignments["blatt1"].MergeRequest != nil {
+		t.Error("an all-empty mergeRequest block should be removed (nil)")
+	}
+}
+
 func TestSetAssignment_rejectsUnresolvable(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()


### PR DESCRIPTION
Zweiter verschachtelter Block für den Editor — **Merge-Request** — nach demselben Muster wie startercode, und **reines Backend**: das GUI rendert jede Gruppe aus Enum-/Bool-Feldern generisch, also erscheint die Merge-Request-Sektion **ohne Frontend-Änderung**.

- **`assignmentSchema`** bekommt die Merge-Request-Gruppe: `mergeMethod` (Enum merge/semi_linear/ff), `squashOption` (Enum never/always/default_off/default_on) und die Booleans `pipeline`, `skippedPipelinesAreSuccessful`, `allThreadsMustBeResolved`, `statusChecksMustSucceed` — je mit kurzer Beschreibung (und Option-Hilfe bei den Enums).
- **`assignmentOwn`** liefert die `mergeRequest.*`-Werte; **`applyDraft`** baut den Block in ein neues Struct (nie das Original mutieren), `nil`t ihn bei leer, und reicht den (noch nicht editierbaren) `approvals`-Block unangetastet durch.

## Verifiziert
`go test ./web/...` (Merge-Request set/unset-Roundtrip) · `go vet` (beide Tags) · `golangci-lint` · **live:** das GUI von main rendert die Merge-Request-Sektion mit den mergeMethod/squashOption-Dropdowns automatisch; Speichern persistiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)