### PR TITLE
feat(web): branches repeat-group in the assignment editor schema

### DIFF
--- a/web/app/assignment_schema.go
+++ b/web/app/assignment_schema.go
@@ -49,6 +49,53 @@ func AssignmentSchema() []FieldMeta {
 	return assignmentFields
 }
 
+// AssignmentBranchSchema returns the metadata for one branch rule — a row of the
+// repeat-group `branches` list. The GUI renders one such control set per row.
+func AssignmentBranchSchema() []FieldMeta {
+	return branchFields
+}
+
+var branchFields = []FieldMeta{
+	{
+		Key:         "name",
+		Label:       "Branch",
+		Description: "Name des Branches, z. B. main.",
+		Kind:        KindString,
+		Required:    true,
+		Example:     "main",
+	},
+	{
+		Key:         "protect",
+		Label:       "Geschützt",
+		Description: "Branch schützen (Push-Regeln, kein versehentliches Löschen).",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "mergeOnly",
+		Label:       "Nur via Merge",
+		Description: "Änderungen nur über Merge-Requests, kein direkter Push.",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "default",
+		Label:       "Default-Branch",
+		Description: "Diesen Branch als Standard-Branch des Repos setzen.",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "allowForcePush",
+		Label:       "Force-Push erlauben",
+		Description: "Force-Push auf den geschützten Branch zulassen.",
+		Kind:        KindBool,
+	},
+	{
+		Key:         "codeOwnerApprovalRequired",
+		Label:       "Code-Owner-Approval",
+		Description: "Freigabe durch Code-Owner erforderlich.",
+		Kind:        KindBool,
+	},
+}
+
 var assignmentFields = []FieldMeta{
 	{
 		Key:         "extends",

--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -39,7 +39,7 @@ func assignmentOwn(src *config.AssignmentSource) []FieldValue {
 		addBranches = strings.Join(sc.AdditionalBranches, ", ")
 	}
 
-	return []FieldValue{
+	own := []FieldValue{
 		{Key: "extends", Value: src.Extends},
 		{Key: "abstract", Value: strconv.FormatBool(src.Abstract)},
 		{Key: "per", Value: src.Per},
@@ -64,6 +64,22 @@ func assignmentOwn(src *config.AssignmentSource) []FieldValue {
 		{Key: "issues.issueNumbers", Value: issueNumbersStr(src.Issues)},
 		{Key: "issues.includeChildTasks", Value: issuesBool(src.Issues, func(i *config.IssuesSource) bool { return i.IncludeChildTasks })},
 	}
+
+	// branches (repeat group): a count sentinel plus indexed keys per rule, so
+	// the whole list rides in the same flat draft as the scalar fields.
+	own = append(own, FieldValue{Key: "branches.count", Value: strconv.Itoa(len(src.Branches))})
+	for i, b := range src.Branches {
+		p := fmt.Sprintf("branches.%d.", i)
+		own = append(own,
+			FieldValue{Key: p + "name", Value: b.Name},
+			FieldValue{Key: p + "protect", Value: strconv.FormatBool(b.Protect)},
+			FieldValue{Key: p + "mergeOnly", Value: strconv.FormatBool(b.MergeOnly)},
+			FieldValue{Key: p + "default", Value: strconv.FormatBool(b.Default)},
+			FieldValue{Key: p + "allowForcePush", Value: strconv.FormatBool(b.AllowForcePush)},
+			FieldValue{Key: p + "codeOwnerApprovalRequired", Value: strconv.FormatBool(b.CodeOwnerApprovalRequired)},
+		)
+	}
+	return own
 }
 
 func issuesBool(i *config.IssuesSource, f func(*config.IssuesSource) bool) string {
@@ -195,7 +211,37 @@ func applyDraft(src *config.AssignmentSource, draft map[string]string) *config.A
 	c.Startercode = applyStartercodeDraft(src.Startercode, draft)
 	c.MergeRequest = applyMergeRequestDraft(src.MergeRequest, draft)
 	c.Issues = applyIssuesDraft(src.Issues, draft)
+	c.Branches = applyBranchesDraft(src.Branches, draft)
 	return &c
+}
+
+// applyBranchesDraft rebuilds the branches list from the draft's indexed keys
+// (branches.<i>.<field>), driven by the branches.count sentinel so the GUI can
+// also clear the list. Rows without a name are dropped. Returns the original when
+// the draft does not address branches at all.
+func applyBranchesDraft(orig []config.BranchRuleSource, draft map[string]string) []config.BranchRuleSource {
+	countStr, ok := draft["branches.count"]
+	if !ok {
+		return orig
+	}
+	n, _ := strconv.Atoi(countStr)
+	var rules []config.BranchRuleSource
+	for i := 0; i < n; i++ {
+		p := fmt.Sprintf("branches.%d.", i)
+		name := strings.TrimSpace(draft[p+"name"])
+		if name == "" {
+			continue
+		}
+		rules = append(rules, config.BranchRuleSource{
+			Name:                      name,
+			Protect:                   draft[p+"protect"] == "true",
+			MergeOnly:                 draft[p+"mergeOnly"] == "true",
+			Default:                   draft[p+"default"] == "true",
+			AllowForcePush:            draft[p+"allowForcePush"] == "true",
+			CodeOwnerApprovalRequired: draft[p+"codeOwnerApprovalRequired"] == "true",
+		})
+	}
+	return rules
 }
 
 // applyIssuesDraft rebuilds the issues block from the draft's issues.* keys into

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -520,6 +520,62 @@ func TestSetAssignment_issuesBlock(t *testing.T) {
 	}
 }
 
+func TestSetAssignment_branchesRepeatGroup(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	// Two branch rules via indexed keys.
+	view, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{
+		"branches.count":       "2",
+		"branches.0.name":      "main",
+		"branches.0.protect":   "true",
+		"branches.0.mergeOnly": "true",
+		"branches.1.name":      "dev",
+		"branches.1.default":   "true",
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	br := fs.saved.Source.Assignments["blatt1"].Branches
+	if len(br) != 2 {
+		t.Fatalf("branches = %+v, want 2", br)
+	}
+	if br[0].Name != "main" || !br[0].Protect || !br[0].MergeOnly {
+		t.Errorf("branch 0 = %+v", br[0])
+	}
+	if br[1].Name != "dev" || !br[1].Default {
+		t.Errorf("branch 1 = %+v", br[1])
+	}
+	own := ownMap(view.Own)
+	if own["branches.count"] != "2" || own["branches.0.name"] != "main" || own["branches.1.default"] != "true" {
+		t.Errorf("own branch keys wrong: count=%q b0.name=%q b1.default=%q",
+			own["branches.count"], own["branches.0.name"], own["branches.1.default"])
+	}
+
+	// A nameless row is dropped.
+	if _, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{
+		"branches.count":  "2",
+		"branches.0.name": "main",
+		"branches.1.name": "   ",
+	}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if got := fs.saved.Source.Assignments["blatt1"].Branches; len(got) != 1 {
+		t.Errorf("nameless row should be dropped, got %+v", got)
+	}
+
+	// count 0 clears the list.
+	if _, err := a.SetAssignment(ctx, "tc", "blatt1", map[string]string{"branches.count": "0"}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if got := fs.saved.Source.Assignments["blatt1"].Branches; got != nil {
+		t.Errorf("branches should be cleared, got %+v", got)
+	}
+}
+
 func TestSetAssignment_rejectsUnresolvable(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -93,6 +93,8 @@ type ValidationResult {
 extend type Query {
   "Field metadata for the assignment editor (server-authoritative labels, descriptions, dropdown options)."
   assignmentSchema: [FieldMeta!]!
+  "Field metadata for one branch rule — a row of the repeat-group `branches` list."
+  branchRuleSchema: [FieldMeta!]!
   "One assignment of one of the caller's courses: source values, resolved preview. Null when there is no such assignment."
   assignment(course: String!, name: String!): AssignmentView
   "Validate a draft assignment against the real resolver without saving."

--- a/web/graph/assignments.resolvers.go
+++ b/web/graph/assignments.resolvers.go
@@ -33,6 +33,11 @@ func (r *queryResolver) AssignmentSchema(ctx context.Context) ([]*model.FieldMet
 	return toGraphAssignmentSchema(app.AssignmentSchema()), nil
 }
 
+// BranchRuleSchema is the resolver for the branchRuleSchema field.
+func (r *queryResolver) BranchRuleSchema(ctx context.Context) ([]*model.FieldMeta, error) {
+	return toGraphAssignmentSchema(app.AssignmentBranchSchema()), nil
+}
+
 // Assignment is the resolver for the assignment field.
 func (r *queryResolver) Assignment(ctx context.Context, course string, name string) (*model.AssignmentView, error) {
 	view, err := r.app.Assignment(ctx, course, name)

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -117,6 +117,7 @@ type ComplexityRoot struct {
 	Query struct {
 		Assignment              func(childComplexity int, course string, name string) int
 		AssignmentSchema        func(childComplexity int) int
+		BranchRuleSchema        func(childComplexity int) int
 		Course                  func(childComplexity int, name string) int
 		CourseLint              func(childComplexity int, name string) int
 		CourseYaml              func(childComplexity int, name string) int
@@ -166,6 +167,7 @@ type QueryResolver interface {
 	Me(ctx context.Context) (*model.User, error)
 	ServerInfo(ctx context.Context) (*model.ServerInfo, error)
 	AssignmentSchema(ctx context.Context) ([]*model.FieldMeta, error)
+	BranchRuleSchema(ctx context.Context) ([]*model.FieldMeta, error)
 	Assignment(ctx context.Context, course string, name string) (*model.AssignmentView, error)
 	ValidateAssignmentDraft(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.ValidationResult, error)
 	Courses(ctx context.Context) ([]*model.Course, error)
@@ -564,6 +566,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.AssignmentSchema(childComplexity), true
+	case "Query.branchRuleSchema":
+		if e.ComplexityRoot.Query.BranchRuleSchema == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Query.BranchRuleSchema(childComplexity), true
 	case "Query.course":
 		if e.ComplexityRoot.Query.Course == nil {
 			break
@@ -871,6 +879,8 @@ type ValidationResult {
 extend type Query {
   "Field metadata for the assignment editor (server-authoritative labels, descriptions, dropdown options)."
   assignmentSchema: [FieldMeta!]!
+  "Field metadata for one branch rule — a row of the repeat-group ` + "`" + `branches` + "`" + ` list."
+  branchRuleSchema: [FieldMeta!]!
   "One assignment of one of the caller's courses: source values, resolved preview. Null when there is no such assignment."
   assignment(course: String!, name: String!): AssignmentView
   "Validate a draft assignment against the real resolver without saving."
@@ -3169,6 +3179,38 @@ func (ec *executionContext) _Query_assignmentSchema(ctx context.Context, field g
 	)
 }
 func (ec *executionContext) fieldContext_Query_assignmentSchema(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_FieldMeta(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_branchRuleSchema(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_branchRuleSchema(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Query().BranchRuleSchema(ctx)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.FieldMeta) graphql.Marshaler {
+			return ec.marshalNFieldMeta2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐFieldMetaᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_branchRuleSchema(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -5538,6 +5580,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_assignmentSchema(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "branchRuleSchema":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_branchRuleSchema(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}


### PR DESCRIPTION
Der `branches`-Block (eine **Liste von Objekten** — Branch-Regeln) reitet im **selben flachen Draft** wie die Skalarfelder, über indizierte Keys — damit Live-Validierung, Vorschau und Speichern unverändert funktionieren (H1, Backend).

- **`branchRuleSchema`-Query** — Feld-Metadaten einer Branch-Regel: `name` (+ Flags `protect`, `mergeOnly`, `default`, `allowForcePush`, `codeOwnerApprovalRequired`), je mit Beschreibung.
- **`assignmentOwn`** liefert `branches.count` (Sentinel) + `branches.<i>.<feld>` pro Regel.
- **`applyDraft`** baut die Liste aus diesen Keys neu auf, gesteuert von `branches.count` (so kann das GUI die Liste auch leeren); Zeilen ohne Namen fallen weg.

## Verifiziert
`go test ./web/...` (set/own-Roundtrip, namenlose Zeile verworfen, clear-all) · `go vet` (beide Tags) · `golangci-lint` · isolierter Live-Check (`branchRuleSchema` liefert die 6 Felder; zwei Branches persistieren über indizierte Keys).

Nächster Schritt: H2 — Repeat-Group-UI im Assignment-Editor (Zeilen hinzufügen/entfernen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)