### PR TITLE
feat(web): scheduled-job poll runner with grace/configHash/PAT guards (Milestone D2)

### DIFF
--- a/web/app/app.go
+++ b/web/app/app.go
@@ -35,6 +35,8 @@ type store interface {
 	CancelJob(ctx context.Context, owner, id string) (*db.ScheduledJob, error)
 	JobsOf(ctx context.Context, owner string, statuses []string) ([]*db.ScheduledJob, error)
 	JobOf(ctx context.Context, owner, id string) (*db.ScheduledJob, error)
+	ClaimDueJob(ctx context.Context, workerID string, now time.Time) (*db.ScheduledJob, error)
+	FinishJob(ctx context.Context, id, status, logText, errText string) error
 }
 
 type App struct {

--- a/web/app/courses_test.go
+++ b/web/app/courses_test.go
@@ -82,6 +82,35 @@ func (f *fakeStore) JobOf(_ context.Context, owner, id string) (*db.ScheduledJob
 	return j, nil
 }
 
+func (f *fakeStore) ClaimDueJob(_ context.Context, workerID string, now time.Time) (*db.ScheduledJob, error) {
+	var pick *db.ScheduledJob
+	for _, j := range f.jobs {
+		if j.Status == db.JobPending && !j.RunAt.After(now) {
+			if pick == nil || j.RunAt.Before(pick.RunAt) {
+				pick = j
+			}
+		}
+	}
+	if pick == nil {
+		return nil, db.ErrNoDueJob
+	}
+	pick.Status = db.JobRunning
+	pick.StartedAt = &now
+	pick.WorkerID = workerID
+	return pick, nil
+}
+
+func (f *fakeStore) FinishJob(_ context.Context, id, status, logText, errText string) error {
+	j, ok := f.jobs[id]
+	if !ok {
+		return db.ErrJobNotFound
+	}
+	j.Status = status
+	j.Log = logText
+	j.Err = errText
+	return nil
+}
+
 func (f *fakeStore) GetUserByEmail(context.Context, string) (*model.User, error) { return nil, nil }
 
 func (f *fakeStore) CoursesOf(_ context.Context, owner string) ([]*db.StoredCourse, error) {

--- a/web/app/runner.go
+++ b/web/app/runner.go
@@ -1,0 +1,188 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/obcode/glabs/v3/reporter"
+	"github.com/obcode/glabs/v3/web/db"
+	"github.com/obcode/glabs/v3/web/graph/model"
+	"github.com/obcode/glabs/v3/web/principal"
+	"github.com/rs/zerolog/log"
+)
+
+// jobPollInterval is how often the runner looks for due jobs. Scheduled times are
+// absolute wall-clock instants, so a coarse poll is fine.
+const jobPollInterval = 30 * time.Second
+
+// StartJobRunner runs the scheduled-job poll loop until ctx is cancelled. Each
+// tick it drains every due job, claiming them one at a time so exactly one runner
+// ever owns a given job. It is safe to run one per instance against a shared
+// database. Jobs run synchronously in the loop, so a shutdown between ticks waits
+// for the current job to finish.
+func (a *App) StartJobRunner(ctx context.Context) {
+	worker := workerID()
+	ticker := time.NewTicker(jobPollInterval)
+	defer ticker.Stop()
+	log.Info().Str("worker", worker).Dur("interval", jobPollInterval).Msg("scheduled-job runner started")
+	for {
+		a.runDueJobs(ctx, worker)
+		select {
+		case <-ctx.Done():
+			log.Info().Msg("scheduled-job runner stopped")
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func workerID() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown"
+	}
+	return fmt.Sprintf("%s/%d", host, os.Getpid())
+}
+
+// runDueJobs claims and runs due jobs one at a time until none remain (so a batch
+// that came due during downtime is caught up in one tick).
+func (a *App) runDueJobs(ctx context.Context, worker string) {
+	for ctx.Err() == nil {
+		job, err := a.db.ClaimDueJob(ctx, worker, time.Now())
+		if errors.Is(err, db.ErrNoDueJob) {
+			return
+		}
+		if err != nil {
+			log.Error().Err(err).Msg("cannot claim a due job")
+			return
+		}
+		a.runJob(ctx, job)
+	}
+}
+
+// runJob executes one claimed job to a terminal state. It is the guarded core: a
+// panic is recovered (so one bad job never takes the server down), the grace
+// window turns a too-late job into `expired`, and the plan's config hash is
+// re-checked so a job whose config drifted since scheduling fails rather than
+// doing something unintended.
+func (a *App) runJob(parent context.Context, job *db.ScheduledJob) {
+	// Detached context so a shutdown mid-operation does not cancel the GitLab
+	// calls; the runner acts as the job's owner (its context principal), never as a
+	// request user.
+	ctx := principal.WithUser(context.WithoutCancel(parent), &model.User{Email: job.Owner})
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error().Interface("panic", r).Str("job", job.ID).Msg("scheduled job panicked")
+			a.finishJob(ctx, job, db.JobFailed, "", fmt.Sprintf("internal error: %v", r))
+		}
+	}()
+
+	// Grace window: past runAt + grace, do not fire a stale deadline job.
+	if time.Now().After(job.RunAt.Add(time.Duration(job.GraceMin) * time.Minute)) {
+		a.finishJob(ctx, job, db.JobExpired, "",
+			fmt.Sprintf("grace window of %d min passed (was due %s)", job.GraceMin, job.RunAt.UTC().Format(time.RFC3339)))
+		return
+	}
+
+	// Re-resolve and compare the config hash: reject a job whose config changed.
+	cfg, err := a.resolveAssignmentConfig(ctx, job.Course, job.Assignment, job.OnlyFor...)
+	if err != nil {
+		a.finishJob(ctx, job, db.JobFailed, "", err.Error())
+		return
+	}
+	if cfg == nil {
+		a.finishJob(ctx, job, db.JobFailed, "",
+			fmt.Sprintf("assignment %q of course %q no longer resolves", job.Assignment, job.Course))
+		return
+	}
+	hash, err := configHash(cfg)
+	if err != nil {
+		a.finishJob(ctx, job, db.JobFailed, "", err.Error())
+		return
+	}
+	if hash != job.ConfigHash {
+		a.finishJob(ctx, job, db.JobFailed, "",
+			"the configuration changed since the job was scheduled — it was not run")
+		return
+	}
+	if cfg.Seeder != nil {
+		a.finishJob(ctx, job, db.JobFailed, "",
+			"assignment configures a seeder, which the web cannot run")
+		return
+	}
+
+	rep := &captureReporter{}
+	client, err := a.gitlabClientFor(ctx, job.Owner, rep)
+	if err != nil {
+		a.finishJob(ctx, job, db.JobFailed, rep.String(), err.Error())
+		return
+	}
+
+	tok := &opToken{Op: job.Op, Course: job.Course, Assignment: job.Assignment, Params: job.Params, OnlyFor: job.OnlyFor}
+	rep.line(fmt.Sprintf("running %s on %s/%s (%d repositories)", job.Op, job.Course, job.Assignment, len(cfg.RepoTargets())))
+	if err := executeOp(client, tok, cfg); err != nil {
+		a.finishJob(ctx, job, db.JobFailed, rep.String(), err.Error())
+		return
+	}
+	a.finishJob(ctx, job, db.JobDone, rep.String(), "")
+}
+
+// finishJob records a job's terminal state and mirrors it into the activity log so
+// the course page shows a scheduled run exactly like an interactive one.
+func (a *App) finishJob(ctx context.Context, job *db.ScheduledJob, status, logText, errText string) {
+	if err := a.db.FinishJob(ctx, job.ID, status, logText, errText); err != nil {
+		log.Error().Err(err).Str("job", job.ID).Msg("cannot record scheduled-job outcome")
+	}
+	activityStatus, detail := "done", "scheduled run completed"
+	if status != db.JobDone {
+		activityStatus, detail = "failed", errText
+	}
+	tok := &opToken{Op: job.Op, Course: job.Course, Assignment: job.Assignment, Params: job.Params, OnlyFor: job.OnlyFor}
+	if err := a.recordOp(ctx, job.Owner, tok, activityStatus, detail); err != nil {
+		log.Warn().Err(err).Str("job", job.ID).Msg("cannot record scheduled-job activity")
+	}
+}
+
+// captureReporter is a reporter.Reporter that accumulates the operation's output
+// into a string, so a scheduled run (which no one watches) still keeps a log on
+// the job document.
+type captureReporter struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (c *captureReporter) line(s string) {
+	s = strings.TrimSpace(ansiRE.ReplaceAllString(s, ""))
+	if s == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buf.WriteString(s)
+	c.buf.WriteByte('\n')
+}
+
+func (c *captureReporter) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+func (c *captureReporter) Printf(format string, a ...any) { c.line(fmt.Sprintf(format, a...)) }
+func (c *captureReporter) Println(a ...any)               { c.line(fmt.Sprintln(a...)) }
+func (c *captureReporter) Task(description string) reporter.Task {
+	c.line(description)
+	return &captureTask{c}
+}
+
+type captureTask struct{ c *captureReporter }
+
+func (t *captureTask) Update(message string) { t.c.line(message) }
+func (t *captureTask) Done(message string)   { t.c.line(message) }
+func (t *captureTask) Fail(message string)   { t.c.line(message) }

