### PR TITLE
feat(web): stream report progress via a GraphQL subscription

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/99designs/gqlgen v0.17.94
 	github.com/ProtonMail/go-crypto v1.4.1
+	github.com/coder/websocket v1.8.15
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/go-git/go-git/v5 v5.18.0
@@ -36,7 +37,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
-	github.com/coder/websocket v1.8.15 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/web/app/report.go
+++ b/web/app/report.go
@@ -11,9 +11,10 @@ import (
 
 // gitlabClientFor builds a GitLab client from the caller's stored PAT. This is the
 // single place in the web server where the plaintext token exists: it is
-// decrypted here, handed straight to the client, and never logged or returned. A
-// discard reporter keeps the client from writing progress to the server's stdout.
-func (a *App) gitlabClientFor(ctx context.Context, owner string) (*gitlab.Client, error) {
+// decrypted here, handed straight to the client, and never logged or returned.
+// The reporter receives the client's progress: a discard reporter for one-shot
+// queries, or a streaming one for the report subscription.
+func (a *App) gitlabClientFor(ctx context.Context, owner string, rep reporter.Reporter) (*gitlab.Client, error) {
 	if a.sealer == nil {
 		return nil, fmt.Errorf("secret storage is unavailable: set secrets.key in the server config")
 	}
@@ -31,7 +32,7 @@ func (a *App) gitlabClientFor(ctx context.Context, owner string) (*gitlab.Client
 	return gitlab.NewClient(
 		gitlab.WithHost(a.gitlabHost),
 		gitlab.WithToken(token),
-		gitlab.WithReporter(reporter.NewDiscardReporter()),
+		gitlab.WithReporter(rep),
 	)
 }
 
@@ -52,7 +53,7 @@ func (a *App) AssignmentReport(ctx context.Context, course, name string) (*repor
 	if cfg == nil {
 		return nil, nil
 	}
-	client, err := a.gitlabClientFor(ctx, o)
+	client, err := a.gitlabClientFor(ctx, o, reporter.NewDiscardReporter())
 	if err != nil {
 		return nil, err
 	}

--- a/web/app/report_stream.go
+++ b/web/app/report_stream.go
@@ -1,0 +1,115 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/obcode/glabs/v3/gitlab/report"
+	"github.com/obcode/glabs/v3/reporter"
+)
+
+// ReportEvent is one item in the assignment-report stream: either a progress
+// message while the report is being fetched, or the single final event carrying
+// the finished report (or an error).
+type ReportEvent struct {
+	Message string
+	Done    bool
+	Report  *report.Reports
+	Error   string
+}
+
+// StreamAssignmentReport generates the report for one assignment and streams the
+// GitLab client's progress as it goes, ending with exactly one done event that
+// carries the finished report (or an error). The returned channel is closed when
+// generation finishes or ctx is cancelled.
+//
+// Like AssignmentReport, a missing or unresolvable assignment yields a done event
+// with a nil report (no error); a missing token or an unreachable GitLab yields a
+// done event whose Error is set — surfaced to the client rather than tearing down
+// the subscription.
+func (a *App) StreamAssignmentReport(ctx context.Context, course, name string) (<-chan ReportEvent, error) {
+	o, err := owner(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make(chan ReportEvent)
+
+	cfg, err := a.resolveAssignmentConfig(ctx, course, name)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		// Nothing to fetch — one done event with no report.
+		go func() {
+			defer close(events)
+			sendEvent(ctx, events, ReportEvent{Done: true})
+		}()
+		return events, nil
+	}
+
+	client, err := a.gitlabClientFor(ctx, o, &streamReporter{ctx: ctx, events: events})
+	if err != nil {
+		go func() {
+			defer close(events)
+			sendEvent(ctx, events, ReportEvent{Done: true, Error: err.Error()})
+		}()
+		return events, nil
+	}
+
+	go func() {
+		defer close(events)
+		// ReportData drives the streamReporter synchronously as it works, so its
+		// progress lines flow through `events` before this final event.
+		rep, err := client.ReportData(cfg)
+		ev := ReportEvent{Done: true}
+		if err != nil {
+			ev.Error = err.Error()
+		} else {
+			ev.Report = rep
+		}
+		sendEvent(ctx, events, ev)
+	}()
+
+	return events, nil
+}
+
+func sendEvent(ctx context.Context, ch chan<- ReportEvent, ev ReportEvent) {
+	select {
+	case ch <- ev:
+	case <-ctx.Done():
+	}
+}
+
+var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// streamReporter is a reporter.Reporter that forwards the GitLab client's progress
+// into the report stream, stripping ANSI color codes so the browser gets clean
+// lines. Every send is ctx-aware so a disconnected client never blocks the fetch.
+type streamReporter struct {
+	ctx    context.Context
+	events chan<- ReportEvent
+}
+
+func (s *streamReporter) emit(msg string) {
+	msg = strings.TrimSpace(ansiRE.ReplaceAllString(msg, ""))
+	if msg == "" {
+		return
+	}
+	sendEvent(s.ctx, s.events, ReportEvent{Message: msg})
+}
+
+func (s *streamReporter) Printf(format string, a ...any) { s.emit(fmt.Sprintf(format, a...)) }
+func (s *streamReporter) Println(a ...any)               { s.emit(fmt.Sprintln(a...)) }
+func (s *streamReporter) Task(description string) reporter.Task {
+	s.emit(description)
+	return &streamTask{s}
+}
+
+type streamTask struct{ s *streamReporter }
+
+func (t *streamTask) Update(message string) { t.s.emit(message) }
+func (t *streamTask) Done(message string)   { t.s.emit(message) }
+func (t *streamTask) Fail(message string)   { t.s.emit(message) }

--- a/web/app/report_stream_test.go
+++ b/web/app/report_stream_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func drainEvents(ch <-chan ReportEvent) []ReportEvent {
+	var evs []ReportEvent
+	for ev := range ch {
+		evs = append(evs, ev)
+	}
+	return evs
+}
+
+func TestStreamAssignmentReport_missingAssignmentYieldsDoneNoReport(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gl", sealer: testSealer(t)}
+
+	ch, err := a.StreamAssignmentReport(ctxAs(owner), "uc", "nope")
+	if err != nil {
+		t.Fatalf("StreamAssignmentReport: %v", err)
+	}
+	evs := drainEvents(ch)
+	if len(evs) != 1 || !evs[0].Done || evs[0].Report != nil || evs[0].Error != "" {
+		t.Fatalf("events = %+v, want a single done event with no report/error", evs)
+	}
+}
+
+func TestStreamAssignmentReport_abstractBaseYieldsDoneNoReport(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl", sealer: testSealer(t)}
+
+	ch, err := a.StreamAssignmentReport(ctxAs(owner), "tc", "base")
+	if err != nil {
+		t.Fatalf("StreamAssignmentReport: %v", err)
+	}
+	evs := drainEvents(ch)
+	if len(evs) != 1 || !evs[0].Done || evs[0].Report != nil {
+		t.Fatalf("events = %+v, want a single done event with no report", evs)
+	}
+}
+
+func TestStreamAssignmentReport_noTokenYieldsDoneWithError(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gl", sealer: testSealer(t)}
+
+	ch, err := a.StreamAssignmentReport(ctxAs(owner), "uc", "blatt1")
+	if err != nil {
+		t.Fatalf("StreamAssignmentReport: %v", err)
+	}
+	evs := drainEvents(ch)
+	if len(evs) == 0 {
+		t.Fatal("expected at least the final event")
+	}
+	last := evs[len(evs)-1]
+	if !last.Done || !strings.Contains(last.Error, "no GitLab token") {
+		t.Fatalf("final event = %+v, want done with a missing-token error", last)
+	}
+}

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -31,6 +31,7 @@ type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
 type ResolverRoot interface {
 	Mutation() MutationResolver
 	Query() QueryResolver
+	Subscription() SubscriptionResolver
 }
 
 type DirectiveRoot struct {
@@ -204,10 +205,21 @@ type ComplexityRoot struct {
 		URL func(childComplexity int) int
 	}
 
+	ReportProgress struct {
+		Done    func(childComplexity int) int
+		Error   func(childComplexity int) int
+		Message func(childComplexity int) int
+		Report  func(childComplexity int) int
+	}
+
 	ServerInfo struct {
 		Commit  func(childComplexity int) int
 		Date    func(childComplexity int) int
 		Version func(childComplexity int) int
+	}
+
+	Subscription struct {
+		AssignmentReportProgress func(childComplexity int, course string, name string) int
 	}
 
 	User struct {
@@ -256,6 +268,9 @@ type QueryResolver interface {
 	CourseLint(ctx context.Context, name string) ([]*model.Finding, error)
 	GitlabToken(ctx context.Context) (*model.GitLabTokenStatus, error)
 	AssignmentReport(ctx context.Context, course string, name string) (*model.AssignmentReport, error)
+}
+type SubscriptionResolver interface {
+	AssignmentReportProgress(ctx context.Context, course string, name string) (<-chan *model.ReportProgress, error)
 }
 
 // endregion ************************** generated!.gotpl **************************
@@ -1024,6 +1039,31 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.RepoUrl.URL(childComplexity), true
 
+	case "ReportProgress.done":
+		if e.ComplexityRoot.ReportProgress.Done == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ReportProgress.Done(childComplexity), true
+	case "ReportProgress.error":
+		if e.ComplexityRoot.ReportProgress.Error == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ReportProgress.Error(childComplexity), true
+	case "ReportProgress.message":
+		if e.ComplexityRoot.ReportProgress.Message == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ReportProgress.Message(childComplexity), true
+	case "ReportProgress.report":
+		if e.ComplexityRoot.ReportProgress.Report == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ReportProgress.Report(childComplexity), true
+
 	case "ServerInfo.commit":
 		if e.ComplexityRoot.ServerInfo.Commit == nil {
 			break
@@ -1042,6 +1082,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ServerInfo.Version(childComplexity), true
+
+	case "Subscription.assignmentReportProgress":
+		if e.ComplexityRoot.Subscription.AssignmentReportProgress == nil {
+			break
+		}
+
+		args, err := ec.field_Subscription_assignmentReportProgress_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Subscription.AssignmentReportProgress(childComplexity, args["course"].(string), args["name"].(string)), true
 
 	case "User.email":
 		if e.ComplexityRoot.User.Email == nil {
@@ -1134,6 +1186,23 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Mutation(ctx, opCtx.Operation.SelectionSet)
 			var buf bytes.Buffer
+			data.MarshalGQL(&buf)
+
+			return &graphql.Response{
+				Data: buf.Bytes(),
+			}
+		}
+	case ast.Subscription:
+		next := ec._Subscription(ctx, opCtx.Operation.SelectionSet)
+
+		var buf bytes.Buffer
+		return func(ctx context.Context) *graphql.Response {
+			buf.Reset()
+			data := next(ctx)
+
+			if data == nil {
+				return nil
+			}
 			data.MarshalGQL(&buf)
 
 			return &graphql.Response{
@@ -1508,6 +1577,30 @@ extend type Query {
   """
   assignmentReport(course: String!, name: String!): AssignmentReport
 }
+
+"""
+One event while a report is being generated: a progress line as it is fetched, or
+the single final event (done = true) carrying the finished report or an error.
+"""
+type ReportProgress {
+  "A human-readable progress line; empty on the final event."
+  message: String!
+  "True on the final event; then no more events follow."
+  done: Boolean!
+  "The finished report — set only on the final event, and only if it succeeded."
+  report: AssignmentReport
+  "Why generation failed — set only on the final event on failure."
+  error: String
+}
+
+type Subscription {
+  """
+  Generate an assignment report and stream the GitLab client's progress as it
+  goes, ending with one done event carrying the report (or an error). Same
+  semantics as the assignmentReport query, but with live progress.
+  """
+  assignmentReportProgress(course: String!, name: String!): ReportProgress!
+}
 `, BuiltIn: false},
 	{Name: "../schema.graphqls", Input: `"""
 An authenticated user of glabs-web. Identity comes from the auth proxy; there
@@ -1807,6 +1900,20 @@ func (ec *executionContext) childFields_RepoUrl(ctx context.Context, field graph
 		return ec.fieldContext_RepoUrl_url(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type RepoUrl", field.Name)
+}
+
+func (ec *executionContext) childFields_ReportProgress(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "message":
+		return ec.fieldContext_ReportProgress_message(ctx, field)
+	case "done":
+		return ec.fieldContext_ReportProgress_done(ctx, field)
+	case "report":
+		return ec.fieldContext_ReportProgress_report(ctx, field)
+	case "error":
+		return ec.fieldContext_ReportProgress_error(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type ReportProgress", field.Name)
 }
 
 func (ec *executionContext) childFields_ServerInfo(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -2362,6 +2469,28 @@ func (ec *executionContext) field_Query_validateAssignmentDraft_args(ctx context
 		return nil, err
 	}
 	args["draft"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Subscription_assignmentReportProgress_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "course",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["course"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "name",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["name"] = arg1
 	return args, nil
 }
 
@@ -5499,6 +5628,107 @@ func (ec *executionContext) fieldContext_RepoUrl_url(_ context.Context, field gr
 	return graphql.NewScalarFieldContext("RepoUrl", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
+func (ec *executionContext) _ReportProgress_message(ctx context.Context, field graphql.CollectedField, obj *model.ReportProgress) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ReportProgress_message(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Message, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_ReportProgress_message(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ReportProgress", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _ReportProgress_done(ctx context.Context, field graphql.CollectedField, obj *model.ReportProgress) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ReportProgress_done(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Done, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v bool) graphql.Marshaler {
+			return ec.marshalNBoolean2bool(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_ReportProgress_done(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ReportProgress", field, false, false, errors.New("field of type Boolean does not have child fields"))
+}
+
+func (ec *executionContext) _ReportProgress_report(ctx context.Context, field graphql.CollectedField, obj *model.ReportProgress) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ReportProgress_report(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Report, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.AssignmentReport) graphql.Marshaler {
+			return ec.marshalOAssignmentReport2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentReport(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_ReportProgress_report(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ReportProgress",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_AssignmentReport(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ReportProgress_error(ctx context.Context, field graphql.CollectedField, obj *model.ReportProgress) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ReportProgress_error(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Error, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_ReportProgress_error(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ReportProgress", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
 func (ec *executionContext) _ServerInfo_version(ctx context.Context, field graphql.CollectedField, obj *model.ServerInfo) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -5566,6 +5796,50 @@ func (ec *executionContext) _ServerInfo_date(ctx context.Context, field graphql.
 }
 func (ec *executionContext) fieldContext_ServerInfo_date(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("ServerInfo", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _Subscription_assignmentReportProgress(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
+	return graphql.ResolveFieldStream(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Subscription_assignmentReportProgress(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Subscription().AssignmentReportProgress(ctx, fc.Args["course"].(string), fc.Args["name"].(string))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.ReportProgress) graphql.Marshaler {
+			return ec.marshalNReportProgress2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐReportProgress(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Subscription_assignmentReportProgress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Subscription",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_ReportProgress(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Subscription_assignmentReportProgress_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
 }
 
 func (ec *executionContext) _User_email(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
@@ -8349,6 +8623,59 @@ func (ec *executionContext) _RepoUrl(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
+var reportProgressImplementors = []string{"ReportProgress"}
+
+func (ec *executionContext) _ReportProgress(ctx context.Context, sel ast.SelectionSet, obj *model.ReportProgress) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, reportProgressImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferredFieldSet := graphql.NewFieldSet(nil)
+	deferLabelToView := make(map[string]*graphql.FieldSetView)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ReportProgress")
+		case "message":
+			out.Values[i] = ec._ReportProgress_message(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "done":
+			out.Values[i] = ec._ReportProgress_done(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "report":
+			out.Values[i] = ec._ReportProgress_report(ctx, field, obj)
+			if out.Values[i] == graphql.RequiredNull {
+				out.Invalids++
+			}
+		case "error":
+			out.Values[i] = ec._ReportProgress_error(ctx, field, obj)
+			if out.Values[i] == graphql.RequiredNull {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferLabelToView), math.MaxInt32)))
+
+	ec.ProcessDeferredGroup(graphql.DeferredGroup{
+		Defers:   deferLabelToView,
+		Path:     graphql.GetPath(ctx),
+		FieldSet: deferredFieldSet,
+		Context:  ctx,
+	})
+
+	return out
+}
+
 var serverInfoImplementors = []string{"ServerInfo"}
 
 func (ec *executionContext) _ServerInfo(ctx context.Context, sel ast.SelectionSet, obj *model.ServerInfo) graphql.Marshaler {
@@ -8395,6 +8722,26 @@ func (ec *executionContext) _ServerInfo(ctx context.Context, sel ast.SelectionSe
 	})
 
 	return out
+}
+
+var subscriptionImplementors = []string{"Subscription"}
+
+func (ec *executionContext) _Subscription(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, subscriptionImplementors)
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+	})
+	if len(fields) != 1 {
+		graphql.AddErrorf(ctx, "must subscribe to exactly one stream")
+		return nil
+	}
+
+	switch fields[0].Name {
+	case "assignmentReportProgress":
+		return ec._Subscription_assignmentReportProgress(ctx, fields[0])
+	default:
+		panic("unknown field " + strconv.Quote(fields[0].Name))
+	}
 }
 
 var userImplementors = []string{"User"}
@@ -9265,6 +9612,20 @@ func (ec *executionContext) marshalNRepoUrl2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv
 		return graphql.Null
 	}
 	return ec._RepoUrl(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNReportProgress2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐReportProgress(ctx context.Context, sel ast.SelectionSet, v model.ReportProgress) graphql.Marshaler {
+	return ec._ReportProgress(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNReportProgress2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐReportProgress(ctx context.Context, sel ast.SelectionSet, v *model.ReportProgress) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ReportProgress(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNServerInfo2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐServerInfo(ctx context.Context, sel ast.SelectionSet, v model.ServerInfo) graphql.Marshaler {

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -219,11 +219,27 @@ type RepoURL struct {
 	URL string `json:"url"`
 }
 
+// One event while a report is being generated: a progress line as it is fetched, or
+// the single final event (done = true) carrying the finished report or an error.
+type ReportProgress struct {
+	// A human-readable progress line; empty on the final event.
+	Message string `json:"message"`
+	// True on the final event; then no more events follow.
+	Done bool `json:"done"`
+	// The finished report — set only on the final event, and only if it succeeded.
+	Report *AssignmentReport `json:"report,omitempty"`
+	// Why generation failed — set only on the final event on failure.
+	Error *string `json:"error,omitempty"`
+}
+
 // Version and build metadata for the running server.
 type ServerInfo struct {
 	Version string `json:"version"`
 	Commit  string `json:"commit"`
 	Date    string `json:"date"`
+}
+
+type Subscription struct {
 }
 
 // Result of validating a draft assignment against the real resolver (the same one

--- a/web/graph/report.graphqls
+++ b/web/graph/report.graphqls
@@ -82,3 +82,27 @@ extend type Query {
   """
   assignmentReport(course: String!, name: String!): AssignmentReport
 }
+
+"""
+One event while a report is being generated: a progress line as it is fetched, or
+the single final event (done = true) carrying the finished report or an error.
+"""
+type ReportProgress {
+  "A human-readable progress line; empty on the final event."
+  message: String!
+  "True on the final event; then no more events follow."
+  done: Boolean!
+  "The finished report — set only on the final event, and only if it succeeded."
+  report: AssignmentReport
+  "Why generation failed — set only on the final event on failure."
+  error: String
+}
+
+type Subscription {
+  """
+  Generate an assignment report and stream the GitLab client's progress as it
+  goes, ending with one done event carrying the report (or an error). Same
+  semantics as the assignmentReport query, but with live progress.
+  """
+  assignmentReportProgress(course: String!, name: String!): ReportProgress!
+}

--- a/web/graph/report.resolvers.go
+++ b/web/graph/report.resolvers.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 
 	"github.com/obcode/glabs/v3/web/db"
+	"github.com/obcode/glabs/v3/web/graph/generated"
 	"github.com/obcode/glabs/v3/web/graph/model"
 )
 
@@ -27,3 +28,36 @@ func (r *queryResolver) AssignmentReport(ctx context.Context, course string, nam
 	}
 	return toGraphAssignmentReport(rep), nil
 }
+
+// AssignmentReportProgress is the resolver for the assignmentReportProgress field.
+func (r *subscriptionResolver) AssignmentReportProgress(ctx context.Context, course string, name string) (<-chan *model.ReportProgress, error) {
+	events, err := r.app.StreamAssignmentReport(ctx, course, name)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan *model.ReportProgress)
+	go func() {
+		defer close(out)
+		for ev := range events {
+			p := &model.ReportProgress{Message: ev.Message, Done: ev.Done}
+			if ev.Error != "" {
+				msg := ev.Error
+				p.Error = &msg
+			}
+			if ev.Report != nil {
+				p.Report = toGraphAssignmentReport(ev.Report)
+			}
+			select {
+			case out <- p:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// Subscription returns generated.SubscriptionResolver implementation.
+func (r *Resolver) Subscription() generated.SubscriptionResolver { return &subscriptionResolver{r} }
+
+type subscriptionResolver struct{ *Resolver }

--- a/web/graph/server.go
+++ b/web/graph/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -13,6 +14,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
+	coderws "github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
 	"github.com/obcode/glabs/v3/web/app"
 	"github.com/obcode/glabs/v3/web/graph/generated"
@@ -34,6 +36,20 @@ func allowedOrigins() []string {
 	return defaultAllowedOrigins
 }
 
+// originHosts turns the allowed origins (full URLs) into host[:port] patterns for
+// coder/websocket's OriginPatterns, which matches against the Origin header's host.
+func originHosts(origins []string) []string {
+	hosts := make([]string, 0, len(origins))
+	for _, o := range origins {
+		if u, err := url.Parse(o); err == nil && u.Host != "" {
+			hosts = append(hosts, u.Host)
+		} else {
+			hosts = append(hosts, o)
+		}
+	}
+	return hosts
+}
+
 // StartServer wires the GraphQL handler behind CORS and the auth middleware, and
 // blocks until SIGTERM/Interrupt.
 //
@@ -44,9 +60,21 @@ func StartServer(a *app.App, port string) {
 
 	origins := allowedOrigins()
 
-	// POST only for now. The websocket transport (for streaming subscriptions)
-	// arrives with the mutating operations that need it.
 	srv.AddTransport(transport.POST{})
+
+	// WebSocket transport for subscriptions (the report progress stream). The auth
+	// middleware runs on the HTTP upgrade request, so the identity it injects is
+	// already in the connection context — no separate WS auth is needed. The WS
+	// upgrade is not covered by CORS preflight, so origins are checked here via
+	// coder/websocket's OriginPatterns (host[:port], scheme stripped).
+	srv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: 10 * time.Second,
+		Implementation: transport.CoderWebsocketImplementation{
+			AcceptOptions: coderws.AcceptOptions{
+				OriginPatterns: originHosts(origins),
+			},
+		},
+	})
 
 	production := viper.GetBool("server.production")
 	if !production {


### PR DESCRIPTION
Lange Reports ließen das GUI eingefroren wirken: der Report ist ein langsamer GitLab-Abruf, und während er lief, war nichts zu sehen. Diese PR bringt **Live-Fortschritt über eine WebSocket-Subscription** — die erste Subscription der App.

## Was drin ist
- **Server**: WebSocket-Transport ergänzt (gqlgen + `coder/websocket`). Die **Auth-Middleware läuft auf dem HTTP-Upgrade**, daher ist die injizierte Identität bereits im Verbindungs-Kontext (gqlgen leitet ihn aus `r.Context()` ab) — keine separate WS-Auth nötig. Origins werden via `OriginPatterns` geprüft (CORS-Preflight deckt den Upgrade nicht ab).
- **app**: `StreamAssignmentReport` führt den Report mit einem `streamReporter` aus — ein `reporter.Reporter`, der die Fortschrittszeilen des GitLab-Clients (ANSI entfernt) in einen Channel leitet — und sendet **ein** finales `done`-Event mit dem Report bzw. einem Fehler. `gitlabClientFor` bekommt jetzt den Reporter übergeben (Discard für die One-Shot-Query, Streaming für die Subscription).
- **graph**: `Subscription.assignmentReportProgress` + Typ `ReportProgress` + Resolver.
- **Tests**: die offline-Pfade des Streams (fehlend/abstrakt → done ohne Report; kein Token → done mit Fehler).

## GraphQL
```graphql
type ReportProgress { message: String!  done: Boolean!  report: AssignmentReport  error: String }
type Subscription {
  assignmentReportProgress(course: String!, name: String!): ReportProgress!
}
```

## Verifikation
`go build`, `go vet` (+ integration), `go test ./...`, `golangci-lint` — alle grün; `gofmt` clean. Die Kontext-Weitergabe (Principal über den WS-Upgrade) ist an der gqlgen-Quelle verifiziert (`ctx: r.Context()`).

⚠️ Der echte WS-Handshake ist erst mit laufendem Backend live testbar — das passiert im folgenden GUI-PR (graphql-ws-Client + Report-Seite mit Live-Log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)