### PR TITLE
feat(web): create courses and assignments from scratch

### DIFF
--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -334,7 +334,7 @@ func (a *App) draftedAssignment(ctx context.Context, course, name string, draft 
 	}
 	orig, ok := stored.Source.Assignments[name]
 	if !ok || orig == nil {
-		return nil, nil, fmt.Errorf("assignment %q not found in course %q", name, course)
+		orig = &config.AssignmentSource{} // upsert: validate as a new assignment
 	}
 	drafted := applyDraft(orig, draft)
 	return courseWithDraft(stored.Source, name, drafted), drafted, nil
@@ -360,7 +360,12 @@ func (a *App) SetAssignment(ctx context.Context, course, name string, draft map[
 	}
 	orig, ok := stored.Source.Assignments[name]
 	if !ok || orig == nil {
-		return nil, fmt.Errorf("assignment %q not found in course %q", name, course)
+		// Upsert: create the assignment. Validate its name, since it becomes a
+		// GitLab path segment.
+		if !nameRe.MatchString(strings.TrimSpace(name)) {
+			return nil, fmt.Errorf("invalid assignment name %q: use only letters, digits, '.', '-' and '_'", name)
+		}
+		orig = &config.AssignmentSource{}
 	}
 	drafted := applyDraft(orig, draft)
 	newCourse := courseWithDraft(stored.Source, name, drafted)
@@ -380,4 +385,38 @@ func (a *App) SetAssignment(ctx context.Context, course, name string, draft map[
 		return nil, err
 	}
 	return a.Assignment(ctx, course, name)
+}
+
+// DeleteAssignment removes one assignment from one of the caller's courses and
+// re-marshals the course YAML. It returns false when there was no such
+// assignment (and does not touch the course).
+func (a *App) DeleteAssignment(ctx context.Context, course, name string) (bool, error) {
+	stored, err := a.Course(ctx, course)
+	if err != nil {
+		return false, err
+	}
+	if _, ok := stored.Source.Assignments[name]; !ok {
+		return false, nil
+	}
+
+	newCourse := *stored.Source
+	assignments := make(map[string]*config.AssignmentSource, len(stored.Source.Assignments))
+	for k, v := range stored.Source.Assignments {
+		if k != name {
+			assignments[k] = v
+		}
+	}
+	newCourse.Assignments = assignments
+
+	raw, err := config.EncodeCourse(&newCourse)
+	if err != nil {
+		return false, err
+	}
+	stored.Source = &newCourse
+	stored.RawYAML = raw
+	stored.UpdatedAt = time.Now()
+	if err := a.db.SaveCourse(ctx, stored); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -320,6 +320,89 @@ func TestSetAssignment_mergeRequestBlock(t *testing.T) {
 	}
 }
 
+func TestCreateCourse(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	a := &App{db: fs}
+	ctx := ctxAs(owner)
+
+	stored, err := a.CreateCourse(ctx, "newcourse", "nc/sem", "ss26", true, false)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if stored.Source.CoursePath != "nc/sem" || stored.Source.SemesterPath != "ss26" {
+		t.Errorf("paths not stored: %+v", stored.Source)
+	}
+	if len(stored.RawYAML) == 0 {
+		t.Error("expected rawYAML to be marshalled")
+	}
+
+	// Creating the same name again fails.
+	if _, err := a.CreateCourse(ctx, "newcourse", "x", "y", true, false); err == nil {
+		t.Error("expected an error creating a course that already exists")
+	}
+	// Invalid name is rejected.
+	if _, err := a.CreateCourse(ctx, "bad name!", "x", "y", true, false); err == nil {
+		t.Error("expected an error for an invalid course name")
+	}
+}
+
+func TestSetAssignment_upsertCreates(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	// The assignment "neu" does not exist yet; a valid draft creates it.
+	view, err := a.SetAssignment(ctx, "tc", "neu", map[string]string{
+		"per":         "student",
+		"description": "Brand new",
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if ownMap(view.Own)["description"] != "Brand new" {
+		t.Errorf("own[description] = %q", ownMap(view.Own)["description"])
+	}
+	if _, ok := fs.saved.Source.Assignments["neu"]; !ok {
+		t.Error("the new assignment was not persisted")
+	}
+
+	// An invalid assignment name is rejected on create.
+	if _, err := a.SetAssignment(ctx, "tc", "bad name!", map[string]string{"per": "student"}); err == nil {
+		t.Error("expected an error for an invalid new-assignment name")
+	}
+}
+
+func TestDeleteAssignment(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs}
+	ctx := ctxAs(owner)
+
+	ok, err := a.DeleteAssignment(ctx, "tc", "blatt1")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !ok {
+		t.Error("expected delete to report true")
+	}
+	if _, exists := fs.saved.Source.Assignments["blatt1"]; exists {
+		t.Error("blatt1 should be gone from the stored source")
+	}
+
+	// Deleting a non-existent assignment reports false.
+	got, err := a.DeleteAssignment(ctx, "tc", "nope")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got {
+		t.Error("deleting a missing assignment should report false")
+	}
+}
+
 func TestSetAssignment_rejectsUnresolvable(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/app/courses.go
+++ b/web/app/courses.go
@@ -2,13 +2,20 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/obcode/glabs/v3/config"
 	"github.com/obcode/glabs/v3/web/db"
 	"github.com/obcode/glabs/v3/web/principal"
 )
+
+// nameRe restricts course and assignment names to characters that are safe as a
+// path segment (they become part of the GitLab group/project path).
+var nameRe = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 // owner returns the email of the authenticated user, which scopes every course
 // operation. It comes from the request context — set by the auth middleware —
@@ -73,6 +80,54 @@ func (a *App) ImportCourseYAML(ctx context.Context, yaml string) (*db.StoredCour
 		Source:     source,
 		RawYAML:    []byte(yaml),
 		ImportedAt: importedAt,
+		UpdatedAt:  now,
+	}
+	if err := a.db.SaveCourse(ctx, stored); err != nil {
+		return nil, err
+	}
+	return stored, nil
+}
+
+// CreateCourse creates a new, empty course from scratch for the caller. It fails
+// if the caller already has a course by that name — assignments are added
+// afterwards with SetAssignment.
+func (a *App) CreateCourse(ctx context.Context, name, coursePath, semesterPath string, useCoursenameAsPrefix, useEmailDomainAsSuffix bool) (*db.StoredCourse, error) {
+	o, err := owner(ctx)
+	if err != nil {
+		return nil, err
+	}
+	name = strings.TrimSpace(name)
+	if !nameRe.MatchString(name) {
+		return nil, fmt.Errorf("invalid course name %q: use only letters, digits, '.', '-' and '_'", name)
+	}
+
+	existing, err := a.db.CourseOf(ctx, o, name)
+	if err != nil && !errors.Is(err, db.ErrCourseNotFound) {
+		return nil, err
+	}
+	if existing != nil {
+		return nil, fmt.Errorf("a course named %q already exists", name)
+	}
+
+	ueds := useEmailDomainAsSuffix
+	source := &config.CourseSource{
+		Name:                   name,
+		CoursePath:             strings.TrimSpace(coursePath),
+		SemesterPath:           strings.TrimSpace(semesterPath),
+		UseCoursenameAsPrefix:  useCoursenameAsPrefix,
+		UseEmailDomainAsSuffix: &ueds,
+	}
+	raw, err := config.EncodeCourse(source)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	stored := &db.StoredCourse{
+		Owner:      o,
+		Name:       name,
+		Source:     source,
+		RawYAML:    raw,
+		ImportedAt: now,
 		UpdatedAt:  now,
 	}
 	if err := a.db.SaveCourse(ctx, stored); err != nil {

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -100,6 +100,8 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Apply a draft to one of the caller's assignments: validate, then persist (re-marshals the course YAML). Rejects a concrete draft that does not resolve."
+  "Apply a draft to one of the caller's assignments, creating it if it does not exist: validate, then persist (re-marshals the course YAML). Rejects a concrete draft that does not resolve."
   setAssignment(course: String!, name: String!, draft: [FieldValueInput!]!): AssignmentView!
+  "Delete one assignment from one of the caller's courses. Returns false if there was no such assignment."
+  deleteAssignment(course: String!, name: String!): Boolean!
 }

--- a/web/graph/assignments.resolvers.go
+++ b/web/graph/assignments.resolvers.go
@@ -23,6 +23,11 @@ func (r *mutationResolver) SetAssignment(ctx context.Context, course string, nam
 	return toGraphAssignmentView(view), nil
 }
 
+// DeleteAssignment is the resolver for the deleteAssignment field.
+func (r *mutationResolver) DeleteAssignment(ctx context.Context, course string, name string) (bool, error) {
+	return r.app.DeleteAssignment(ctx, course, name)
+}
+
 // AssignmentSchema is the resolver for the assignmentSchema field.
 func (r *queryResolver) AssignmentSchema(ctx context.Context) ([]*model.FieldMeta, error) {
 	return toGraphAssignmentSchema(app.AssignmentSchema()), nil

--- a/web/graph/courses.graphqls
+++ b/web/graph/courses.graphqls
@@ -44,6 +44,17 @@ extend type Query {
 type Mutation {
   "Import a course from an uploaded YAML file, replacing any course of the same name."
   importCourseYAML(yaml: String!): Course!
+  """
+  Create a new, empty course from scratch. Fails if the caller already has a
+  course by that name (use setAssignment to add assignments afterwards).
+  """
+  createCourse(
+    name: String!
+    coursePath: String!
+    semesterPath: String!
+    useCoursenameAsPrefix: Boolean!
+    useEmailDomainAsSuffix: Boolean!
+  ): Course!
   "Delete one of the current user's courses."
   deleteCourse(name: String!): Boolean!
 }

--- a/web/graph/courses.resolvers.go
+++ b/web/graph/courses.resolvers.go
@@ -23,6 +23,15 @@ func (r *mutationResolver) ImportCourseYaml(ctx context.Context, yaml string) (*
 	return toGraphCourse(stored), nil
 }
 
+// CreateCourse is the resolver for the createCourse field.
+func (r *mutationResolver) CreateCourse(ctx context.Context, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) (*model.Course, error) {
+	stored, err := r.app.CreateCourse(ctx, name, coursePath, semesterPath, useCoursenameAsPrefix, useEmailDomainAsSuffix)
+	if err != nil {
+		return nil, err
+	}
+	return toGraphCourse(stored), nil
+}
+
 // DeleteCourse is the resolver for the deleteCourse field.
 func (r *mutationResolver) DeleteCourse(ctx context.Context, name string) (bool, error) {
 	if err := r.app.DeleteCourse(ctx, name); err != nil {

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -93,6 +93,8 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
+		CreateCourse      func(childComplexity int, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) int
+		DeleteAssignment  func(childComplexity int, course string, name string) int
 		DeleteCourse      func(childComplexity int, name string) int
 		ImportCourseYaml  func(childComplexity int, yaml string) int
 		RemoveGitlabToken func(childComplexity int) int
@@ -138,8 +140,10 @@ type ComplexityRoot struct {
 
 type MutationResolver interface {
 	ImportCourseYaml(ctx context.Context, yaml string) (*model.Course, error)
+	CreateCourse(ctx context.Context, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) (*model.Course, error)
 	DeleteCourse(ctx context.Context, name string) (bool, error)
 	SetAssignment(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.AssignmentView, error)
+	DeleteAssignment(ctx context.Context, course string, name string) (bool, error)
 	SetGitlabToken(ctx context.Context, token string) (*model.GitLabTokenStatus, error)
 	RemoveGitlabToken(ctx context.Context) (*model.GitLabTokenStatus, error)
 }
@@ -385,6 +389,28 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.GitLabTokenStatus.UpdatedAt(childComplexity), true
 
+	case "Mutation.createCourse":
+		if e.ComplexityRoot.Mutation.CreateCourse == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createCourse_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.CreateCourse(childComplexity, args["name"].(string), args["coursePath"].(string), args["semesterPath"].(string), args["useCoursenameAsPrefix"].(bool), args["useEmailDomainAsSuffix"].(bool)), true
+	case "Mutation.deleteAssignment":
+		if e.ComplexityRoot.Mutation.DeleteAssignment == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteAssignment_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.DeleteAssignment(childComplexity, args["course"].(string), args["name"].(string)), true
 	case "Mutation.deleteCourse":
 		if e.ComplexityRoot.Mutation.DeleteCourse == nil {
 			break
@@ -766,8 +792,10 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Apply a draft to one of the caller's assignments: validate, then persist (re-marshals the course YAML). Rejects a concrete draft that does not resolve."
+  "Apply a draft to one of the caller's assignments, creating it if it does not exist: validate, then persist (re-marshals the course YAML). Rejects a concrete draft that does not resolve."
   setAssignment(course: String!, name: String!, draft: [FieldValueInput!]!): AssignmentView!
+  "Delete one assignment from one of the caller's courses. Returns false if there was no such assignment."
+  deleteAssignment(course: String!, name: String!): Boolean!
 }
 `, BuiltIn: false},
 	{Name: "../courses.graphqls", Input: `"""
@@ -816,6 +844,17 @@ extend type Query {
 type Mutation {
   "Import a course from an uploaded YAML file, replacing any course of the same name."
   importCourseYAML(yaml: String!): Course!
+  """
+  Create a new, empty course from scratch. Fails if the caller already has a
+  course by that name (use setAssignment to add assignments afterwards).
+  """
+  createCourse(
+    name: String!
+    coursePath: String!
+    semesterPath: String!
+    useCoursenameAsPrefix: Boolean!
+    useEmailDomainAsSuffix: Boolean!
+  ): Course!
   "Delete one of the current user's courses."
   deleteCourse(name: String!): Boolean!
 }
@@ -1136,6 +1175,74 @@ func (ec *executionContext) childFields___Type(ctx context.Context, field graphq
 // endregion ************************** internal!.gotpl ***************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Mutation_createCourse_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "name",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["name"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "coursePath",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["coursePath"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "semesterPath",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["semesterPath"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "useCoursenameAsPrefix",
+		func(ctx context.Context, v any) (bool, error) {
+			return ec.unmarshalNBoolean2bool(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["useCoursenameAsPrefix"] = arg3
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "useEmailDomainAsSuffix",
+		func(ctx context.Context, v any) (bool, error) {
+			return ec.unmarshalNBoolean2bool(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["useEmailDomainAsSuffix"] = arg4
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteAssignment_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "course",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["course"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "name",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["name"] = arg1
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_deleteCourse_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
@@ -2221,6 +2328,50 @@ func (ec *executionContext) fieldContext_Mutation_importCourseYAML(ctx context.C
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createCourse(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_createCourse(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().CreateCourse(ctx, fc.Args["name"].(string), fc.Args["coursePath"].(string), fc.Args["semesterPath"].(string), fc.Args["useCoursenameAsPrefix"].(bool), fc.Args["useEmailDomainAsSuffix"].(bool))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.Course) graphql.Marshaler {
+			return ec.marshalNCourse2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐCourse(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_createCourse(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Course(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createCourse_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_deleteCourse(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2303,6 +2454,50 @@ func (ec *executionContext) fieldContext_Mutation_setAssignment(ctx context.Cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_setAssignment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteAssignment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_deleteAssignment(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().DeleteAssignment(ctx, fc.Args["course"].(string), fc.Args["name"].(string))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v bool) graphql.Marshaler {
+			return ec.marshalNBoolean2bool(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_deleteAssignment(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteAssignment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -4580,6 +4775,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "createCourse":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createCourse(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "deleteCourse":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteCourse(ctx, field)
@@ -4590,6 +4792,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "setAssignment":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_setAssignment(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteAssignment":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteAssignment(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++


### PR DESCRIPTION
Vervollständigt „**Config geführt anlegen**": ein Kurs lässt sich jetzt komplett im Web bauen — ganz ohne YAML-Import.

- **Mutation `createCourse(name, coursePath, semesterPath, useCoursenameAsPrefix, useEmailDomainAsSuffix)`** — legt einen neuen leeren Kurs an; scheitert, wenn der Aufrufer schon einen gleichen Namens hat. Der Name ist auf pfad-sichere Zeichen beschränkt.
- **`setAssignment` ist jetzt ein UPSERT** — existiert das Assignment nicht, wird es aus dem Draft erzeugt (mit derselben Validierung über den echten Resolver). Damit ist der geführte Editor zugleich das „Neues Assignment"-Formular. Der Name eines neuen Assignments wird validiert.
- **Mutation `deleteAssignment(course, name)`** — entfernt ein Assignment und marshallt die Kurs-YAML neu; `false`, wenn es keines gab.

## Verifiziert
`go test ./web/...` (create/upsert/delete) · `go vet` (beide Tags) · `golangci-lint` · **live gegen glabs-web:** `createCourse` → Assignment per Upsert anlegen → die Kurs-YAML entsteht from scratch → `deleteAssignment`.

Nächster Schritt: E2 — die GUI-Formulare („Neuer Kurs", „Neues Assignment", Löschen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)