--- a/web/app/runner_test.go
+++ b/web/app/runner_test.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/obcode/glabs/v3/web/db"
+)
+
+// A job that is already past its grace window is expired, not run.
+func TestRunJob_expiredWhenPastGrace(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+
+	job := &db.ScheduledJob{
+		ID: "j1", Owner: owner, Op: "setaccess", Course: "uc", Assignment: "blatt1",
+		RunAt: time.Now().Add(-2 * time.Hour), GraceMin: 60, ConfigHash: "irrelevant",
+		Status: db.JobRunning,
+	}
+	fs.jobs["j1"] = job
+
+	a.runJob(context.Background(), job)
+
+	if fs.jobs["j1"].Status != db.JobExpired {
+		t.Errorf("status = %q, want expired", fs.jobs["j1"].Status)
+	}
+	if len(fs.activity) == 0 || fs.activity[len(fs.activity)-1].Status != "failed" {
+		t.Error("an expired job should be mirrored into the activity log as failed")
+	}
+}
+
+// A job whose config drifted since scheduling (hash mismatch) fails instead of
+// doing something unintended.
+func TestRunJob_failsOnConfigDrift(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+
+	job := &db.ScheduledJob{
+		ID: "j1", Owner: owner, Op: "setaccess", Course: "uc", Assignment: "blatt1",
+		RunAt: time.Now(), GraceMin: 60, ConfigHash: "stale-hash", Status: db.JobRunning,
+	}
+	fs.jobs["j1"] = job
+
+	a.runJob(context.Background(), job)
+
+	if fs.jobs["j1"].Status != db.JobFailed {
+		t.Errorf("status = %q, want failed", fs.jobs["j1"].Status)
+	}
+	if !strings.Contains(fs.jobs["j1"].Err, "changed") {
+		t.Errorf("err = %q, want a config-changed message", fs.jobs["j1"].Err)
+	}
+}
+
+// With the right hash but no stored GitLab token, the job fails at client
+// construction — before any GitLab call.
+func TestRunJob_failsWithoutStoredToken(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gl"}
+
+	cfg, err := a.resolveAssignmentConfig(ctxAs(owner), "uc", "blatt1")
+	if err != nil || cfg == nil {
+		t.Fatalf("resolve: cfg=%v err=%v", cfg, err)
+	}
+	hash, err := configHash(cfg)
+	if err != nil {
+		t.Fatalf("configHash: %v", err)
+	}
+
+	job := &db.ScheduledJob{
+		ID: "j1", Owner: owner, Op: "setaccess", Course: "uc", Assignment: "blatt1",
+		RunAt: time.Now(), GraceMin: 60, ConfigHash: hash, Status: db.JobRunning,
+	}
+	fs.jobs["j1"] = job
+
+	a.runJob(context.Background(), job)
+
+	if fs.jobs["j1"].Status != db.JobFailed {
+		t.Errorf("status = %q, want failed", fs.jobs["j1"].Status)
+	}
+	if fs.jobs["j1"].Err == "" {
+		t.Error("a job that cannot authenticate should record an error")
+	}
+}
+
+// The poll loop leaves a not-yet-due job untouched.
+func TestRunDueJobs_skipsFutureJobs(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	a := &App{db: fs, gitlabHost: "https://gl"}
+
+	fs.jobs["future"] = &db.ScheduledJob{
+		ID: "future", Owner: owner, Op: "setaccess", Course: "uc", Assignment: "blatt1",
+		RunAt: time.Now().Add(time.Hour), GraceMin: 60, Status: db.JobPending,
+	}
+
+	a.runDueJobs(context.Background(), "worker-1")
+
+	if fs.jobs["future"].Status != db.JobPending {
+		t.Errorf("a future job was claimed (status %q), want it left pending", fs.jobs["future"].Status)
+	}
+}

