### PR TITLE
feat(web): rename a course or an assignment

### DIFF
--- a/web/app/assignments.go
+++ b/web/app/assignments.go
@@ -693,6 +693,56 @@ func (a *App) CopyAssignment(ctx context.Context, course, from, newName string) 
 	return a.Assignment(ctx, course, newName)
 }
 
+// RenameAssignment renames one of the caller's assignments within a course and
+// re-marshals the course YAML. Any sibling that inherits from the old name via
+// `extends` is repointed to the new name (so, unlike editing plain YAML by hand,
+// no inheritance chain silently breaks). It fails if the new name is not
+// path-safe or already exists.
+func (a *App) RenameAssignment(ctx context.Context, course, oldName, newName string) (*AssignmentView, error) {
+	stored, err := a.Course(ctx, course)
+	if err != nil {
+		return nil, err
+	}
+	src, ok := stored.Source.Assignments[oldName]
+	if !ok || src == nil {
+		return nil, fmt.Errorf("course %q has no assignment %q to rename", course, oldName)
+	}
+	newName = strings.TrimSpace(newName)
+	if !nameRe.MatchString(newName) {
+		return nil, fmt.Errorf("invalid assignment name %q: use only letters, digits, '.', '-' and '_'", newName)
+	}
+	if newName == oldName {
+		return a.Assignment(ctx, course, oldName)
+	}
+	if _, exists := stored.Source.Assignments[newName]; exists {
+		return nil, fmt.Errorf("an assignment named %q already exists in course %q", newName, course)
+	}
+
+	newSource := *stored.Source
+	assignments := make(map[string]*config.AssignmentSource, len(stored.Source.Assignments))
+	for k, v := range stored.Source.Assignments {
+		if k == oldName {
+			continue
+		}
+		// Repoint any sibling that extends the old name onto the new one. Copy
+		// the struct first so the stored original is never mutated.
+		if v != nil && v.Extends == oldName {
+			cp := *v
+			cp.Extends = newName
+			v = &cp
+		}
+		assignments[k] = v
+	}
+	// The renamed assignment keeps its own `extends` (it points at its parent).
+	assignments[newName] = src
+	newSource.Assignments = assignments
+
+	if _, err := a.saveCourseSource(ctx, stored, &newSource); err != nil {
+		return nil, err
+	}
+	return a.Assignment(ctx, course, newName)
+}
+
 // DeleteAssignment removes one assignment from one of the caller's courses and
 // re-marshals the course YAML. It returns false when there was no such
 // assignment (and does not touch the course).

--- a/web/app/assignments_test.go
+++ b/web/app/assignments_test.go
@@ -526,6 +526,49 @@ func TestCopyAssignment(t *testing.T) {
 	}
 }
 
