### PR TITLE
feat(web): runOp — run a planned op with exclusive lock and streaming (Milestone C)

### DIFF
--- a/web/app/app.go
+++ b/web/app/app.go
@@ -39,10 +39,12 @@ type App struct {
 	// gitlabHost is the base URL glabs builds project URLs against; it feeds the
 	// resolved-config preview so the web shows the same URLs the CLI would.
 	gitlabHost string
+	// ops serializes mutating operations per (owner, course, assignment).
+	ops *opGuard
 }
 
 func New(database *db.DB, sealer *secrets.Sealer, gitlabHost string) *App {
-	return &App{db: database, sealer: sealer, gitlabHost: gitlabHost}
+	return &App{db: database, sealer: sealer, gitlabHost: gitlabHost, ops: newOpGuard()}
 }
 
 // GetUserByEmail looks up a user for the auth middleware's allowlist check.

--- a/web/app/exclusive.go
+++ b/web/app/exclusive.go
@@ -1,0 +1,35 @@
+package app
+
+import "sync"
+
+// opGuard serializes mutating operations per (owner, course, assignment): a second
+// operation on the SAME assignment is rejected while one runs, but operations on
+// different assignments (or by different owners) run concurrently. Unlike plexams'
+// single global mutex, the lock key is scoped so one prof's long op never blocks
+// another's.
+type opGuard struct {
+	mu   sync.Mutex
+	busy map[string]struct{}
+}
+
+func newOpGuard() *opGuard {
+	return &opGuard{busy: make(map[string]struct{})}
+}
+
+// tryBegin reserves the (owner, course, assignment) slot. It returns a release
+// function and true on success, or (nil, false) if an operation is already running
+// for that key. The caller must call release exactly once when the op finishes.
+func (g *opGuard) tryBegin(owner, course, assignment string) (release func(), ok bool) {
+	key := owner + "\x00" + course + "\x00" + assignment
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if _, running := g.busy[key]; running {
+		return nil, false
+	}
+	g.busy[key] = struct{}{}
+	return func() {
+		g.mu.Lock()
+		delete(g.busy, key)
+		g.mu.Unlock()
+	}, true
+}

--- a/web/app/exclusive_test.go
+++ b/web/app/exclusive_test.go
@@ -1,0 +1,35 @@
+package app
+
+import "testing"
+
+func TestOpGuard_serializesPerKey(t *testing.T) {
+	g := newOpGuard()
+
+	rel, ok := g.tryBegin("prof@hm.edu", "uc", "blatt1")
+	if !ok {
+		t.Fatal("first begin should succeed")
+	}
+	if _, ok := g.tryBegin("prof@hm.edu", "uc", "blatt1"); ok {
+		t.Fatal("a second op on the same (owner,course,assignment) must be rejected")
+	}
+
+	// A different assignment, course, or owner is allowed concurrently.
+	if rel2, ok := g.tryBegin("prof@hm.edu", "uc", "blatt2"); !ok {
+		t.Error("a different assignment should be allowed")
+	} else {
+		rel2()
+	}
+	if rel3, ok := g.tryBegin("other@hm.edu", "uc", "blatt1"); !ok {
+		t.Error("a different owner should be allowed")
+	} else {
+		rel3()
+	}
+
+	// After release the key frees up.
+	rel()
+	if rel4, ok := g.tryBegin("prof@hm.edu", "uc", "blatt1"); !ok {
+		t.Fatal("after release the same key should succeed again")
+	} else {
+		rel4()
+	}
+}

