### PR TITLE
feat(web): edit course-level settings after creation

### DIFF
--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -347,6 +347,40 @@ func TestCreateCourse(t *testing.T) {
 	}
 }
 
+func TestSetCourse(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs}
+	ctx := ctxAs(owner)
+
+	stored, err := a.SetCourse(ctx, "tc", "changed/path", "ws27", false, true)
+	if err != nil {
+		t.Fatalf("set course: %v", err)
+	}
+	if stored.Source.CoursePath != "changed/path" || stored.Source.SemesterPath != "ws27" {
+		t.Errorf("paths not updated: %+v", stored.Source)
+	}
+	if stored.Source.UseCoursenameAsPrefix {
+		t.Error("useCoursenameAsPrefix should be false")
+	}
+	if stored.Source.UseEmailDomainAsSuffix == nil || !*stored.Source.UseEmailDomainAsSuffix {
+		t.Error("useEmailDomainAsSuffix should be true")
+	}
+	// Assignments are preserved.
+	if _, ok := stored.Source.Assignments["blatt1"]; !ok {
+		t.Error("assignments must be preserved when editing course settings")
+	}
+	if !bytes.Contains(fs.saved.RawYAML, []byte("changed/path")) {
+		t.Errorf("rawYAML not re-marshalled:\n%s", fs.saved.RawYAML)
+	}
+
+	// A course that is not the caller's → ErrCourseNotFound.
+	if _, err := a.SetCourse(ctx, "nope", "x", "y", true, false); !errors.Is(err, db.ErrCourseNotFound) {
+		t.Errorf("expected ErrCourseNotFound, got %v", err)
+	}
+}
+
 func TestSetAssignment_upsertCreates(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/app/courses.go
+++ b/web/app/courses.go
@@ -136,6 +136,37 @@ func (a *App) CreateCourse(ctx context.Context, name, coursePath, semesterPath s
 	return stored, nil
 }
 
+// SetCourse updates the course-level settings of one of the caller's courses,
+// leaving assignments, students and groups untouched, and re-marshals the course
+// YAML.
+func (a *App) SetCourse(ctx context.Context, name, coursePath, semesterPath string, useCoursenameAsPrefix, useEmailDomainAsSuffix bool) (*db.StoredCourse, error) {
+	stored, err := a.Course(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Shallow copy: only the course-level scalars change; the Assignments map,
+	// Students slice and Groups map are shared and never mutated here.
+	newSource := *stored.Source
+	newSource.CoursePath = strings.TrimSpace(coursePath)
+	newSource.SemesterPath = strings.TrimSpace(semesterPath)
+	newSource.UseCoursenameAsPrefix = useCoursenameAsPrefix
+	ueds := useEmailDomainAsSuffix
+	newSource.UseEmailDomainAsSuffix = &ueds
+
+	raw, err := config.EncodeCourse(&newSource)
+	if err != nil {
+		return nil, err
+	}
+	stored.Source = &newSource
+	stored.RawYAML = raw
+	stored.UpdatedAt = time.Now()
+	if err := a.db.SaveCourse(ctx, stored); err != nil {
+		return nil, err
+	}
+	return stored, nil
+}
+
 // DeleteCourse removes one of the caller's own courses.
 func (a *App) DeleteCourse(ctx context.Context, name string) error {
 	o, err := owner(ctx)

--- a/web/graph/courses.graphqls
+++ b/web/graph/courses.graphqls
@@ -6,6 +6,10 @@ type Course {
   name: String!
   coursePath: String!
   semesterPath: String!
+  "Whether the course name is prepended to each project path."
+  useCoursenameAsPrefix: Boolean!
+  "Whether the student's email domain is appended as a suffix (default true)."
+  useEmailDomainAsSuffix: Boolean!
   "The names of the assignments in this course, sorted."
   assignmentNames: [String!]!
   studentCount: Int!
@@ -49,6 +53,14 @@ type Mutation {
   course by that name (use setAssignment to add assignments afterwards).
   """
   createCourse(
+    name: String!
+    coursePath: String!
+    semesterPath: String!
+    useCoursenameAsPrefix: Boolean!
+    useEmailDomainAsSuffix: Boolean!
+  ): Course!
+  "Update the course-level settings of one of the caller's courses (assignments, students and groups are untouched)."
+  setCourse(
     name: String!
     coursePath: String!
     semesterPath: String!

--- a/web/graph/courses.resolvers.go
+++ b/web/graph/courses.resolvers.go
@@ -32,6 +32,15 @@ func (r *mutationResolver) CreateCourse(ctx context.Context, name string, course
 	return toGraphCourse(stored), nil
 }
 
+// SetCourse is the resolver for the setCourse field.
+func (r *mutationResolver) SetCourse(ctx context.Context, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) (*model.Course, error) {
+	stored, err := r.app.SetCourse(ctx, name, coursePath, semesterPath, useCoursenameAsPrefix, useEmailDomainAsSuffix)
+	if err != nil {
+		return nil, err
+	}
+	return toGraphCourse(stored), nil
+}
+
 // DeleteCourse is the resolver for the deleteCourse field.
 func (r *mutationResolver) DeleteCourse(ctx context.Context, name string) (bool, error) {
 	if err := r.app.DeleteCourse(ctx, name); err != nil {

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -48,14 +48,16 @@ type ComplexityRoot struct {
 	}
 
 	Course struct {
-		AssignmentNames func(childComplexity int) int
-		CoursePath      func(childComplexity int) int
-		GroupCount      func(childComplexity int) int
-		ImportedAt      func(childComplexity int) int
-		Name            func(childComplexity int) int
-		SemesterPath    func(childComplexity int) int
-		StudentCount    func(childComplexity int) int
-		UpdatedAt       func(childComplexity int) int
+		AssignmentNames        func(childComplexity int) int
+		CoursePath             func(childComplexity int) int
+		GroupCount             func(childComplexity int) int
+		ImportedAt             func(childComplexity int) int
+		Name                   func(childComplexity int) int
+		SemesterPath           func(childComplexity int) int
+		StudentCount           func(childComplexity int) int
+		UpdatedAt              func(childComplexity int) int
+		UseCoursenameAsPrefix  func(childComplexity int) int
+		UseEmailDomainAsSuffix func(childComplexity int) int
 	}
 
 	FieldMeta struct {
@@ -99,6 +101,7 @@ type ComplexityRoot struct {
 		ImportCourseYaml  func(childComplexity int, yaml string) int
 		RemoveGitlabToken func(childComplexity int) int
 		SetAssignment     func(childComplexity int, course string, name string, draft []*model.FieldValueInput) int
+		SetCourse         func(childComplexity int, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) int
 		SetGitlabToken    func(childComplexity int, token string) int
 	}
 
@@ -141,6 +144,7 @@ type ComplexityRoot struct {
 type MutationResolver interface {
 	ImportCourseYaml(ctx context.Context, yaml string) (*model.Course, error)
 	CreateCourse(ctx context.Context, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) (*model.Course, error)
+	SetCourse(ctx context.Context, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) (*model.Course, error)
 	DeleteCourse(ctx context.Context, name string) (bool, error)
 	SetAssignment(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.AssignmentView, error)
 	DeleteAssignment(ctx context.Context, course string, name string) (bool, error)
@@ -269,6 +273,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Course.UpdatedAt(childComplexity), true
+	case "Course.useCoursenameAsPrefix":
+		if e.ComplexityRoot.Course.UseCoursenameAsPrefix == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Course.UseCoursenameAsPrefix(childComplexity), true
+	case "Course.useEmailDomainAsSuffix":
+		if e.ComplexityRoot.Course.UseEmailDomainAsSuffix == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Course.UseEmailDomainAsSuffix(childComplexity), true
 
 	case "FieldMeta.deprecated":
 		if e.ComplexityRoot.FieldMeta.Deprecated == nil {
@@ -450,6 +466,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.SetAssignment(childComplexity, args["course"].(string), args["name"].(string), args["draft"].([]*model.FieldValueInput)), true
+	case "Mutation.setCourse":
+		if e.ComplexityRoot.Mutation.SetCourse == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_setCourse_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.SetCourse(childComplexity, args["name"].(string), args["coursePath"].(string), args["semesterPath"].(string), args["useCoursenameAsPrefix"].(bool), args["useEmailDomainAsSuffix"].(bool)), true
 	case "Mutation.setGitlabToken":
 		if e.ComplexityRoot.Mutation.SetGitlabToken == nil {
 			break
@@ -806,6 +833,10 @@ type Course {
   name: String!
   coursePath: String!
   semesterPath: String!
+  "Whether the course name is prepended to each project path."
+  useCoursenameAsPrefix: Boolean!
+  "Whether the student's email domain is appended as a suffix (default true)."
+  useEmailDomainAsSuffix: Boolean!
   "The names of the assignments in this course, sorted."
   assignmentNames: [String!]!
   studentCount: Int!
@@ -849,6 +880,14 @@ type Mutation {
   course by that name (use setAssignment to add assignments afterwards).
   """
   createCourse(
+    name: String!
+    coursePath: String!
+    semesterPath: String!
+    useCoursenameAsPrefix: Boolean!
+    useEmailDomainAsSuffix: Boolean!
+  ): Course!
+  "Update the course-level settings of one of the caller's courses (assignments, students and groups are untouched)."
+  setCourse(
     name: String!
     coursePath: String!
     semesterPath: String!
@@ -942,6 +981,10 @@ func (ec *executionContext) childFields_Course(ctx context.Context, field graphq
 		return ec.fieldContext_Course_coursePath(ctx, field)
 	case "semesterPath":
 		return ec.fieldContext_Course_semesterPath(ctx, field)
+	case "useCoursenameAsPrefix":
+		return ec.fieldContext_Course_useCoursenameAsPrefix(ctx, field)
+	case "useEmailDomainAsSuffix":
+		return ec.fieldContext_Course_useEmailDomainAsSuffix(ctx, field)
 	case "assignmentNames":
 		return ec.fieldContext_Course_assignmentNames(ctx, field)
 	case "studentCount":
@@ -1299,6 +1342,52 @@ func (ec *executionContext) field_Mutation_setAssignment_args(ctx context.Contex
 		return nil, err
 	}
 	args["draft"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_setCourse_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "name",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["name"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "coursePath",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["coursePath"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "semesterPath",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["semesterPath"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "useCoursenameAsPrefix",
+		func(ctx context.Context, v any) (bool, error) {
+			return ec.unmarshalNBoolean2bool(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["useCoursenameAsPrefix"] = arg3
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "useEmailDomainAsSuffix",
+		func(ctx context.Context, v any) (bool, error) {
+			return ec.unmarshalNBoolean2bool(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["useEmailDomainAsSuffix"] = arg4
 	return args, nil
 }
 
@@ -1721,6 +1810,52 @@ func (ec *executionContext) _Course_semesterPath(ctx context.Context, field grap
 }
 func (ec *executionContext) fieldContext_Course_semesterPath(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Course", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _Course_useCoursenameAsPrefix(ctx context.Context, field graphql.CollectedField, obj *model.Course) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Course_useCoursenameAsPrefix(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.UseCoursenameAsPrefix, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v bool) graphql.Marshaler {
+			return ec.marshalNBoolean2bool(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Course_useCoursenameAsPrefix(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Course", field, false, false, errors.New("field of type Boolean does not have child fields"))
+}
+
+func (ec *executionContext) _Course_useEmailDomainAsSuffix(ctx context.Context, field graphql.CollectedField, obj *model.Course) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Course_useEmailDomainAsSuffix(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.UseEmailDomainAsSuffix, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v bool) graphql.Marshaler {
+			return ec.marshalNBoolean2bool(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Course_useEmailDomainAsSuffix(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Course", field, false, false, errors.New("field of type Boolean does not have child fields"))
 }
 
 func (ec *executionContext) _Course_assignmentNames(ctx context.Context, field graphql.CollectedField, obj *model.Course) (ret graphql.Marshaler) {
@@ -2366,6 +2501,50 @@ func (ec *executionContext) fieldContext_Mutation_createCourse(ctx context.Conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createCourse_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_setCourse(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_setCourse(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().SetCourse(ctx, fc.Args["name"].(string), fc.Args["coursePath"].(string), fc.Args["semesterPath"].(string), fc.Args["useCoursenameAsPrefix"].(bool), fc.Args["useEmailDomainAsSuffix"].(bool))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.Course) graphql.Marshaler {
+			return ec.marshalNCourse2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐCourse(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_setCourse(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Course(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_setCourse_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -4442,6 +4621,16 @@ func (ec *executionContext) _Course(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "useCoursenameAsPrefix":
+			out.Values[i] = ec._Course_useCoursenameAsPrefix(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "useEmailDomainAsSuffix":
+			out.Values[i] = ec._Course_useEmailDomainAsSuffix(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "assignmentNames":
 			out.Values[i] = ec._Course_assignmentNames(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -4778,6 +4967,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "createCourse":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createCourse(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "setCourse":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_setCourse(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/web/graph/mapping.go
+++ b/web/graph/mapping.go
@@ -25,6 +25,9 @@ func toGraphCourse(s *db.StoredCourse) *model.Course {
 	if s.Source != nil {
 		c.CoursePath = s.Source.CoursePath
 		c.SemesterPath = s.Source.SemesterPath
+		c.UseCoursenameAsPrefix = s.Source.UseCoursenameAsPrefix
+		// Absent means true (see config.CourseSource.UseEmailDomainAsSuffix).
+		c.UseEmailDomainAsSuffix = s.Source.UseEmailDomainAsSuffix == nil || *s.Source.UseEmailDomainAsSuffix
 		c.StudentCount = len(s.Source.Students)
 		c.GroupCount = len(s.Source.Groups)
 		names := make([]string, 0, len(s.Source.Assignments))

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -33,6 +33,10 @@ type Course struct {
 	Name         string `json:"name"`
 	CoursePath   string `json:"coursePath"`
 	SemesterPath string `json:"semesterPath"`
+	// Whether the course name is prepended to each project path.
+	UseCoursenameAsPrefix bool `json:"useCoursenameAsPrefix"`
+	// Whether the student's email domain is appended as a suffix (default true).
+	UseEmailDomainAsSuffix bool `json:"useEmailDomainAsSuffix"`
 	// The names of the assignments in this course, sorted.
 	AssignmentNames []string  `json:"assignmentNames"`
 	StudentCount    int       `json:"studentCount"`


### PR DESCRIPTION
Schließt die Lücke, dass Kurs-Einstellungen bisher **nur beim Anlegen** setzbar waren (F1).

- **`Course`-Typ** liefert jetzt `useCoursenameAsPrefix` und `useEmailDomainAsSuffix` (letzteres = `true`, wenn in der Quelle abwesend), damit das GUI sie anzeigen und vorbefüllen kann.
- **Mutation `setCourse(name, coursePath, semesterPath, useCoursenameAsPrefix, useEmailDomainAsSuffix)`** — aktualisiert die Kurs-Skalare, lässt Assignments/Studierende/Gruppen unangetastet und marshallt die Kurs-YAML neu.

## Verifiziert
`go test ./web/...` (setCourse aktualisiert Felder, erhält Assignments, ErrCourseNotFound) · `go vet` (beide Tags) · `golangci-lint` · **live:** setCourse ändert Pfade + Toggles, das Assignment überlebt.

Nächster Schritt: F2 — „Kurs bearbeiten"-Formular im GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)