### PR TITLE
feat(web): add assignmentUrls query for per-student/group repo URLs

### DIFF
--- a/config/urls.go
+++ b/config/urls.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -71,13 +72,58 @@ func gitURLToHTTPSBase(raw string) (string, error) {
 func (cfg *AssignmentConfig) Urls(assignment bool) {
 	if assignment {
 		fmt.Println(cfg.URL)
-	} else if cfg.Per == PerStudent {
+		return
+	}
+	for _, r := range cfg.RepoURLs() {
+		fmt.Println(r.URL)
+	}
+}
+
+// RepoURL is one repository URL together with who it belongs to: a student's
+// email (or username/id fallback) for per-student assignments, or the group
+// name for per-group assignments.
+type RepoURL struct {
+	For string
+	URL string
+}
+
+// RepoURLs returns the per-student or per-group repository URLs for the
+// assignment (depending on Per). The assignment-level group URL is cfg.URL.
+// It is the data behind the printing Urls method, reusable by the web layer.
+func (cfg *AssignmentConfig) RepoURLs() []RepoURL {
+	var out []RepoURL
+	if cfg.Per == PerStudent {
 		for _, stud := range cfg.Students {
-			fmt.Printf("%s/%s\n", cfg.URL, cfg.RepoNameForStudent(stud))
+			out = append(out, RepoURL{
+				For: studentLabel(stud),
+				URL: cfg.URL + "/" + cfg.RepoNameForStudent(stud),
+			})
 		}
 	} else { // PerGroup
 		for _, group := range cfg.Groups {
-			fmt.Printf("%s/%s\n", cfg.URL, cfg.RepoNameForGroup(group))
+			out = append(out, RepoURL{
+				For: group.Name,
+				URL: cfg.URL + "/" + cfg.RepoNameForGroup(group),
+			})
 		}
 	}
+	return out
+}
+
+// studentLabel is a human-readable identifier for a student: the email, else the
+// username, else the raw roster entry, else the numeric id.
+func studentLabel(s *Student) string {
+	if s.Email != nil && *s.Email != "" {
+		return *s.Email
+	}
+	if s.Username != nil && *s.Username != "" {
+		return *s.Username
+	}
+	if s.Raw != "" {
+		return s.Raw
+	}
+	if s.Id != nil {
+		return strconv.Itoa(*s.Id)
+	}
+	return ""
 }

--- a/config/urls_show_test.go
+++ b/config/urls_show_test.go
@@ -81,6 +81,55 @@ func TestUrls_PerGroup(t *testing.T) {
 	}
 }
 