--- a/web/app/run_op.go
+++ b/web/app/run_op.go
@@ -1,0 +1,154 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/obcode/glabs/v3/config"
+	"github.com/obcode/glabs/v3/gitlab"
+	"github.com/obcode/glabs/v3/reporter"
+)
+
+// RunLine is one line of an operation's streamed output: a level (INFO, WARN,
+// ERROR, PROGRESS, RESULT, DONE) plus text (may contain ANSI, though the reporter
+// strips it).
+type RunLine struct {
+	Level string
+	Text  string
+}
+
+// RunOp validates a plan token and runs the mutating GitLab operation it describes,
+// streaming its output line by line. The pre-flight checks (token, config drift,
+// seeder, confirm phrase, exclusive lock, GitLab token) fail synchronously with an
+// error; once the operation starts, failures are streamed as an ERROR line.
+//
+// The operation runs on a context DETACHED from the subscription
+// (context.WithoutCancel): closing the browser tab cancels the subscription (so the
+// reporter stops streaming) but the operation keeps running to completion.
+func (a *App) RunOp(ctx context.Context, token, confirmPhrase string) (<-chan RunLine, error) {
+	o, err := owner(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	tok, err := a.openOpToken(token)
+	if err != nil {
+		return nil, err
+	}
+	if tok.Owner != o {
+		return nil, fmt.Errorf("this plan was not created by you")
+	}
+
+	// Re-resolve and compare the config hash: reject a plan whose config changed
+	// since it was made (the whole point of the token).
+	cfg, err := a.resolveAssignmentConfig(ctx, tok.Course, tok.Assignment, tok.OnlyFor...)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("assignment %q of course %q no longer resolves", tok.Assignment, tok.Course)
+	}
+	hash, err := configHash(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if hash != tok.ConfigHash {
+		return nil, fmt.Errorf("the configuration changed since you planned this operation — please plan again")
+	}
+
+	if cfg.Seeder != nil {
+		return nil, fmt.Errorf("assignment %q configures a seeder, which the web cannot run — use the CLI", tok.Assignment)
+	}
+	if tok.Op == "archive" || tok.Op == "delete" {
+		want := tok.Course + "/" + tok.Assignment
+		if confirmPhrase != want {
+			return nil, fmt.Errorf("type %q to confirm this destructive operation", want)
+		}
+	}
+
+	release, ok := a.ops.tryBegin(o, tok.Course, tok.Assignment)
+	if !ok {
+		return nil, fmt.Errorf("another operation on %s/%s is already running", tok.Course, tok.Assignment)
+	}
+
+	events := make(chan RunLine, 256)
+	// Detached context: the op survives a client disconnect. The reporter still
+	// uses the subscription ctx, so streaming stops once the client is gone.
+	opCtx := context.WithoutCancel(ctx)
+	rep := &opReporter{ctx: ctx, events: events}
+
+	client, err := a.gitlabClientFor(opCtx, o, rep)
+	if err != nil {
+		release()
+		return nil, err
+	}
+
+	go func() {
+		defer close(events)
+		defer release()
+		rep.emit("INFO", fmt.Sprintf("running %s on %s/%s (%d repositories)", tok.Op, tok.Course, tok.Assignment, len(cfg.RepoTargets())))
+		if err := executeOp(client, tok, cfg); err != nil {
+			rep.emit("ERROR", err.Error())
+		} else {
+			rep.emit("RESULT", fmt.Sprintf("%s completed", tok.Op))
+		}
+		rep.emit("DONE", "done")
+	}()
+
+	return events, nil
+}
+
+// executeOp applies the op's parameters to the resolved config and dispatches to
+// the corresponding GitLab client method. None of these touch git.
+func executeOp(client *gitlab.Client, tok *opToken, cfg *config.AssignmentConfig) error {
+	switch tok.Op {
+	case "setaccess":
+		if lvl := tok.Params["accessLevel"]; lvl != "" {
+			cfg.SetAccessLevel(lvl)
+		}
+		return client.Setaccess(cfg)
+	case "protect":
+		if br := tok.Params["branch"]; br != "" {
+			cfg.SetProtectToBranch(br)
+		}
+		return client.ProtectToBranch(cfg)
+	case "archive":
+		return client.Archive(cfg, tok.Params["unarchive"] == "true")
+	case "delete":
+		return client.Delete(cfg)
+	}
+	return fmt.Errorf("unknown operation %q", tok.Op)
+}
+
+// opReporter is a reporter.Reporter that classifies the GitLab client's progress
+// into levelled RunLines and forwards them (ANSI stripped) on the subscription
+// context, so a disconnected client never blocks the operation.
+type opReporter struct {
+	ctx    context.Context
+	events chan<- RunLine
+}
+
+func (r *opReporter) emit(level, msg string) {
+	msg = strings.TrimSpace(ansiRE.ReplaceAllString(msg, ""))
+	if msg == "" {
+		return
+	}
+	select {
+	case r.events <- RunLine{Level: level, Text: msg}:
+	case <-r.ctx.Done():
+	}
+}
+
+func (r *opReporter) Printf(format string, a ...any) { r.emit("INFO", fmt.Sprintf(format, a...)) }
+func (r *opReporter) Println(a ...any)               { r.emit("INFO", fmt.Sprintln(a...)) }
+func (r *opReporter) Task(description string) reporter.Task {
+	r.emit("PROGRESS", description)
+	return &opTask{r}
+}
+
+type opTask struct{ r *opReporter }
+
+func (t *opTask) Update(message string) { t.r.emit("PROGRESS", message) }
+func (t *opTask) Done(message string)   { t.r.emit("INFO", message) }
+func (t *opTask) Fail(message string)   { t.r.emit("ERROR", message) }

--- a/web/app/run_op_test.go
+++ b/web/app/run_op_test.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+const seederCourse = `sc:
+  coursepath: sc/sem
+  semesterpath: ss26
+  blatt1:
+    per: student
+    accesslevel: developer
+    students:
+      - a@hm.edu
+    seeder:
+      cmd: make
+      args:
+        - build
+`
+
+func newRunApp(t *testing.T, owner, name, yaml string) *App {
+	t.Helper()
+	fs := newFakeStore()
+	fs.courses[owner+"/"+name] = storedCourse(t, owner, yaml)
+	return &App{db: fs, gitlabHost: "https://gl", sealer: testSealer(t), ops: newOpGuard()}
+}
+
+func planToken(t *testing.T, a *App, owner, op, course, assignment string) string {
+	t.Helper()
+	plan, err := a.PlanOp(ctxAs(owner), op, course, assignment, nil, nil)
+	if err != nil {
+		t.Fatalf("PlanOp: %v", err)
+	}
+	return plan.Token
+}
+
+func TestRunOp_badTokenRejected(t *testing.T) {
+	a := newRunApp(t, "prof@hm.edu", "uc", urlsCourse)
+	if _, err := a.RunOp(ctxAs("prof@hm.edu"), "not-a-real-token", ""); err == nil {
+		t.Fatal("expected an error for a bad token")
+	}
+}
+
+func TestRunOp_wrongOwnerRejected(t *testing.T) {
+	a := newRunApp(t, "prof@hm.edu", "uc", urlsCourse)
+	token := planToken(t, a, "prof@hm.edu", "setaccess", "uc", "blatt1")
+
+	_, err := a.RunOp(ctxAs("someone-else@hm.edu"), token, "")
+	if err == nil || !strings.Contains(err.Error(), "not created by you") {
+		t.Fatalf("error = %v, want a wrong-owner rejection", err)
+	}
+}
+
+func TestRunOp_configChangedRejected(t *testing.T) {
+	const owner = "prof@hm.edu"
+	a := newRunApp(t, owner, "uc", urlsCourse)
+	token := planToken(t, a, owner, "setaccess", "uc", "blatt1")
+
+	// Change the stored config after planning: the hash no longer matches.
+	changed := strings.Replace(urlsCourse, "accesslevel: developer", "accesslevel: maintainer", 1)
+	fs := a.db.(*fakeStore)
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, changed)
+
+	_, err := a.RunOp(ctxAs(owner), token, "")
+	if err == nil || !strings.Contains(err.Error(), "configuration changed") {
+		t.Fatalf("error = %v, want a config-changed rejection", err)
+	}
+}
+
+func TestRunOp_seederRejected(t *testing.T) {
+	const owner = "prof@hm.edu"
+	a := newRunApp(t, owner, "sc", seederCourse)
+	token := planToken(t, a, owner, "setaccess", "sc", "blatt1")
+
+	_, err := a.RunOp(ctxAs(owner), token, "")
+	if err == nil || !strings.Contains(err.Error(), "seeder") {
+		t.Fatalf("error = %v, want a seeder rejection", err)
+	}
+}
+
+func TestRunOp_destructiveNeedsConfirmPhrase(t *testing.T) {
+	const owner = "prof@hm.edu"
+	a := newRunApp(t, owner, "uc", urlsCourse)
+	token := planToken(t, a, owner, "delete", "uc", "blatt1")
+
+	if _, err := a.RunOp(ctxAs(owner), token, ""); err == nil || !strings.Contains(err.Error(), "confirm") {
+		t.Fatalf("empty phrase: error = %v, want a confirm-phrase rejection", err)
+	}
+	// With the correct phrase the guards pass; then it fails on the missing token
+	// (no PAT stored) — synchronously, before streaming.
+	if _, err := a.RunOp(ctxAs(owner), token, "uc/blatt1"); err == nil || !strings.Contains(err.Error(), "no GitLab token") {
+		t.Fatalf("correct phrase: error = %v, want a missing-token error", err)
+	}
+}
+
+func TestRunOp_noTokenStoredRejected(t *testing.T) {
+	const owner = "prof@hm.edu"
+	a := newRunApp(t, owner, "uc", urlsCourse)
+	token := planToken(t, a, owner, "setaccess", "uc", "blatt1")
+
+	// All guards pass, but no GitLab token is stored → synchronous error.
+	_, err := a.RunOp(ctxAs(owner), token, "")
+	if err == nil || !strings.Contains(err.Error(), "no GitLab token") {
+		t.Fatalf("error = %v, want a missing-token error", err)
+	}
+}

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -162,6 +162,11 @@ type ComplexityRoot struct {
 		Name    func(childComplexity int) int
 	}
 
