### PR TITLE
fix(gitlab): skip missing repos instead of aborting setaccess/protect/archive

### DIFF
--- a/gitlab/archive.go
+++ b/gitlab/archive.go
@@ -41,7 +41,7 @@ func (c *Client) archivePerStudent(assignmentCfg *config.AssignmentConfig, unarc
 		)
 		if err != nil {
 			c.rep.Printf("cannot archive project %s failed with %s", projectname, err)
-			return
+			continue
 		}
 		if err := c.archive(assignmentCfg, project, true, unarchive); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot archive project")
@@ -63,7 +63,7 @@ func (c *Client) archivePerGroup(assignmentCfg *config.AssignmentConfig, unarchi
 		)
 		if err != nil {
 			c.rep.Printf("cannot archive project %s failed with %s", projectname, err)
-			return
+			continue
 		}
 		if err := c.archive(assignmentCfg, project, true, unarchive); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot archive project")

--- a/gitlab/protect.go
+++ b/gitlab/protect.go
@@ -227,7 +227,7 @@ func (c *Client) protectToBranchPerStudent(assignmentCfg *config.AssignmentConfi
 		)
 		if err != nil {
 			c.rep.Printf("cannot protect branch for project %s failed with %s", projectname, err)
-			return
+			continue
 		}
 		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, 1); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot protect the branch")
@@ -249,7 +249,7 @@ func (c *Client) protectToBranchPerGroup(assignmentCfg *config.AssignmentConfig)
 		)
 		if err != nil {
 			c.rep.Printf("cannot protect branch for project %s failed with %s", projectname, err)
-			return
+			continue
 		}
 		if err := c.protectBranchForMemberCount(assignmentCfg, project, true, len(grp.Members)); err != nil {
 			log.Error().Err(err).Str("group", assignmentCfg.Course).Msg("cannot protect the branch")

--- a/gitlab/setaccess.go
+++ b/gitlab/setaccess.go
@@ -97,7 +97,7 @@ func (c *Client) setaccessPerStudent(assignmentCfg *config.AssignmentConfig) {
 		)
 		if err != nil {
 			c.rep.Printf("cannot set access for project %s failed with %s", projectname, err)
-			return
+			continue
 		}
 		c.setaccess(assignmentCfg, project, []*config.Student{student})
 	}
@@ -117,7 +117,7 @@ func (c *Client) setaccessPerGroup(assignmentCfg *config.AssignmentConfig) {
 		)
 		if err != nil {
 			c.rep.Printf("cannot set access for project %s failed with %s", projectname, err)
-			return
+			continue
 		}
 		c.setaccess(assignmentCfg, project, grp.Members)
 	}


### PR DESCRIPTION
**Echter Bug, den du gerade live getroffen hast.** Beim setaccess auf mpd/blatt01 (42 Repos) kam:
```
cannot set access for project …/mpd-blatt01-a.ciftci failed with 404 Not Found
setaccess completed
```
`setaccessPerStudent`/`PerGroup` (und die protect/archive-Pendants) machten bei einem `GetProject`-Fehler ein **`return` aus der ganzen Schleife** — ein einzelnes **nicht existierendes Repo** (z. B. ein Studi, dessen Repo nie generiert wurde → 404) **bricht die Op für alle restlichen Repos ab**. Da das Roster alphabetisch ist, hat ein früher Treffer (`a.ciftci`) fast alle übersprungen — trotz „completed". **Es wurden also deutlich weniger als 41 Repos wirklich gesetzt.**

Fix: das per-Repo-`return` → **`continue`** (fehlendes Repo loggen und weitermachen). Korrigiert **CLI und Web** gleichermaßen; im Web zeigt das Live-Log dann **jedes** Repo statt am ersten Loch zu stoppen.

- betrifft `setaccess`, `protect`, `archive` (je perStudent + perGroup).
- `delete` ist nicht betroffen (dort ist jedes Repo unabhängig).

## Verifikation (lokal grün)
`go build`, `go vet ./gitlab/...`, `go test ./gitlab/...`, `golangci-lint`.

**Empfehlung:** nach dem Merge setaccess nochmal laufen lassen — jetzt werden alle existierenden Repos gesetzt und nur die fehlenden (404) übersprungen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)