--- a/web/bootstrap/bootstrap.go
+++ b/web/bootstrap/bootstrap.go
@@ -85,6 +85,10 @@ func Serve() error {
 		return err
 	}
 
+	// The scheduled-job runner polls in the background for the life of the process
+	// (a background context, since StartServer blocks and never returns here).
+	go a.StartJobRunner(context.Background())
+
 	graph.StartServer(a, viper.GetString("server.port"))
 	return nil
 }


### PR DESCRIPTION
## Was

Milestone **D2**: der Poll-Runner, der die in D1 persistierten Jobs tatsächlich feuert — **noch ohne Mail**.

## Änderungen

- `app.StartJobRunner`: ~30s-Poll-Loop, leert pro Tick alle fälligen Jobs, claimt sie einzeln über den atomaren `ClaimDueJob` (exactly-once über Instanzen); als Hintergrund-Goroutine in `bootstrap` gestartet. Jobs laufen synchron im Loop → ein Shutdown zwischen Ticks lässt den laufenden Job fertig werden.
- `runJob` = der abgesicherte Kern: **`recover()` pro Job** (ein Job reißt den Server nie mit); **Grace-Fenster** → `expired`; **configHash-Neuvergleich** (drift/seeder/nicht-auflösbar → `failed` statt Unfug); fehlender **PAT** → `failed` bei Client-Bau. Läuft als der Owner des Jobs (Context-Principal) auf einem **detached Context** (Shutdown mitten in der Op cancelt die GitLab-Calls nicht), nutzt das bestehende `executeOp`. Jeder Endzustand wird ins **Aktivitäts-Log** gespiegelt → geplanter Lauf erscheint auf der Kurs-Seite wie ein interaktiver.
- `store`: `ClaimDueJob` + `FinishJob`; Fake-Store implementiert sie.

Guard-Pfade (grace/drift/kein-Token/nicht-fällig) unit-getestet; atomarer Claim + echter Lauf gegen Mongo/GitLab CE. **Mail bei jedem Endzustand folgt in D3/D4.**

## Verifikation

`go build ./... && go vet ./... && go vet -tags=integration ./... && go test ./... && golangci-lint run` — alle grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)