### PR TITLE
feat(web): issues fields in the assignment editor schema

### DIFF
--- a/web/app/assignment_schema.go
+++ b/web/app/assignment_schema.go
@@ -215,4 +215,28 @@ var assignmentFields = []FieldMeta{
 		Group:       "Merge-Request",
 		Kind:        KindBool,
 	},
+
+	// --- Issues: welche Issues aus dem Startercode in die Studi-Repos kommen ---
+	{
+		Key:         "issues.replicateFromStartercode",
+		Label:       "Issues aus Startercode übernehmen",
+		Description: "Issues des Startercode-Repos in die erzeugten Repos replizieren.",
+		Group:       "Issues",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "issues.issueNumbers",
+		Label:       "Issue-Nummern",
+		Description: "Nur diese Issue-Nummern übernehmen (kommagetrennt). Leer = alle.",
+		Group:       "Issues",
+		Kind:        KindStringList,
+		Example:     "1, 2, 5",
+	},
+	{
+		Key:         "issues.includeChildTasks",
+		Label:       "Unteraufgaben einschließen",
+		Description: "Auch die Child-Tasks der übernommenen Issues replizieren.",
+		Group:       "Issues",
+		Kind:        KindBool,
+	},
 }

--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -60,7 +60,28 @@ func assignmentOwn(src *config.AssignmentSource) []FieldValue {
 		{Key: "mergeRequest.skippedPipelinesAreSuccessful", Value: mrBool(src.MergeRequest, func(m *config.MergeRequestSource) bool { return m.SkippedPipelinesAreSuccessful })},
 		{Key: "mergeRequest.allThreadsMustBeResolved", Value: mrBool(src.MergeRequest, func(m *config.MergeRequestSource) bool { return m.AllThreadsMustBeResolved })},
 		{Key: "mergeRequest.statusChecksMustSucceed", Value: mrBool(src.MergeRequest, func(m *config.MergeRequestSource) bool { return m.StatusChecksMustSucceed })},
+		{Key: "issues.replicateFromStartercode", Value: issuesBool(src.Issues, func(i *config.IssuesSource) bool { return i.ReplicateFromStartercode })},
+		{Key: "issues.issueNumbers", Value: issueNumbersStr(src.Issues)},
+		{Key: "issues.includeChildTasks", Value: issuesBool(src.Issues, func(i *config.IssuesSource) bool { return i.IncludeChildTasks })},
 	}
+}
+
+func issuesBool(i *config.IssuesSource, f func(*config.IssuesSource) bool) string {
+	if i == nil {
+		return "false"
+	}
+	return strconv.FormatBool(f(i))
+}
+
+func issueNumbersStr(i *config.IssuesSource) string {
+	if i == nil || len(i.IssueNumbers) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(i.IssueNumbers))
+	for _, n := range i.IssueNumbers {
+		parts = append(parts, strconv.Itoa(n))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func mrStr(m *config.MergeRequestSource, f func(*config.MergeRequestSource) string) string {
@@ -173,7 +194,56 @@ func applyDraft(src *config.AssignmentSource, draft map[string]string) *config.A
 	}
 	c.Startercode = applyStartercodeDraft(src.Startercode, draft)
 	c.MergeRequest = applyMergeRequestDraft(src.MergeRequest, draft)
+	c.Issues = applyIssuesDraft(src.Issues, draft)
 	return &c
+}
+
+// applyIssuesDraft rebuilds the issues block from the draft's issues.* keys into
+// a NEW struct (never mutating the shared original) and nils it when every field
+// is empty. issueNumbers is a comma-separated list of integers; non-numeric
+// entries are dropped.
+func applyIssuesDraft(orig *config.IssuesSource, draft map[string]string) *config.IssuesSource {
+	touched := false
+	for k := range draft {
+		if strings.HasPrefix(k, "issues.") {
+			touched = true
+			break
+		}
+	}
+	if !touched {
+		return orig
+	}
+
+	var is config.IssuesSource
+	if orig != nil {
+		is = *orig
+	}
+	for k, v := range draft {
+		switch k {
+		case "issues.replicateFromStartercode":
+			is.ReplicateFromStartercode = v == "true"
+		case "issues.includeChildTasks":
+			is.IncludeChildTasks = v == "true"
+		case "issues.issueNumbers":
+			is.IssueNumbers = splitIntList(v)
+		}
+	}
+	if !is.ReplicateFromStartercode && !is.IncludeChildTasks && len(is.IssueNumbers) == 0 {
+		return nil
+	}
+	return &is
+}
+
+// splitIntList parses a comma-/newline-separated list of integers, dropping
+// blank and non-numeric entries.
+func splitIntList(s string) []int {
+	var out []int
+	for _, f := range splitList(s) {
+		if n, err := strconv.Atoi(f); err == nil {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // applyMergeRequestDraft rebuilds the mergeRequest block from the draft's

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -437,6 +437,48 @@ func TestDeleteAssignment(t *testing.T) {
 	}
 }
 
+func TestSetAssignment_issuesBlock(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	view, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{
+		"issues.replicateFromStartercode": "true",
+		"issues.issueNumbers":             "1, 2, foo, 5",
+		"issues.includeChildTasks":        "true",
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	own := ownMap(view.Own)
+	if own["issues.replicateFromStartercode"] != "true" {
+		t.Errorf("own[replicate] = %q", own["issues.replicateFromStartercode"])
+	}
+	// non-numeric "foo" is dropped, order preserved.
+	if own["issues.issueNumbers"] != "1, 2, 5" {
+		t.Errorf("own[issueNumbers] = %q, want '1, 2, 5'", own["issues.issueNumbers"])
+	}
+	if got := fs.saved.Source.Assignments["blatt1"].Issues; got == nil || len(got.IssueNumbers) != 3 {
+		t.Errorf("stored issue numbers wrong: %+v", got)
+	}
+
+	// Unsetting everything removes the block.
+	view2, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{
+		"issues.replicateFromStartercode": "false",
+		"issues.issueNumbers":             "",
+		"issues.includeChildTasks":        "false",
+	})
+	if err != nil {
+		t.Fatalf("set (unset): %v", err)
+	}
+	if ownMap(view2.Own)["issues.replicateFromStartercode"] != "false" ||
+		fs.saved.Source.Assignments["blatt1"].Issues != nil {
+		t.Error("an all-empty issues block should be removed (nil)")
+	}
+}
+
 func TestSetAssignment_rejectsUnresolvable(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()


### PR DESCRIPTION
Dritter verschachtelter Block — **Issues** — backend-only (das GUI rendert ihn generisch, keine Frontend-Änderung nötig).

- **`assignmentSchema`** bekommt die Issues-Gruppe: `replicateFromStartercode` (bool), `issueNumbers` (kommagetrennte Ganzzahl-Liste), `includeChildTasks` (bool) — je mit kurzer Beschreibung.
- **`assignmentOwn`** liefert die `issues.*`-Werte (`issueNumbers` als „1, 2, 5"); **`applyDraft`** baut den Block in ein neues Struct (nie das Original mutieren), parst `issueNumbers` via `splitIntList` (nicht-numerische Einträge fallen weg) und `nil`t den Block bei leer.

## Verifiziert
`go test ./web/...` (Issues set/unset-Roundtrip, nicht-numerische verworfen) · `go vet` (beide Tags) · `golangci-lint` · isolierter Live-Check (Schema exponiert die Issues-Gruppe; own spiegelt die Source-Werte). Der Check lief mit eigenem Binary/Config im Scratchpad — die lokale Backend-Config wurde nicht angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)