+func TestRepoURLs_PerStudent_PrefersEmailLabel(t *testing.T) {
+	mail := "a@hm.edu"
+	user := "bob"
+	cfg := &AssignmentConfig{
+		URL:                   "https://gitlab.example.org/mpd/ss26/blatt-01",
+		Name:                  "blatt01",
+		Course:                "mpd",
+		UseCoursenameAsPrefix: true,
+		Per:                   PerStudent,
+		Students: []*Student{
+			{Email: &mail, Raw: "a@hm.edu"},
+			{Username: &user, Raw: "bob"},
+		},
+	}
+	got := cfg.RepoURLs()
+	if len(got) != 2 {
+		t.Fatalf("RepoURLs() len = %d, want 2", len(got))
+	}
+	if got[0].For != "a@hm.edu" {
+		t.Errorf("For[0] = %q, want the email", got[0].For)
+	}
+	if got[1].For != "bob" {
+		t.Errorf("For[1] = %q, want the username fallback", got[1].For)
+	}
+	want := cfg.URL + "/" + cfg.RepoNameForStudent(cfg.Students[0])
+	if got[0].URL != want {
+		t.Errorf("URL[0] = %q, want %q", got[0].URL, want)
+	}
+}
+
+func TestRepoURLs_PerGroup(t *testing.T) {
+	cfg := &AssignmentConfig{
+		URL:                   "https://gitlab.example.org/mpd/ss26/blatt-01",
+		Name:                  "blatt01",
+		Course:                "mpd",
+		UseCoursenameAsPrefix: true,
+		Per:                   PerGroup,
+		Groups:                []*Group{{Name: "team1"}, {Name: "team2"}},
+	}
+	got := cfg.RepoURLs()
+	if len(got) != 2 || got[0].For != "team1" || got[1].For != "team2" {
+		t.Fatalf("RepoURLs() = %+v, want two groups team1/team2", got)
+	}
+	want := cfg.URL + "/" + cfg.RepoNameForGroup(cfg.Groups[1])
+	if got[1].URL != want {
+		t.Errorf("URL[1] = %q, want %q", got[1].URL, want)
+	}
+}
+
 func TestShow_Minimal(t *testing.T) {
 	cfg := &AssignmentConfig{
 		Course: "mpd",

--- a/web/app/urls.go
+++ b/web/app/urls.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"context"
+
+	"github.com/obcode/glabs/v3/config"
+)
+
+// AssignmentURLs are the repository URLs for one assignment: the assignment-level
+// group URL plus one entry per student or per group. Derived purely from the
+// resolved configuration — no GitLab token or API call is involved.
+type AssignmentURLs struct {
+	// Per is "student" or "group".
+	Per string
+	// GroupURL is the assignment-level group URL where all the repos live.
+	GroupURL string
+	// Repos is one URL per student/group repository.
+	Repos []config.RepoURL
+}
+
+// AssignmentURLs returns the repository URLs for one assignment of one of the
+// caller's own courses. It returns nil (no error) when the course has no such
+// assignment, or when the assignment cannot be resolved (e.g. an abstract base) —
+// in both cases there simply are no URLs. ErrCourseNotFound propagates when the
+// course itself is not the caller's.
+func (a *App) AssignmentURLs(ctx context.Context, course, name string) (*AssignmentURLs, error) {
+	stored, err := a.Course(ctx, course)
+	if err != nil {
+		return nil, err
+	}
+
+	src, ok := stored.Source.Assignments[name]
+	if !ok || src == nil {
+		return nil, nil
+	}
+
+	// Resolve from the stored bytes so the URLs match the CLI exactly (the same
+	// inheritance, roster resolution and path normalization). Fall back to
+	// re-encoding the source if the raw bytes are absent.
+	bytes := stored.RawYAML
+	if len(bytes) == 0 {
+		if encoded, err := config.EncodeCourse(stored.Source); err == nil {
+			bytes = encoded
+		}
+	}
+	cfg, err := config.ResolveAssignmentFromBytes(bytes, course, name, config.Globals{GitlabHost: a.gitlabHost})
+	if err != nil {
+		// Not resolvable (abstract base, missing parent, cycle) → no URLs.
+		return nil, nil
+	}
+
+	return &AssignmentURLs{
+		Per:      string(cfg.Per),
+		GroupURL: cfg.URL,
+		Repos:    cfg.RepoURLs(),
+	}, nil
+}

--- a/web/app/urls_test.go
+++ b/web/app/urls_test.go
@@ -1,0 +1,82 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+const urlsCourse = `uc:
+  coursepath: uc/sem
+  semesterpath: ss26
+  usecoursenameasprefix: true
+  blatt1:
+    per: student
+    accesslevel: developer
+    students:
+      - a@hm.edu
+      - b@hm.edu
+`
+
+func TestAssignmentURLs_PerStudent(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gitlab.example"}
+	ctx := ctxAs(owner)
+
+	u, err := a.AssignmentURLs(ctx, "uc", "blatt1")
+	if err != nil {
+		t.Fatalf("AssignmentURLs: %v", err)
+	}
+	if u == nil {
+		t.Fatal("expected URLs for blatt1")
+	}
+	if u.Per != "student" {
+		t.Errorf("Per = %q, want student", u.Per)
+	}
+	if !strings.HasPrefix(u.GroupURL, "https://gitlab.example/") {
+		t.Errorf("GroupURL = %q, want it under the gitlab host", u.GroupURL)
+	}
+	if len(u.Repos) != 2 {
+		t.Fatalf("Repos len = %d, want 2", len(u.Repos))
+	}
+	for _, r := range u.Repos {
+		if r.For == "" {
+			t.Errorf("repo For is empty: %+v", r)
+		}
+		if !strings.HasPrefix(r.URL, u.GroupURL+"/") {
+			t.Errorf("repo URL %q is not under the group URL %q", r.URL, u.GroupURL)
+		}
+	}
+}
+
+func TestAssignmentURLs_missingAssignmentReturnsNil(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gitlab.example"}
+
+	u, err := a.AssignmentURLs(ctxAs(owner), "uc", "nope")
+	if err != nil {
+		t.Fatalf("AssignmentURLs: %v", err)
+	}
+	if u != nil {
+		t.Errorf("expected nil for a missing assignment, got %+v", u)
+	}
+}
+
+func TestAssignmentURLs_abstractBaseReturnsNil(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+
+	// An abstract base does not resolve → no URLs (nil, no error).
+	u, err := a.AssignmentURLs(ctxAs(owner), "tc", "base")
+	if err != nil {
+		t.Fatalf("AssignmentURLs: %v", err)
+	}
+	if u != nil {
+		t.Errorf("expected nil for an abstract base, got %+v", u)
+	}
+}

--- a/web/graph/assignment_mapping.go
+++ b/web/graph/assignment_mapping.go
@@ -65,6 +65,16 @@ func toGraphValidationResult(vr *app.ValidationResult) *model.ValidationResult {
 	}
 }
 
