### PR TITLE
feat(web): copyAssignment — duplicate an assignment under a new name

### DIFF
--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -651,6 +651,48 @@ func (a *App) SetAssignment(ctx context.Context, course, name string, draft map[
 	return a.Assignment(ctx, course, name)
 }
 
+// CopyAssignment duplicates one of the caller's assignments under a new name.
+// Only the name has to be unique — the copy is otherwise identical to the
+// source, including its `extends`. It validates the new name (it becomes a
+// GitLab path segment), rejects a name that already exists, then persists —
+// re-marshalling the whole course YAML. The persisted round-trip
+// (encode → store → decode) makes the copy fully independent of the source.
+func (a *App) CopyAssignment(ctx context.Context, course, from, newName string) (*AssignmentView, error) {
+	stored, err := a.Course(ctx, course)
+	if err != nil {
+		return nil, err
+	}
+	src, ok := stored.Source.Assignments[from]
+	if !ok || src == nil {
+		return nil, fmt.Errorf("course %q has no assignment %q to copy", course, from)
+	}
+	newName = strings.TrimSpace(newName)
+	if !nameRe.MatchString(newName) {
+		return nil, fmt.Errorf("invalid assignment name %q: use only letters, digits, '.', '-' and '_'", newName)
+	}
+	if _, exists := stored.Source.Assignments[newName]; exists {
+		return nil, fmt.Errorf("an assignment named %q already exists in course %q", newName, course)
+	}
+
+	// Copy the source struct under the new key. Nested block pointers are shared
+	// in memory but only ever read here; EncodeCourse serialises them into
+	// independent bytes and the reload below decodes fresh structs.
+	cp := *src
+	newCourse := courseWithDraft(stored.Source, newName, &cp)
+
+	raw, err := config.EncodeCourse(newCourse)
+	if err != nil {
+		return nil, err
+	}
+	stored.Source = newCourse
+	stored.RawYAML = raw
+	stored.UpdatedAt = time.Now()
+	if err := a.db.SaveCourse(ctx, stored); err != nil {
+		return nil, err
+	}
+	return a.Assignment(ctx, course, newName)
+}
+
 // DeleteAssignment removes one assignment from one of the caller's courses and
 // re-marshals the course YAML. It returns false when there was no such
 // assignment (and does not touch the course).

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -483,6 +483,49 @@ func TestDeleteAssignment(t *testing.T) {
 	}
 }
 