+func TestRenameAssignment(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/tc"] = storedCourse(t, owner, tcCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+	ctx := ctxAs(owner)
+
+	// Rename the base that blatt1 extends: the sibling's `extends` must follow.
+	view, err := a.RenameAssignment(ctx, "tc", "base", "foundation")
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if view.Name != "foundation" {
+		t.Errorf("renamed name = %q, want foundation", view.Name)
+	}
+	as := fs.saved.Source.Assignments
+	if _, gone := as["base"]; gone {
+		t.Error("old name base should be gone")
+	}
+	if _, ok := as["foundation"]; !ok {
+		t.Error("new name foundation should exist")
+	}
+	if as["blatt1"].Extends != "foundation" {
+		t.Errorf("blatt1.extends = %q, want foundation (repointed)", as["blatt1"].Extends)
+	}
+	if !bytes.Contains(fs.saved.RawYAML, []byte("foundation")) {
+		t.Errorf("rawYAML not re-marshalled with the new name:\n%s", fs.saved.RawYAML)
+	}
+
+	// Renaming onto an existing name is rejected.
+	if _, err := a.RenameAssignment(ctx, "tc", "blatt1", "foundation"); err == nil {
+		t.Error("renaming onto an existing name should fail")
+	}
+	// Renaming a missing assignment is rejected.
+	if _, err := a.RenameAssignment(ctx, "tc", "nope", "x"); err == nil {
+		t.Error("renaming a missing assignment should fail")
+	}
+	// An invalid target name is rejected.
+	if _, err := a.RenameAssignment(ctx, "tc", "blatt1", "bad name"); err == nil {
+		t.Error("an invalid target name should fail")
+	}
+}
+
 func TestSetAssignment_issuesBlock(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/app/courses.go
+++ b/web/app/courses.go
@@ -239,6 +239,61 @@ func (a *App) SetCourseGroups(ctx context.Context, name string, groups map[strin
 	return a.saveCourseSource(ctx, stored, &newSource)
 }
 
+// RenameCourse renames one of the caller's own courses. The course name is the
+// YAML file's top-level key, so the raw bytes are re-encoded under the new name.
+// It fails if the new name is not path-safe or the caller already has a course
+// by that name. Assignments, students and groups are carried over unchanged.
+func (a *App) RenameCourse(ctx context.Context, oldName, newName string) (*db.StoredCourse, error) {
+	o, err := owner(ctx)
+	if err != nil {
+		return nil, err
+	}
+	newName = strings.TrimSpace(newName)
+	if !nameRe.MatchString(newName) {
+		return nil, fmt.Errorf("invalid course name %q: use only letters, digits, '.', '-' and '_'", newName)
+	}
+
+	stored, err := a.db.CourseOf(ctx, o, oldName)
+	if err != nil {
+		return nil, err
+	}
+	if newName == oldName {
+		return stored, nil
+	}
+
+	existing, err := a.db.CourseOf(ctx, o, newName)
+	if err != nil && !errors.Is(err, db.ErrCourseNotFound) {
+		return nil, err
+	}
+	if existing != nil {
+		return nil, fmt.Errorf("a course named %q already exists", newName)
+	}
+
+	newSource := *stored.Source
+	newSource.Name = newName
+	raw, err := config.EncodeCourse(&newSource)
+	if err != nil {
+		return nil, err
+	}
+	renamed := &db.StoredCourse{
+		Owner:      o,
+		Name:       newName,
+		Source:     &newSource,
+		RawYAML:    raw,
+		ImportedAt: stored.ImportedAt,
+		UpdatedAt:  time.Now(),
+	}
+	// Save the new-named course first, then drop the old one, so a failure never
+	// loses the course (at worst it leaves a duplicate to clean up).
+	if err := a.db.SaveCourse(ctx, renamed); err != nil {
+		return nil, err
+	}
+	if err := a.db.DeleteCourse(ctx, o, oldName); err != nil {
+		return nil, err
+	}
+	return renamed, nil
+}
+
 // DeleteCourse removes one of the caller's own courses.
 func (a *App) DeleteCourse(ctx context.Context, name string) error {
 	o, err := owner(ctx)

--- a/web/app/courses_test.go
+++ b/web/app/courses_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -114,6 +116,47 @@ func TestCourseOperationsScopeToThePrincipal(t *testing.T) {
 	}
 	if fs.saved == nil || fs.saved.Owner != "prof@hm.edu" {
 		t.Errorf("saved course owner = %v, want prof@hm.edu", fs.saved)
+	}
+}
+
+func TestRenameCourse(t *testing.T) {
+	fs := newFakeStore()
+	a := &App{db: fs}
+	ctx := ctxAs("prof@hm.edu")
+
+	if _, err := a.ImportCourseYAML(ctx, "tc:\n  coursepath: tc/s\n"); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	renamed, err := a.RenameCourse(ctx, "tc", "mpd")
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if renamed.Name != "mpd" || renamed.Source.Name != "mpd" {
+		t.Errorf("renamed name = %q/%q, want mpd", renamed.Name, renamed.Source.Name)
+	}
+	// The YAML top-level key (the course name) must follow.
+	if !bytes.Contains(renamed.RawYAML, []byte("mpd:")) {
+		t.Errorf("rawYAML not re-encoded under the new name:\n%s", renamed.RawYAML)
+	}
+	// The old name is gone, the new one resolves.
+	if _, err := a.Course(ctx, "tc"); !errors.Is(err, db.ErrCourseNotFound) {
+		t.Errorf("old course tc still present, err = %v", err)
+	}
+	if _, err := a.Course(ctx, "mpd"); err != nil {
+		t.Errorf("new course mpd not found: %v", err)
+	}
+
+	// Renaming onto an existing course name is rejected.
+	if _, err := a.ImportCourseYAML(ctx, "vss:\n  coursepath: vss/s\n"); err != nil {
+		t.Fatalf("import vss: %v", err)
+	}
+	if _, err := a.RenameCourse(ctx, "mpd", "vss"); err == nil {
+		t.Error("renaming onto an existing course name should fail")
+	}
+	// An invalid target name is rejected.
+	if _, err := a.RenameCourse(ctx, "mpd", "bad name"); err == nil {
+		t.Error("an invalid course name should fail")
 	}
 }
 

--- a/web/graph/assignments.graphqls
+++ b/web/graph/assignments.graphqls
@@ -138,6 +138,8 @@ extend type Mutation {
   importAssignmentYAML(course: String!, yaml: String!): AssignmentView!
   "Copy one of the caller's assignments to a new name within the same course. Only the name must be unique; the copy is otherwise identical (including `extends`). Rejects a name that already exists or is not path-safe."
   copyAssignment(course: String!, from: String!, newName: String!): AssignmentView!
+  "Rename one of the caller's assignments within a course. Any sibling that inherits from the old name via `extends` is repointed to the new name. Rejects a name that already exists or is not path-safe."
+  renameAssignment(course: String!, oldName: String!, newName: String!): AssignmentView!
   "Delete one assignment from one of the caller's courses. Returns false if there was no such assignment."
   deleteAssignment(course: String!, name: String!): Boolean!
 }

--- a/web/graph/assignments.resolvers.go
+++ b/web/graph/assignments.resolvers.go
@@ -41,6 +41,15 @@ func (r *mutationResolver) CopyAssignment(ctx context.Context, course string, fr
 	return toGraphAssignmentView(view), nil
 }
 
+// RenameAssignment is the resolver for the renameAssignment field.
+func (r *mutationResolver) RenameAssignment(ctx context.Context, course string, oldName string, newName string) (*model.AssignmentView, error) {
+	view, err := r.app.RenameAssignment(ctx, course, oldName, newName)
+	if err != nil {
+		return nil, err
+	}
+	return toGraphAssignmentView(view), nil
+}
+
 // DeleteAssignment is the resolver for the deleteAssignment field.
 func (r *mutationResolver) DeleteAssignment(ctx context.Context, course string, name string) (bool, error) {
 	return r.app.DeleteAssignment(ctx, course, name)

--- a/web/graph/courses.graphqls
+++ b/web/graph/courses.graphqls
@@ -87,6 +87,8 @@ type Mutation {
   setCourseStudents(name: String!, students: [String!]!): Course!
   "Replace the course-level groups of one of the caller's courses. The GUI merges additively before calling this."
   setCourseGroups(name: String!, groups: [GroupInput!]!): Course!
+  "Rename one of the caller's courses. The course name is the YAML file's top-level key, so this re-encodes the raw bytes. Rejects a new name that already exists or is not path-safe."
+  renameCourse(oldName: String!, newName: String!): Course!
   "Delete one of the current user's courses."
   deleteCourse(name: String!): Boolean!
 }

--- a/web/graph/courses.resolvers.go
+++ b/web/graph/courses.resolvers.go
@@ -65,6 +65,15 @@ func (r *mutationResolver) SetCourseGroups(ctx context.Context, name string, gro
 	return toGraphCourse(stored), nil
 }
 
+// RenameCourse is the resolver for the renameCourse field.
+func (r *mutationResolver) RenameCourse(ctx context.Context, oldName string, newName string) (*model.Course, error) {
+	stored, err := r.app.RenameCourse(ctx, oldName, newName)
+	if err != nil {
+		return nil, err
+	}
+	return toGraphCourse(stored), nil
+}
+
 // DeleteCourse is the resolver for the deleteCourse field.
 func (r *mutationResolver) DeleteCourse(ctx context.Context, name string) (bool, error) {
 	if err := r.app.DeleteCourse(ctx, name); err != nil {

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -177,6 +177,8 @@ type ComplexityRoot struct {
 		ImportCourseYaml     func(childComplexity int, yaml string) int
 		PlanOp               func(childComplexity int, op model.Op, course string, assignment string, params *model.OpParams, onlyFor []string) int
 		RemoveGitlabToken    func(childComplexity int) int
+		RenameAssignment     func(childComplexity int, course string, oldName string, newName string) int
+		RenameCourse         func(childComplexity int, oldName string, newName string) int
 		SetAssignment        func(childComplexity int, course string, name string, draft []*model.FieldValueInput) int
 		SetCourse            func(childComplexity int, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) int
 		SetCourseGroups      func(childComplexity int, name string, groups []*model.GroupInput) int
@@ -307,10 +309,12 @@ type MutationResolver interface {
 	SetCourse(ctx context.Context, name string, coursePath string, semesterPath string, useCoursenameAsPrefix bool, useEmailDomainAsSuffix bool) (*model.Course, error)
 	SetCourseStudents(ctx context.Context, name string, students []string) (*model.Course, error)
 	SetCourseGroups(ctx context.Context, name string, groups []*model.GroupInput) (*model.Course, error)
+	RenameCourse(ctx context.Context, oldName string, newName string) (*model.Course, error)
 	DeleteCourse(ctx context.Context, name string) (bool, error)
 	SetAssignment(ctx context.Context, course string, name string, draft []*model.FieldValueInput) (*model.AssignmentView, error)
 	ImportAssignmentYaml(ctx context.Context, course string, yaml string) (*model.AssignmentView, error)
 	CopyAssignment(ctx context.Context, course string, from string, newName string) (*model.AssignmentView, error)
+	RenameAssignment(ctx context.Context, course string, oldName string, newName string) (*model.AssignmentView, error)
 	DeleteAssignment(ctx context.Context, course string, name string) (bool, error)
 	SetGitlabToken(ctx context.Context, token string) (*model.GitLabTokenStatus, error)
 	RemoveGitlabToken(ctx context.Context) (*model.GitLabTokenStatus, error)
@@ -915,6 +919,28 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.RemoveGitlabToken(childComplexity), true
+	case "Mutation.renameAssignment":
+		if e.ComplexityRoot.Mutation.RenameAssignment == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_renameAssignment_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.RenameAssignment(childComplexity, args["course"].(string), args["oldName"].(string), args["newName"].(string)), true
+	case "Mutation.renameCourse":
+		if e.ComplexityRoot.Mutation.RenameCourse == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_renameCourse_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.RenameCourse(childComplexity, args["oldName"].(string), args["newName"].(string)), true
 	case "Mutation.setAssignment":
 		if e.ComplexityRoot.Mutation.SetAssignment == nil {
 			break
@@ -1704,6 +1730,8 @@ extend type Mutation {
   importAssignmentYAML(course: String!, yaml: String!): AssignmentView!
   "Copy one of the caller's assignments to a new name within the same course. Only the name must be unique; the copy is otherwise identical (including ` + "`" + `extends` + "`" + `). Rejects a name that already exists or is not path-safe."
   copyAssignment(course: String!, from: String!, newName: String!): AssignmentView!
+  "Rename one of the caller's assignments within a course. Any sibling that inherits from the old name via ` + "`" + `extends` + "`" + ` is repointed to the new name. Rejects a name that already exists or is not path-safe."
+  renameAssignment(course: String!, oldName: String!, newName: String!): AssignmentView!
   "Delete one assignment from one of the caller's courses. Returns false if there was no such assignment."
   deleteAssignment(course: String!, name: String!): Boolean!
 }
@@ -1877,6 +1905,8 @@ type Mutation {
   setCourseStudents(name: String!, students: [String!]!): Course!
   "Replace the course-level groups of one of the caller's courses. The GUI merges additively before calling this."
   setCourseGroups(name: String!, groups: [GroupInput!]!): Course!
+  "Rename one of the caller's courses. The course name is the YAML file's top-level key, so this re-encodes the raw bytes. Rejects a new name that already exists or is not path-safe."
+  renameCourse(oldName: String!, newName: String!): Course!
   "Delete one of the current user's courses."
   deleteCourse(name: String!): Boolean!
 }
@@ -2874,6 +2904,58 @@ func (ec *executionContext) field_Mutation_planOp_args(ctx context.Context, rawA
 		return nil, err
 	}
 	args["onlyFor"] = arg4
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_renameAssignment_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "course",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["course"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "oldName",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["oldName"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "newName",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["newName"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_renameCourse_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "oldName",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["oldName"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "newName",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["newName"] = arg1
 	return args, nil
 }
 
@@ -5362,6 +5444,50 @@ func (ec *executionContext) fieldContext_Mutation_setCourseGroups(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_renameCourse(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_renameCourse(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().RenameCourse(ctx, fc.Args["oldName"].(string), fc.Args["newName"].(string))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.Course) graphql.Marshaler {
+			return ec.marshalNCourse2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐCourse(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_renameCourse(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Course(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_renameCourse_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_deleteCourse(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -5532,6 +5658,50 @@ func (ec *executionContext) fieldContext_Mutation_copyAssignment(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_copyAssignment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_renameAssignment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_renameAssignment(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().RenameAssignment(ctx, fc.Args["course"].(string), fc.Args["oldName"].(string), fc.Args["newName"].(string))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.AssignmentView) graphql.Marshaler {
+			return ec.marshalNAssignmentView2ᚖgithubᚗcomᚋobcodeᚋglabsᚋv3ᚋwebᚋgraphᚋmodelᚐAssignmentView(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_renameAssignment(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_AssignmentView(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_renameAssignment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9968,6 +10138,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "renameCourse":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_renameCourse(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "deleteCourse":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteCourse(ctx, field)
@@ -9992,6 +10169,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "copyAssignment":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_copyAssignment(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "renameAssignment":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_renameAssignment(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++


### PR DESCRIPTION
## Was

Block I / F1 (Backend): einen Kurs oder ein Assignment umbenennen — ohne Einschränkung ggü. plain YAML.

## Änderungen

- `web/app/courses.go`: `RenameCourse(oldName, newName)` — der Kursname ist der Top-Level-YAML-Key, also werden die Rohbytes unter dem neuen Namen re-encodiert; das Mongo-Dokument wird umgeschlüsselt (neu speichern, alt löschen — data-loss-sicher). Lehnt vergebene/nicht-pfadsichere Namen ab.
- `web/app/assignments.go`: `RenameAssignment(course, oldName, newName)` — schlüsselt das Assignment in der Kursquelle um und re-marshalled. **Jedes Geschwister, das per `extends` vom alten Namen erbt, wird auf den neuen umgebogen** — so bricht keine Vererbungskette still (was ein Hand-Rename im YAML dem Nutzer überließe).
- GraphQL: `renameCourse`/`renameAssignment` (+ Regenerate, ungenutzte `fmt`-Imports entfernt).
- Tests: `TestRenameCourse` (Re-Key, YAML-Top-Level-Key, alter Name weg, Kollision/Invalid) und `TestRenameAssignment` (Re-Key, `extends`-Repointing, Fehlerfälle).

GUI-Teil (Umbenennen-Dialoge) folgt als separater `glabs.gui`-PR.

## Verifikation

`go build ./... && go vet ./... && go vet -tags=integration ./... && go test ./... && golangci-lint run` — alle grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)