### PR TITLE
fix(web): keep report/check subscriptions alive (PongOnlyInterval)

### DIFF
--- a/web/graph/server.go
+++ b/web/graph/server.go
@@ -68,7 +68,13 @@ func StartServer(a *app.App, port string) {
 	// upgrade is not covered by CORS preflight, so origins are checked here via
 	// coder/websocket's OriginPatterns (host[:port], scheme stripped).
 	srv.AddTransport(transport.Websocket{
-		KeepAlivePingInterval: 10 * time.Second,
+		// graphql-ws (the browser client) speaks the modern graphql-transport-ws
+		// subprotocol, for which KeepAlivePingInterval does NOT apply — only the
+		// legacy apollo subprotocol uses it. Send an unsolicited pong every 10s
+		// (PongOnlyInterval, the correct field here) so a long report/check stream
+		// (minutes, with gaps between progress) is not dropped as idle and then
+		// re-subscribed from scratch by the client's retry.
+		PongOnlyInterval: 10 * time.Second,
 		Implementation: transport.CoderWebsocketImplementation{
 			AcceptOptions: coderws.AcceptOptions{
 				OriginPatterns: originHosts(origins),


### PR DESCRIPTION
**Behebt: der Report-/Check-Stream fängt bei langen Läufen mehrfach von vorne an.**

Ursache: `graphql-ws` (der Browser-Client) spricht das moderne **graphql-transport-ws**-Subprotokoll. Für dieses ist gqlgens `KeepAlivePingInterval` ein **No-op** (es greift nur beim Legacy-apollo-Subprotokoll). Ohne Keepalive geht ein langer Stream mit Lücken zwischen den Fortschrittsmeldungen idle, der Socket wird gedroppt, und der Client re-subscribed → der ganze Report läuft von vorne.

Fix: **`PongOnlyInterval` (10s)** — das korrekte Keepalive für graphql-transport-ws. Der Server sendet alle 10s ein unsolicited `pong`, die Verbindung bleibt warm.

## Verifikation
`go build`, `go vet ./web/...` grün. (Der echte WS-Effekt ist erst gegen ein laufendes Backend sichtbar.)

Ein begleitender glabs.gui-PR ergänzt zusätzlich clientseitiges `keepAlive` als Redundanz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)