+func TestCopyAssignment(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	// Copy blatt1 → blatt2: identical content (extends, description), new name.
+	view, err := a.CopyAssignment(ctx, "tc", "blatt1", "blatt2")
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if view.Name != "blatt2" {
+		t.Errorf("copy name = %q, want blatt2", view.Name)
+	}
+	if view.Extends != "base" {
+		t.Errorf("copy extends = %q, want base (carried over)", view.Extends)
+	}
+	if ownMap(view.Own)["description"] != "First sheet" {
+		t.Errorf("copy description = %q, want 'First sheet'", ownMap(view.Own)["description"])
+	}
+	// Both the source and the copy exist; the source is untouched.
+	if _, ok := fs.saved.Source.Assignments["blatt1"]; !ok {
+		t.Error("source blatt1 should still exist after copy")
+	}
+	if _, ok := fs.saved.Source.Assignments["blatt2"]; !ok {
+		t.Error("copy blatt2 should exist in the stored source")
+	}
+
+	// Copying onto an existing name is rejected.
+	if _, err := a.CopyAssignment(ctx, "tc", "blatt1", "base"); err == nil {
+		t.Error("copying onto an existing name should fail")
+	}
+	// Copying a non-existent source is rejected.
+	if _, err := a.CopyAssignment(ctx, "tc", "nope", "blatt3"); err == nil {
+		t.Error("copying a missing source should fail")
+	}
+	// An invalid target name is rejected.
+	if _, err := a.CopyAssignment(ctx, "tc", "blatt1", "bad name"); err == nil {
+		t.Error("an invalid target name should fail")
+	}
+}
+
 func TestSetAssignment_issuesBlock(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -136,6 +136,8 @@ extend type Mutation {
   setAssignment(course: String!, name: String!, draft: [FieldValueInput!]!): AssignmentView!
   "Import a single assignment into one of the caller's courses from a YAML snippet keyed by the assignment name (as it appears in a course file), upserting it: validate against the real resolver, then persist. Rejects a concrete assignment that does not resolve."
   importAssignmentYAML(course: String!, yaml: String!): AssignmentView!
+  "Copy one of the caller's assignments to a new name within the same course. Only the name must be unique; the copy is otherwise identical (including `extends`). Rejects a name that already exists or is not path-safe."
+  copyAssignment(course: String!, from: String!, newName: String!): AssignmentView!
   "Delete one assignment from one of the caller's courses. Returns false if there was no such assignment."
   deleteAssignment(course: String!, name: String!): Boolean!
 }

--- a/web/graph/assignments.resolvers.go
+++ b/web/graph/assignments.resolvers.go
@@ -32,6 +32,15 @@ func (r *mutationResolver) ImportAssignmentYaml(ctx context.Context, course stri
 	return toGraphAssignmentView(view), nil
 }
 
+// CopyAssignment is the resolver for the copyAssignment field.
+func (r *mutationResolver) CopyAssignment(ctx context.Context, course string, from string, newName string) (*model.AssignmentView, error) {
+	view, err := r.app.CopyAssignment(ctx, course, from, newName)
+	if err != nil {
+		return nil, err
+	}
+	return toGraphAssignmentView(view), nil
+}
+
 // DeleteAssignment is the resolver for the deleteAssignment field.
 func (r *mutationResolver) DeleteAssignment(ctx context.Context, course string, name string) (bool, error) {
 	return r.app.DeleteAssignment(ctx, course, name)

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -169,6 +169,7 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
+		CopyAssignment       func(childComplexity int, course string, from string, newName string) int
 		CreateCourse         func(childComplexity int, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) int
 		DeleteAssignment     func(childComplexity int, course string, name string) int
 		DeleteCourse         func(childComplexity int, name string) int
@@ -309,6 +310,7 @@ type MutationResolver interface {
 	DeleteCourse(ctx context.Context, name string) (bool, error)
 	SetAssignment(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.AssignmentView, error)
 	ImportAssignmentYaml(ctx context.Context, course string, yaml string) (*model.AssignmentView, error)
+	CopyAssignment(ctx context.Context, course string, from string, newName string) (*model.AssignmentView, error)
 	DeleteAssignment(ctx context.Context, course string, name string) (bool, error)
 	SetGitlabToken(ctx context.Context, token string) (*model.GitLabTokenStatus, error)
 	RemoveGitlabToken(ctx context.Context) (*model.GitLabTokenStatus, error)
@@ -830,6 +832,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.LogLine.Text(childComplexity), true
 
+	case "Mutation.copyAssignment":
+		if e.ComplexityRoot.Mutation.CopyAssignment == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_copyAssignment_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.CopyAssignment(childComplexity, args["course"].(string), args["from"].(string), args["newName"].(string)), true
 	case "Mutation.createCourse":
 		if e.ComplexityRoot.Mutation.CreateCourse == nil {
 			break
@@ -1689,6 +1702,8 @@ extend type Mutation {
   setAssignment(course: String!, name: String!, draft: [FieldValueInput!]!): AssignmentView!
   "Import a single assignment into one of the caller's courses from a YAML snippet keyed by the assignment name (as it appears in a course file), upserting it: validate against the real resolver, then persist. Rejects a concrete assignment that does not resolve."
   importAssignmentYAML(course: String!, yaml: String!): AssignmentView!
+  "Copy one of the caller's assignments to a new name within the same course. Only the name must be unique; the copy is otherwise identical (including ` + "`" + `extends` + "`" + `). Rejects a name that already exists or is not path-safe."
+  copyAssignment(course: String!, from: String!, newName: String!): AssignmentView!
   "Delete one assignment from one of the caller's courses. Returns false if there was no such assignment."
   deleteAssignment(course: String!, name: String!): Boolean!
 }
@@ -2667,6 +2682,36 @@ func (ec *executionContext) childFields___Type(ctx context.Context, field graphq
 // endregion ************************** internal!.gotpl ***************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Mutation_copyAssignment_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "course",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["course"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "from",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["from"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "newName",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["newName"] = arg2
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_createCourse_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
@@ -5443,6 +5488,50 @@ func (ec *executionContext) fieldContext_Mutation_importAssignmentYAML(ctx conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_importAssignmentYAML_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_copyAssignment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_copyAssignment(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().CopyAssignment(ctx, fc.Args["course"].(string), fc.Args["from"].(string), fc.Args["newName"].(string))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.AssignmentView) graphql.Marshaler {
+			return ec.marshalNAssignmentView2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentView(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_copyAssignment(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_AssignmentView(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_copyAssignment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9896,6 +9985,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "importAssignmentYAML":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_importAssignmentYAML(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "copyAssignment":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_copyAssignment(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++


### PR DESCRIPTION
## Was

Block I / F2 (Backend): ein Assignment kopieren. Nur der Name muss eindeutig sein — die Kopie ist ansonsten identisch (inkl. `extends`).

## Änderungen

- `web/app/assignments.go`: `CopyAssignment(course, from, newName)` — dupliziert die Quell-`AssignmentSource` unter neuem Key, re-marshalled die Kurs-YAML. Der Persistenz-Round-Trip (encode → store → decode) macht die Kopie unabhängig. Lehnt existierenden/nicht-pfadsicheren Namen und fehlende Quelle ab.
- `web/graph/assignments.graphqls`: neue Mutation `copyAssignment(course, from, newName): AssignmentView!` (+ Regenerate, ungenutzten `fmt`-Import im Resolver entfernt).
- Test `TestCopyAssignment`: Inhalt übernommen, Quelle unangetastet, Fehlerfälle (existierender Name / fehlende Quelle / ungültiger Name).

GUI-Teil (Kopieren-Button) folgt als separater `glabs.gui`-PR.

## Verifikation

`go build ./... && go vet ./... && go vet -tags=integration ./... && go test ./... && golangci-lint run` — alle grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)