+// toGraphAssignmentURLs projects the assignment repository URLs onto the GraphQL
+// model.
+func toGraphAssignmentURLs(u *app.AssignmentURLs) *model.AssignmentUrls {
+	repos := make([]*model.RepoURL, 0, len(u.Repos))
+	for _, r := range u.Repos {
+		repos = append(repos, &model.RepoURL{For: r.For, URL: r.URL})
+	}
+	return &model.AssignmentUrls{Per: u.Per, GroupURL: u.GroupURL, Repos: repos}
+}
+
 // toGraphAssignmentView projects an assignment view onto the GraphQL model.
 func toGraphAssignmentView(view *app.AssignmentView) *model.AssignmentView {
 	own := make([]*model.FieldValue, 0, len(view.Own))

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -103,6 +103,30 @@ extend type Query {
   assignment(course: String!, name: String!): AssignmentView
   "Validate a draft assignment against the real resolver without saving."
   validateAssignmentDraft(course: String!, name: String!, draft: [FieldValueInput!]!): ValidationResult!
+  "The repository URLs for one assignment, derived from the resolved config (no GitLab token needed). Null when there is no such assignment or it cannot be resolved (e.g. an abstract base)."
+  assignmentUrls(course: String!, name: String!): AssignmentUrls
+}
+
+"""
+The repository URLs for one assignment: the assignment-level group URL plus one
+URL per student or per group. Read-only and derived purely from the resolved
+configuration — no GitLab token or API call is involved.
+"""
+type AssignmentUrls {
+  "Whether repos are per student or per group (`student` or `group`)."
+  per: String!
+  "The assignment-level group URL, where all the repos live."
+  groupUrl: String!
+  "One entry per student/group repository."
+  repos: [RepoUrl!]!
+}
+
+"One repository URL together with who it belongs to."
+type RepoUrl {
+  "The student's email (or username/id fallback) or the group's name."
+  for: String!
+  "The full web URL of the repository."
+  url: String!
 }
 
 extend type Mutation {

--- a/web/graph/assignments.resolvers.go
+++ b/web/graph/assignments.resolvers.go
@@ -71,3 +71,18 @@ func (r *queryResolver) ValidateAssignmentDraft(ctx context.Context, course stri
 	}
 	return toGraphValidationResult(vr), nil
 }
+
+// AssignmentUrls is the resolver for the assignmentUrls field.
+func (r *queryResolver) AssignmentUrls(ctx context.Context, course string, name string) (*model.AssignmentUrls, error) {
+	u, err := r.app.AssignmentURLs(ctx, course, name)
+	if err != nil {
+		if errors.Is(err, db.ErrCourseNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if u == nil {
+		return nil, nil
+	}
+	return toGraphAssignmentURLs(u), nil
+}

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -37,6 +37,12 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	AssignmentUrls struct {
+		GroupURL func(childComplexity int) int
+		Per      func(childComplexity int) int
+		Repos    func(childComplexity int) int
+	}
+
 	AssignmentView struct {
 		Abstract     func(childComplexity int) int
 		Course       func(childComplexity int) int
@@ -119,6 +125,7 @@ type ComplexityRoot struct {
 		ApprovalSettingsSchema  func(childComplexity int) int
 		Assignment              func(childComplexity int, course string, name string) int
 		AssignmentSchema        func(childComplexity int) int
+		AssignmentUrls          func(childComplexity int, course string, name string) int
 		BranchRuleSchema        func(childComplexity int) int
 		Course                  func(childComplexity int, name string) int
 		CourseLint              func(childComplexity int, name string) int
@@ -128,6 +135,11 @@ type ComplexityRoot struct {
 		Me                      func(childComplexity int) int
 		ServerInfo              func(childComplexity int) int
 		ValidateAssignmentDraft func(childComplexity int, course string, name string, draft []*model.FieldValueInput) int
+	}
+
+	RepoUrl struct {
+		For func(childComplexity int) int
+		URL func(childComplexity int) int
 	}
 
 	ServerInfo struct {
@@ -174,6 +186,7 @@ type QueryResolver interface {
 	ApprovalRuleSchema(ctx context.Context) ([]*model.FieldMeta, error)
 	Assignment(ctx context.Context, course string, name string) (*model.AssignmentView, error)
 	ValidateAssignmentDraft(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.ValidationResult, error)
+	AssignmentUrls(ctx context.Context, course string, name string) (*model.AssignmentUrls, error)
 	Courses(ctx context.Context) ([]*model.Course, error)
 	Course(ctx context.Context, name string) (*model.Course, error)
 	CourseYaml(ctx context.Context, name string) (string, error)
@@ -198,6 +211,25 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	ec := newExecutionContext(nil, e, nil)
 	_ = ec
 	switch typeName + "." + field {
+
+	case "AssignmentUrls.groupUrl":
+		if e.ComplexityRoot.AssignmentUrls.GroupURL == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AssignmentUrls.GroupURL(childComplexity), true
+	case "AssignmentUrls.per":
+		if e.ComplexityRoot.AssignmentUrls.Per == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AssignmentUrls.Per(childComplexity), true
+	case "AssignmentUrls.repos":
+		if e.ComplexityRoot.AssignmentUrls.Repos == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AssignmentUrls.Repos(childComplexity), true
 
 	case "AssignmentView.abstract":
 		if e.ComplexityRoot.AssignmentView.Abstract == nil {
@@ -582,6 +614,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.AssignmentSchema(childComplexity), true
+	case "Query.assignmentUrls":
+		if e.ComplexityRoot.Query.AssignmentUrls == nil {
+			break
+		}
+
+		args, err := ec.field_Query_assignmentUrls_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.AssignmentUrls(childComplexity, args["course"].(string), args["name"].(string)), true
 	case "Query.branchRuleSchema":
 		if e.ComplexityRoot.Query.BranchRuleSchema == nil {
 			break
@@ -657,6 +700,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.ValidateAssignmentDraft(childComplexity, args["course"].(string), args["name"].(string), args["draft"].([]*model.FieldValueInput)), true
+
+	case "RepoUrl.for":
+		if e.ComplexityRoot.RepoUrl.For == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RepoUrl.For(childComplexity), true
+	case "RepoUrl.url":
+		if e.ComplexityRoot.RepoUrl.URL == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RepoUrl.URL(childComplexity), true
 
 	case "ServerInfo.commit":
 		if e.ComplexityRoot.ServerInfo.Commit == nil {
@@ -905,6 +961,30 @@ extend type Query {
   assignment(course: String!, name: String!): AssignmentView
   "Validate a draft assignment against the real resolver without saving."
   validateAssignmentDraft(course: String!, name: String!, draft: [FieldValueInput!]!): ValidationResult!
+  "The repository URLs for one assignment, derived from the resolved config (no GitLab token needed). Null when there is no such assignment or it cannot be resolved (e.g. an abstract base)."
+  assignmentUrls(course: String!, name: String!): AssignmentUrls
+}
+
+"""
+The repository URLs for one assignment: the assignment-level group URL plus one
+URL per student or per group. Read-only and derived purely from the resolved
+configuration — no GitLab token or API call is involved.
+"""
+type AssignmentUrls {
+  "Whether repos are per student or per group (` + "`" + `student` + "`" + ` or ` + "`" + `group` + "`" + `)."
+  per: String!
+  "The assignment-level group URL, where all the repos live."
+  groupUrl: String!
+  "One entry per student/group repository."
+  repos: [RepoUrl!]!
+}
+
+"One repository URL together with who it belongs to."
+type RepoUrl {
+  "The student's email (or username/id fallback) or the group's name."
+  for: String!
+  "The full web URL of the repository."
+  url: String!
 }
 
 extend type Mutation {
@@ -1062,6 +1142,18 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // Each function is generated once per unique object type, deduplicating the
 // switch statements that were previously inlined in every fieldContext_* function.
 
+func (ec *executionContext) childFields_AssignmentUrls(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "per":
+		return ec.fieldContext_AssignmentUrls_per(ctx, field)
+	case "groupUrl":
+		return ec.fieldContext_AssignmentUrls_groupUrl(ctx, field)
+	case "repos":
+		return ec.fieldContext_AssignmentUrls_repos(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type AssignmentUrls", field.Name)
+}
+
 func (ec *executionContext) childFields_AssignmentView(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "course":
@@ -1188,6 +1280,16 @@ func (ec *executionContext) childFields_Group(ctx context.Context, field graphql
 		return ec.fieldContext_Group_members(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Group", field.Name)
+}
+
+func (ec *executionContext) childFields_RepoUrl(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "for":
+		return ec.fieldContext_RepoUrl_for(ctx, field)
+	case "url":
+		return ec.fieldContext_RepoUrl_url(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type RepoUrl", field.Name)
 }
 
 func (ec *executionContext) childFields_ServerInfo(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -1586,6 +1688,28 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_assignmentUrls_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "course",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["course"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "name",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["name"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_assignment_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -1739,6 +1863,84 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 // endregion ***************************** args.gotpl *****************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _AssignmentUrls_per(ctx context.Context, field graphql.CollectedField, obj *model.AssignmentUrls) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_AssignmentUrls_per(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Per, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_AssignmentUrls_per(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("AssignmentUrls", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _AssignmentUrls_groupUrl(ctx context.Context, field graphql.CollectedField, obj *model.AssignmentUrls) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_AssignmentUrls_groupUrl(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.GroupURL, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_AssignmentUrls_groupUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("AssignmentUrls", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _AssignmentUrls_repos(ctx context.Context, field graphql.CollectedField, obj *model.AssignmentUrls) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_AssignmentUrls_repos(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Repos, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.RepoURL) graphql.Marshaler {
+			return ec.marshalNRepoUrl2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐRepoURLᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_AssignmentUrls_repos(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AssignmentUrls",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_RepoUrl(ctx, field)
+		},
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _AssignmentView_course(ctx context.Context, field graphql.CollectedField, obj *model.AssignmentView) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
@@ -3395,6 +3597,50 @@ func (ec *executionContext) fieldContext_Query_validateAssignmentDraft(ctx conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_assignmentUrls(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_assignmentUrls(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().AssignmentUrls(ctx, fc.Args["course"].(string), fc.Args["name"].(string))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.AssignmentUrls) graphql.Marshaler {
+			return ec.marshalOAssignmentUrls2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentUrls(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Query_assignmentUrls(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_AssignmentUrls(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_assignmentUrls_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_courses(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -3665,6 +3911,52 @@ func (ec *executionContext) fieldContext_Query___schema(_ context.Context, field
 		},
 	}
 	return fc, nil
+}
+
+func (ec *executionContext) _RepoUrl_for(ctx context.Context, field graphql.CollectedField, obj *model.RepoURL) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_RepoUrl_for(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.For, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_RepoUrl_for(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("RepoUrl", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _RepoUrl_url(ctx context.Context, field graphql.CollectedField, obj *model.RepoURL) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_RepoUrl_url(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.URL, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_RepoUrl_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("RepoUrl", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _ServerInfo_version(ctx context.Context, field graphql.CollectedField, obj *model.ServerInfo) (ret graphql.Marshaler) {
@@ -5015,6 +5307,54 @@ func (ec *executionContext) unmarshalInputGroupInput(ctx context.Context, obj an
 
 // region    **************************** object.gotpl ****************************
 
+var assignmentUrlsImplementors = []string{"AssignmentUrls"}
+
+func (ec *executionContext) _AssignmentUrls(ctx context.Context, sel ast.SelectionSet, obj *model.AssignmentUrls) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, assignmentUrlsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferredFieldSet := graphql.NewFieldSet(nil)
+	deferLabelToView := make(map[string]*graphql.FieldSetView)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AssignmentUrls")
+		case "per":
+			out.Values[i] = ec._AssignmentUrls_per(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "groupUrl":
+			out.Values[i] = ec._AssignmentUrls_groupUrl(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "repos":
+			out.Values[i] = ec._AssignmentUrls_repos(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferLabelToView), math.MaxInt32)))
+
+	ec.ProcessDeferredGroup(graphql.DeferredGroup{
+		Defers:   deferLabelToView,
+		Path:     graphql.GetPath(ctx),
+		FieldSet: deferredFieldSet,
+		Context:  ctx,
+	})
+
+	return out
+}
+
 var assignmentViewImplementors = []string{"AssignmentView"}
 
 func (ec *executionContext) _AssignmentView(ctx context.Context, sel ast.SelectionSet, obj *model.AssignmentView) graphql.Marshaler {
@@ -5786,6 +6126,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "assignmentUrls":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_assignmentUrls(ctx, field)
+				if res == graphql.RequiredNull {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "courses":
 			field := field
 
@@ -5909,6 +6271,49 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			})
 			if out.Values[i] == graphql.RequiredNull {
 				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferLabelToView), math.MaxInt32)))
+
+	ec.ProcessDeferredGroup(graphql.DeferredGroup{
+		Defers:   deferLabelToView,
+		Path:     graphql.GetPath(ctx),
+		FieldSet: deferredFieldSet,
+		Context:  ctx,
+	})
+
+	return out
+}
+
+var repoUrlImplementors = []string{"RepoUrl"}
+
+func (ec *executionContext) _RepoUrl(ctx context.Context, sel ast.SelectionSet, obj *model.RepoURL) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, repoUrlImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferredFieldSet := graphql.NewFieldSet(nil)
+	deferLabelToView := make(map[string]*graphql.FieldSetView)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RepoUrl")
+		case "for":
+			out.Values[i] = ec._RepoUrl_for(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "url":
+			out.Values[i] = ec._RepoUrl_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -6745,6 +7150,32 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 	return res
 }
 
+func (ec *executionContext) marshalNRepoUrl2ᚕᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐRepoURLᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.RepoURL) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNRepoUrl2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐRepoURL(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNRepoUrl2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐRepoURL(ctx context.Context, sel ast.SelectionSet, v *model.RepoURL) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._RepoUrl(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNServerInfo2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐServerInfo(ctx context.Context, sel ast.SelectionSet, v model.ServerInfo) graphql.Marshaler {
 	return ec._ServerInfo(ctx, sel, &v)
 }
@@ -6986,6 +7417,13 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalOAssignmentUrls2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentUrls(ctx context.Context, sel ast.SelectionSet, v *model.AssignmentUrls) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._AssignmentUrls(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOAssignmentView2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentView(ctx context.Context, sel ast.SelectionSet, v *model.AssignmentView) graphql.Marshaler {

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -10,6 +10,18 @@ import (
 	"time"
 )
 
+// The repository URLs for one assignment: the assignment-level group URL plus one
+// URL per student or per group. Read-only and derived purely from the resolved
+// configuration — no GitLab token or API call is involved.
+type AssignmentUrls struct {
+	// Whether repos are per student or per group (`student` or `group`).
+	Per string `json:"per"`
+	// The assignment-level group URL, where all the repos live.
+	GroupURL string `json:"groupUrl"`
+	// One entry per student/group repository.
+	Repos []*RepoURL `json:"repos"`
+}
+
 // One assignment in source (own) form plus its resolved preview — the same
 // rendering `glabs show` produces, so inheritance is visible.
 type AssignmentView struct {
@@ -124,6 +136,14 @@ type Mutation struct {
 }
 
 type Query struct {
+}
+
+// One repository URL together with who it belongs to.
+type RepoURL struct {
+	// The student's email (or username/id fallback) or the group's name.
+	For string `json:"for"`
+	// The full web URL of the repository.
+	URL string `json:"url"`
 }
 
 // Version and build metadata for the running server.


### PR DESCRIPTION
Erste read-only GitLab-nahe Operation für glabs-web (**Milestone B**). Sie ist rein aus der aufgelösten Kurs-Config abgeleitet — **kein GitLab-Token, kein API-Call** — daher voll testbar und gefahrlos vor den token-gestützten Operationen exponierbar.

## Was drin ist
- **config**: `RepoURLs()` (je Studierende/Gruppe `For` + `URL`) aus der druckenden `Urls`-Methode herausgezogen, sodass CLI und Web **eine** Implementierung teilen. `Urls` druckt jetzt darüber (identische Ausgabe). Neuer Helfer `studentLabel` (E-Mail, sonst Username/Raw/Id).
- **web/app**: `AssignmentURLs` löst das Assignment aus den gespeicherten Bytes auf (genau wie `Assignment`) und liefert die Gruppen-URL plus je einen Eintrag pro Studierende/Gruppe. Gibt `nil` (kein Fehler) zurück, wenn es das Assignment nicht gibt oder es nicht auflösbar ist (z. B. abstrakte Basis).
- **graph**: Typen `AssignmentUrls`/`RepoUrl`, Query `assignmentUrls(course, name)`, Resolver + Mapping (gqlgen regeneriert).
- **Tests**: `RepoURLs` (config, Student-Label-Fallback + per-group) und `AssignmentURLs` (app: per-student, fehlendes Assignment, abstrakte Basis).

## GraphQL
```graphql
assignmentUrls(course: String!, name: String!): AssignmentUrls
type AssignmentUrls { per: String!  groupUrl: String!  repos: [RepoUrl!]! }
type RepoUrl { for: String!  url: String! }
```

## Verifikation (lokal grün)
`go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`, `golangci-lint run` — alle sauber; `gofmt` clean.

Nächster Schritt: das GUI konsumiert `assignmentUrls` und zeigt die Repo-Links auf der Assignment-Seite (separater glabs.gui-PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)