### PR TITLE
feat(web): expose extendsOptions for the assignment inheritance dropdown

### DIFF
--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -3,12 +3,27 @@ package app
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/obcode/glabs/v3/config"
 )
+
+// siblingNames returns the names of all assignments in the course except the
+// given one, sorted. These are the valid targets for `extends` (which is
+// course-internal), i.e. the choices for the editor's inheritance dropdown.
+func siblingNames(src *config.CourseSource, self string) []string {
+	names := make([]string, 0, len(src.Assignments))
+	for name := range src.Assignments {
+		if name != self {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
 
 // FieldValue is one field's own (source) value, stringified and keyed by the
 // same key as FieldMeta so the GUI can pre-fill the schema-driven form.
@@ -174,6 +189,11 @@ type AssignmentView struct {
 	Name     string
 	Extends  string
 	Abstract bool
+	// ExtendsOptions lists the names of the sibling assignments this one may
+	// inherit from (all assignments in the same course except this one, sorted).
+	// `extends` is course-internal, so these are exactly the valid choices for
+	// the editor's dropdown.
+	ExtendsOptions []string
 	// Own holds the assignment's own (source) field values, keyed by
 	// FieldMeta.key, for pre-filling the editor form.
 	Own []FieldValue
@@ -202,11 +222,12 @@ func (a *App) Assignment(ctx context.Context, course, name string) (*AssignmentV
 	}
 
 	view := &AssignmentView{
-		Course:   course,
-		Name:     name,
-		Extends:  src.Extends,
-		Abstract: src.Abstract,
-		Own:      assignmentOwn(src),
+		Course:         course,
+		Name:           name,
+		Extends:        src.Extends,
+		Abstract:       src.Abstract,
+		ExtendsOptions: siblingNames(stored.Source, name),
+		Own:            assignmentOwn(src),
 	}
 
 	// Resolve from the stored bytes so the preview matches the CLI exactly

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -90,6 +91,10 @@ func TestAssignment_resolvesWithInheritance(t *testing.T) {
 	}
 	if v.Extends != "base" {
 		t.Errorf("extends = %q, want base", v.Extends)
+	}
+	// ExtendsOptions offers the sibling assignments (base), never blatt1 itself.
+	if !slices.Equal(v.ExtendsOptions, []string{"base"}) {
+		t.Errorf("extendsOptions = %v, want [base]", v.ExtendsOptions)
 	}
 	if v.ResolveError != "" {
 		t.Errorf("unexpected resolveError: %s", v.ResolveError)

--- a/web/graph/assignment_mapping.go
+++ b/web/graph/assignment_mapping.go
@@ -81,13 +81,18 @@ func toGraphAssignmentView(view *app.AssignmentView) *model.AssignmentView {
 	for _, v := range view.Own {
 		own = append(own, &model.FieldValue{Key: v.Key, Value: v.Value})
 	}
+	options := view.ExtendsOptions
+	if options == nil {
+		options = []string{}
+	}
 	return &model.AssignmentView{
-		Course:       view.Course,
-		Name:         view.Name,
-		Extends:      emptyToNil(view.Extends),
-		Abstract:     view.Abstract,
-		Own:          own,
-		Resolved:     view.Resolved,
-		ResolveError: emptyToNil(view.ResolveError),
+		Course:         view.Course,
+		Name:           view.Name,
+		Extends:        emptyToNil(view.Extends),
+		ExtendsOptions: options,
+		Abstract:       view.Abstract,
+		Own:            own,
+		Resolved:       view.Resolved,
+		ResolveError:   emptyToNil(view.ResolveError),
 	}
 }

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -59,6 +59,8 @@ type AssignmentView {
   name: String!
   "The assignment this one inherits from, if any (`extends`)."
   extends: String
+  "The names of the sibling assignments this one may inherit from — all assignments in the same course except this one (`extends` is course-internal). The valid choices for the editor's inheritance dropdown."
+  extendsOptions: [String!]!
   "Whether this is an abstract base (a template for `extends`)."
   abstract: Boolean!
   "The assignment's own (source) field values, keyed by FieldMeta.key, for pre-filling the editor form."

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -56,13 +56,14 @@ type ComplexityRoot struct {
 	}
 
 	AssignmentView struct {
-		Abstract     func(childComplexity int) int
-		Course       func(childComplexity int) int
-		Extends      func(childComplexity int) int
-		Name         func(childComplexity int) int
-		Own          func(childComplexity int) int
-		ResolveError func(childComplexity int) int
-		Resolved     func(childComplexity int) int
+		Abstract       func(childComplexity int) int
+		Course         func(childComplexity int) int
+		Extends        func(childComplexity int) int
+		ExtendsOptions func(childComplexity int) int
+		Name           func(childComplexity int) int
+		Own            func(childComplexity int) int
+		ResolveError   func(childComplexity int) int
+		Resolved       func(childComplexity int) int
 	}
 
 	CheckProgress struct {
@@ -441,6 +442,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.AssignmentView.Extends(childComplexity), true
+	case "AssignmentView.extendsOptions":
+		if e.ComplexityRoot.AssignmentView.ExtendsOptions == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AssignmentView.ExtendsOptions(childComplexity), true
 	case "AssignmentView.name":
 		if e.ComplexityRoot.AssignmentView.Name == nil {
 			break
@@ -1605,6 +1612,8 @@ type AssignmentView {
   name: String!
   "The assignment this one inherits from, if any (` + "`" + `extends` + "`" + `)."
   extends: String
+  "The names of the sibling assignments this one may inherit from — all assignments in the same course except this one (` + "`" + `extends` + "`" + ` is course-internal). The valid choices for the editor's inheritance dropdown."
+  extendsOptions: [String!]!
   "Whether this is an abstract base (a template for ` + "`" + `extends` + "`" + `)."
   abstract: Boolean!
   "The assignment's own (source) field values, keyed by FieldMeta.key, for pre-filling the editor form."
@@ -2151,6 +2160,8 @@ func (ec *executionContext) childFields_AssignmentView(ctx context.Context, fiel
 		return ec.fieldContext_AssignmentView_name(ctx, field)
 	case "extends":
 		return ec.fieldContext_AssignmentView_extends(ctx, field)
+	case "extendsOptions":
+		return ec.fieldContext_AssignmentView_extendsOptions(ctx, field)
 	case "abstract":
 		return ec.fieldContext_AssignmentView_abstract(ctx, field)
 	case "own":
@@ -3576,6 +3587,29 @@ func (ec *executionContext) _AssignmentView_extends(ctx context.Context, field g
 	)
 }
 func (ec *executionContext) fieldContext_AssignmentView_extends(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("AssignmentView", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _AssignmentView_extendsOptions(ctx context.Context, field graphql.CollectedField, obj *model.AssignmentView) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_AssignmentView_extendsOptions(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ExtendsOptions, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []string) graphql.Marshaler {
+			return ec.marshalNString2ᚕstringᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_AssignmentView_extendsOptions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("AssignmentView", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
@@ -8962,6 +8996,11 @@ func (ec *executionContext) _AssignmentView(ctx context.Context, sel ast.Selecti
 		case "extends":
 			out.Values[i] = ec._AssignmentView_extends(ctx, field, obj)
 			if out.Values[i] == graphql.RequiredNull {
+				out.Invalids++
+			}
+		case "extendsOptions":
+			out.Values[i] = ec._AssignmentView_extendsOptions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
 		case "abstract":

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -48,6 +48,8 @@ type AssignmentView struct {
 	Name   string `json:"name"`
 	// The assignment this one inherits from, if any (`extends`).
 	Extends *string `json:"extends,omitempty"`
+	// The names of the sibling assignments this one may inherit from — all assignments in the same course except this one (`extends` is course-internal). The valid choices for the editor's inheritance dropdown.
+	ExtendsOptions []string `json:"extendsOptions"`
 	// Whether this is an abstract base (a template for `extends`).
 	Abstract bool `json:"abstract"`
 	// The assignment's own (source) field values, keyed by FieldMeta.key, for pre-filling the editor form.


### PR DESCRIPTION
## Was

Block I / F3 (Backend-Teil): das `extends`-Feld im Assignment-Editor soll ein **Dropdown** möglicher Elternteile werden statt eines Freitextfelds.

`extends` ist rein kurs-intern (`config/resolve.go` verlangt, dass das Ziel ein anderes Assignment desselben Kurses ist; `config/lint.go` validiert das). Die gültigen Optionen sind also genau die Geschwister-Assignments.

`AssignmentView` trägt jetzt `extendsOptions: [String!]!` — alle Assignment-Namen des Kurses außer dem gerade bearbeiteten, sortiert.

## Änderungen

- `web/app/assignments.go`: `AssignmentView.ExtendsOptions` + `siblingNames()` Helper, befüllt in `Assignment()`.
- `web/graph/assignments.graphqls`: neues Feld `extendsOptions: [String!]!` auf `AssignmentView` (+ Regenerate).
- `web/graph/assignment_mapping.go`: Mapping (nil → `[]`).
- Test: `TestAssignment_resolvesWithInheritance` prüft `extendsOptions == [base]`.

Rein additiv am Schema — nichts Bestehendes bricht. Der GUI-Teil (Dropdown-Rendering) folgt als separater `glabs.gui`-PR, sobald das hier gemergt und das Schema gepullt ist.

## Verifikation

`go build ./... && go vet ./... && go vet -tags=integration ./... && go test ./... && golangci-lint run` — alle grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)