+	LogLine struct {
+		Level func(childComplexity int) int
+		Text  func(childComplexity int) int
+	}
+
 	Mutation struct {
 		CreateCourse         func(childComplexity int, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) int
 		DeleteAssignment     func(childComplexity int, course string, name string) int
@@ -274,6 +279,7 @@ type ComplexityRoot struct {
 	Subscription struct {
 		AssignmentReportProgress func(childComplexity int, course string, name string) int
 		CourseCheckProgress      func(childComplexity int, name string) int
+		RunOp                    func(childComplexity int, token string, confirmPhrase *string) int
 	}
 
 	User struct {
@@ -328,6 +334,7 @@ type QueryResolver interface {
 type SubscriptionResolver interface {
 	AssignmentReportProgress(ctx context.Context, course string, name string) (<-chan *model.ReportProgress, error)
 	CourseCheckProgress(ctx context.Context, name string) (<-chan *model.CheckProgress, error)
+	RunOp(ctx context.Context, token string, confirmPhrase *string) (<-chan *model.LogLine, error)
 }
 
 // endregion ************************** generated!.gotpl **************************
@@ -802,6 +809,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.GroupCheck.Name(childComplexity), true
+
+	case "LogLine.level":
+		if e.ComplexityRoot.LogLine.Level == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LogLine.Level(childComplexity), true
+	case "LogLine.text":
+		if e.ComplexityRoot.LogLine.Text == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LogLine.Text(childComplexity), true
 
 	case "Mutation.createCourse":
 		if e.ComplexityRoot.Mutation.CreateCourse == nil {
@@ -1371,6 +1391,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Subscription.CourseCheckProgress(childComplexity, args["name"].(string)), true
+	case "Subscription.runOp":
+		if e.ComplexityRoot.Subscription.RunOp == nil {
+			break
+		}
+
+		args, err := ec.field_Subscription_runOp_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Subscription.RunOp(childComplexity, args["token"].(string), args["confirmPhrase"].(*string)), true
 
 	case "User.email":
 		if e.ComplexityRoot.User.Email == nil {
@@ -1910,6 +1941,34 @@ extend type Mutation {
   """
   planOp(op: Op!, course: String!, assignment: String!, params: OpParams, onlyFor: [String!]): OpPlan!
 }
+
+"The severity/kind of one streamed output line."
+enum LogLevel {
+  INFO
+  WARN
+  ERROR
+  PROGRESS
+  RESULT
+  DONE
+}
+
+"One line of a running operation's streamed output."
+type LogLine {
+  level: LogLevel!
+  "The line text (ANSI stripped)."
+  text: String!
+}
+
+extend type Subscription {
+  """
+  Run a planned operation against GitLab (from planOp's token) and stream its output
+  line by line, ending with a DONE line. The operation keeps running server-side even
+  if the client disconnects (closing the tab does NOT abort it). A second operation on
+  the same assignment is rejected while one runs. For a destructive op (archive/delete)
+  confirmPhrase must equal the plan's confirmPhrase.
+  """
+  runOp(token: String!, confirmPhrase: String): LogLine!
+}
 `, BuiltIn: false},
 	{Name: "../report.graphqls", Input: `"""
 A live report over the repositories of one assignment — one row per project
@@ -2296,6 +2355,16 @@ func (ec *executionContext) childFields_GroupCheck(ctx context.Context, field gr
 		return ec.fieldContext_GroupCheck_members(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type GroupCheck", field.Name)
+}
+
+func (ec *executionContext) childFields_LogLine(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "level":
+		return ec.fieldContext_LogLine_level(ctx, field)
+	case "text":
+		return ec.fieldContext_LogLine_text(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type LogLine", field.Name)
 }
 
 func (ec *executionContext) childFields_OpPlan(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -3085,6 +3154,28 @@ func (ec *executionContext) field_Subscription_courseCheckProgress_args(ctx cont
 		return nil, err
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Subscription_runOp_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "token",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["token"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "confirmPhrase",
+		func(ctx context.Context, v any) (*string, error) {
+			return ec.unmarshalOString2ᚖstring(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["confirmPhrase"] = arg1
 	return args, nil
 }
 
@@ -4924,6 +5015,52 @@ func (ec *executionContext) fieldContext_GroupCheck_members(_ context.Context, f
 		},
 	}
 	return fc, nil
+}
+
+func (ec *executionContext) _LogLine_level(ctx context.Context, field graphql.CollectedField, obj *model.LogLine) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LogLine_level(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Level, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v model.LogLevel) graphql.Marshaler {
+			return ec.marshalNLogLevel2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐLogLevel(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LogLine_level(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LogLine", field, false, false, errors.New("field of type LogLevel does not have child fields"))
+}
+
+func (ec *executionContext) _LogLine_text(ctx context.Context, field graphql.CollectedField, obj *model.LogLine) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LogLine_text(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Text, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LogLine_text(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LogLine", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _Mutation_importCourseYAML(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -7312,6 +7449,50 @@ func (ec *executionContext) fieldContext_Subscription_courseCheckProgress(ctx co
 	return fc, nil
 }
 
+func (ec *executionContext) _Subscription_runOp(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
+	return graphql.ResolveFieldStream(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Subscription_runOp(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Subscription().RunOp(ctx, fc.Args["token"].(string), fc.Args["confirmPhrase"].(*string))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.LogLine) graphql.Marshaler {
+			return ec.marshalNLogLine2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐLogLine(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Subscription_runOp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Subscription",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_LogLine(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Subscription_runOp_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _User_email(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -9561,6 +9742,49 @@ func (ec *executionContext) _GroupCheck(ctx context.Context, sel ast.SelectionSe
 	return out
 }
 
+var logLineImplementors = []string{"LogLine"}
+
+func (ec *executionContext) _LogLine(ctx context.Context, sel ast.SelectionSet, obj *model.LogLine) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, logLineImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferredFieldSet := graphql.NewFieldSet(nil)
+	deferLabelToView := make(map[string]*graphql.FieldSetView)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LogLine")
+		case "level":
+			out.Values[i] = ec._LogLine_level(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "text":
+			out.Values[i] = ec._LogLine_text(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferLabelToView), math.MaxInt32)))
+
+	ec.ProcessDeferredGroup(graphql.DeferredGroup{
+		Defers:   deferLabelToView,
+		Path:     graphql.GetPath(ctx),
+		FieldSet: deferredFieldSet,
+		Context:  ctx,
+	})
+
+	return out
+}
+
 var mutationImplementors = []string{"Mutation"}
 
 func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet) graphql.Marshaler {
@@ -10665,6 +10889,8 @@ func (ec *executionContext) _Subscription(ctx context.Context, sel ast.Selection
 		return ec._Subscription_assignmentReportProgress(ctx, fields[0])
 	case "courseCheckProgress":
 		return ec._Subscription_courseCheckProgress(ctx, fields[0])
+	case "runOp":
+		return ec._Subscription_runOp(ctx, fields[0])
 	default:
 		panic("unknown field " + strconv.Quote(fields[0].Name))
 	}
@@ -11526,6 +11752,30 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNLogLevel2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐLogLevel(ctx context.Context, v any) (model.LogLevel, error) {
+	var res model.LogLevel
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNLogLevel2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐLogLevel(ctx context.Context, sel ast.SelectionSet, v model.LogLevel) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) marshalNLogLine2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐLogLine(ctx context.Context, sel ast.SelectionSet, v model.LogLine) graphql.Marshaler {
+	return ec._LogLine(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNLogLine2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐLogLine(ctx context.Context, sel ast.SelectionSet, v *model.LogLine) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._LogLine(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNOp2githubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐOp(ctx context.Context, v any) (model.Op, error) {

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -207,6 +207,13 @@ type GroupInput struct {
 	Members []string `json:"members"`
 }
 
+// One line of a running operation's streamed output.
+type LogLine struct {
+	Level LogLevel `json:"level"`
+	// The line text (ANSI stripped).
+	Text string `json:"text"`
+}
+
 type Mutation struct {
 }
 
@@ -457,6 +464,70 @@ func (e *FindingSeverity) UnmarshalJSON(b []byte) error {
 }
 
 func (e FindingSeverity) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+// The severity/kind of one streamed output line.
+type LogLevel string
+
+const (
+	LogLevelInfo     LogLevel = "INFO"
+	LogLevelWarn     LogLevel = "WARN"
+	LogLevelError    LogLevel = "ERROR"
+	LogLevelProgress LogLevel = "PROGRESS"
+	LogLevelResult   LogLevel = "RESULT"
+	LogLevelDone     LogLevel = "DONE"
+)
+
+var AllLogLevel = []LogLevel{
+	LogLevelInfo,
+	LogLevelWarn,
+	LogLevelError,
+	LogLevelProgress,
+	LogLevelResult,
+	LogLevelDone,
+}
+
+func (e LogLevel) IsValid() bool {
+	switch e {
+	case LogLevelInfo, LogLevelWarn, LogLevelError, LogLevelProgress, LogLevelResult, LogLevelDone:
+		return true
+	}
+	return false
+}
+
+func (e LogLevel) String() string {
+	return string(e)
+}
+
+func (e *LogLevel) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = LogLevel(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid LogLevel", str)
+	}
+	return nil
+}
+
+func (e LogLevel) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *LogLevel) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e LogLevel) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil

--- a/web/graph/op.graphqls
+++ b/web/graph/op.graphqls
@@ -57,3 +57,31 @@ extend type Mutation {
   """
   planOp(op: Op!, course: String!, assignment: String!, params: OpParams, onlyFor: [String!]): OpPlan!
 }
+
+"The severity/kind of one streamed output line."
+enum LogLevel {
+  INFO
+  WARN
+  ERROR
+  PROGRESS
+  RESULT
+  DONE
+}
+
+"One line of a running operation's streamed output."
+type LogLine {
+  level: LogLevel!
+  "The line text (ANSI stripped)."
+  text: String!
+}
+
+extend type Subscription {
+  """
+  Run a planned operation against GitLab (from planOp's token) and stream its output
+  line by line, ending with a DONE line. The operation keeps running server-side even
+  if the client disconnects (closing the tab does NOT abort it). A second operation on
+  the same assignment is rejected while one runs. For a destructive op (archive/delete)
+  confirmPhrase must equal the plan's confirmPhrase.
+  """
+  runOp(token: String!, confirmPhrase: String): LogLine!
+}

--- a/web/graph/op.resolvers.go
+++ b/web/graph/op.resolvers.go
@@ -19,3 +19,27 @@ func (r *mutationResolver) PlanOp(ctx context.Context, op model.Op, course strin
 	}
 	return toGraphOpPlan(plan), nil
 }
+
+// RunOp is the resolver for the runOp field.
+func (r *subscriptionResolver) RunOp(ctx context.Context, token string, confirmPhrase *string) (<-chan *model.LogLine, error) {
+	phrase := ""
+	if confirmPhrase != nil {
+		phrase = *confirmPhrase
+	}
+	events, err := r.app.RunOp(ctx, token, phrase)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan *model.LogLine)
+	go func() {
+		defer close(out)
+		for ev := range events {
+			select {
+			case out <- &model.LogLine{Level: model.LogLevel(ev.Level), Text: ev.Text}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}


### PR DESCRIPTION
**Zweiter Schritt von Milestone C: die Apply-Hälfte.** `runOp(token, confirmPhrase)` ist eine Subscription, die einen Plan-Token validiert und die beschriebene mutierende GitLab-Op (setaccess/protect/archive/delete) ausführt — mit **gestreamter Ausgabe** als getypte `LogLine`s (INFO/WARN/ERROR/PROGRESS/RESULT/DONE), endend mit DONE.

## Vorab-Prüfungen (synchroner, sauberer Fehler)
Unbekannter/abgelaufener Token, Token nicht vom Aufrufer, **Config-Drift** (neu auflösen + configHash aus dem Token vergleichen — der Sinn des Tokens), ein **Seeder** (Web kann ihn nicht ausführen), fehlende **confirmPhrase** bei destruktiven Ops (archive/delete), ein **bereits laufender** Op auf dasselbe Assignment, oder **kein hinterlegter GitLab-Token**. Läuft die Op erst, kommen Fehler als ERROR-Zeile.

## Kernpunkte
- **`exclusive.go`**: `opGuard` serialisiert Ops **pro `(owner, course, assignment)`** — **kein globaler** Mutex, damit ein langer Op von Prof A nicht Prof B blockiert. `App.New` verdrahtet ihn.
- **`run_op.go`**: `RunOp` + `executeOp` (Params anwenden, an den gitlab-Client dispatchen) + `opReporter` (klassifiziert den Fortschritt in getypte Zeilen, ANSI entfernt, auf dem Subscription-Kontext). Die Op läuft auf **`context.WithoutCancel(ctx)`** → **Tab schließen bricht sie NICHT ab**, nur das Streaming stoppt.
- **graph**: `LogLevel`/`LogLine` + `runOp`-Subscription, Resolver.
- **Tests**: opGuard-Serialisierung pro Key; RunOp-Guards (bad/wrong-owner Token, Config geändert, Seeder, destruktive confirmPhrase, fehlender Token).

## Verifikation (lokal grün)
`go build`, `go vet` (+ integration), `go test ./...`, `golangci-lint`.

Folgt: **Audit-Log** (`web/db`) und das **GUI** (Plan/Apply-Flow). Milestone D (Scheduling) nutzt denselben Token → `scheduleOp(token, runAt)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)