### PR TITLE
feat(web): wire email into scheduling — confirmation + terminal-state mails (Milestone D4)

### DIFF
--- a/web/app/app.go
+++ b/web/app/app.go
@@ -37,6 +37,14 @@ type store interface {
 	JobOf(ctx context.Context, owner, id string) (*db.ScheduledJob, error)
 	ClaimDueJob(ctx context.Context, workerID string, now time.Time) (*db.ScheduledJob, error)
 	FinishJob(ctx context.Context, id, status, logText, errText string) error
+	UnnotifiedTerminalJobs(ctx context.Context) ([]*db.ScheduledJob, error)
+	MarkNotified(ctx context.Context, id string) error
+}
+
+// Mailer sends a rendered notification. *mail.Sender implements it; the App holds
+// one only when SMTP is configured (nil otherwise, so notifications are skipped).
+type Mailer interface {
+	Send(dryRun bool, to, subject string, text, html []byte) error
 }
 
 type App struct {
@@ -50,10 +58,22 @@ type App struct {
 	gitlabHost string
 	// ops serializes mutating operations per (owner, course, assignment).
 	ops *opGuard
+	// mailer sends job notifications; nil when no SMTP is configured (then
+	// notifications are silently skipped). mailDryRun redirects every send to the
+	// configured test recipient.
+	mailer     Mailer
+	mailDryRun bool
 }
 
-func New(database *db.DB, sealer *secrets.Sealer, gitlabHost string) *App {
-	return &App{db: database, sealer: sealer, gitlabHost: gitlabHost, ops: newOpGuard()}
+func New(database *db.DB, sealer *secrets.Sealer, gitlabHost string, mailer Mailer, mailDryRun bool) *App {
+	return &App{
+		db:         database,
+		sealer:     sealer,
+		gitlabHost: gitlabHost,
+		ops:        newOpGuard(),
+		mailer:     mailer,
+		mailDryRun: mailDryRun,
+	}
 }
 
 // GetUserByEmail looks up a user for the auth middleware's allowlist check.

--- a/web/app/courses_test.go
+++ b/web/app/courses_test.go
@@ -111,6 +111,24 @@ func (f *fakeStore) FinishJob(_ context.Context, id, status, logText, errText st
 	return nil
 }
 
+func (f *fakeStore) UnnotifiedTerminalJobs(_ context.Context) ([]*db.ScheduledJob, error) {
+	terminal := map[string]bool{db.JobDone: true, db.JobFailed: true, db.JobExpired: true}
+	var out []*db.ScheduledJob
+	for _, j := range f.jobs {
+		if !j.Notified && terminal[j.Status] {
+			out = append(out, j)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeStore) MarkNotified(_ context.Context, id string) error {
+	if j, ok := f.jobs[id]; ok {
+		j.Notified = true
+	}
+	return nil
+}
+
 func (f *fakeStore) GetUserByEmail(context.Context, string) (*model.User, error) { return nil, nil }
 
 func (f *fakeStore) CoursesOf(_ context.Context, owner string) ([]*db.StoredCourse, error) {

--- a/web/app/mail.go
+++ b/web/app/mail.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obcode/glabs/v3/web/db"
+	"github.com/obcode/glabs/v3/web/mail"
+	"github.com/rs/zerolog/log"
+)
+
+// sendJobMail renders one job-notification template and sends it to the job's
+// owner (the OIDC email is the address). It is a no-op when no mailer is
+// configured, so scheduling and running work with SMTP disabled — only the
+// notifications are missing.
+func (a *App) sendJobMail(job *db.ScheduledJob, template, subject string) error {
+	if a.mailer == nil {
+		log.Debug().Str("job", job.ID).Msg("no mailer configured; skipping notification")
+		return nil
+	}
+	data := mail.JobMail{
+		Op:         job.Op,
+		Course:     job.Course,
+		Assignment: job.Assignment,
+		RunAt:      job.RunAt,
+		GraceMin:   job.GraceMin,
+		Err:        job.Err,
+		Log:        job.Log,
+	}
+	text, html, err := mail.Render(template, data)
+	if err != nil {
+		return err
+	}
+	return a.mailer.Send(a.mailDryRun, job.Owner, subject, text, html)
+}
+
+// terminalMailSpec maps a terminal status to its template and the subject word.
+// Only done/failed/expired are mailed — a user-initiated cancel needs no mail
+// (there is no cancellation template).
+func terminalMailSpec(status string) (template, word string, ok bool) {
+	switch status {
+	case db.JobDone:
+		return mail.TmplDone, "erfolgreich", true
+	case db.JobFailed:
+		return mail.TmplFailed, "fehlgeschlagen", true
+	case db.JobExpired:
+		return mail.TmplExpired, "abgelaufen", true
+	}
+	return "", "", false
+}
+
+// notifyFinishedJobs mails the outcome of every finished-but-unnotified job, then
+// flags it notified so it is not mailed again. A send failure leaves the job
+// unnotified, so the next poll tick retries it — the poll interval is the backoff.
+func (a *App) notifyFinishedJobs(ctx context.Context) {
+	if a.mailer == nil {
+		return
+	}
+	jobs, err := a.db.UnnotifiedTerminalJobs(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("cannot read unnotified jobs")
+		return
+	}
+	for _, job := range jobs {
+		template, word, ok := terminalMailSpec(job.Status)
+		if !ok {
+			continue
+		}
+		subject := fmt.Sprintf("glabs: %s für %s/%s %s", job.Op, job.Course, job.Assignment, word)
+		if err := a.sendJobMail(job, template, subject); err != nil {
+			log.Warn().Err(err).Str("job", job.ID).Msg("cannot send job notification; will retry next tick")
+			continue
+		}
+		if err := a.db.MarkNotified(ctx, job.ID); err != nil {
+			log.Error().Err(err).Str("job", job.ID).Msg("notification sent but cannot mark job notified")
+		}
+	}
+}
+
+// sendScheduledConfirmation sends the "operation scheduled" confirmation for a
+// freshly created job. Best-effort: a mail failure must not fail the scheduling.
+func (a *App) sendScheduledConfirmation(job *db.ScheduledJob) {
+	subject := fmt.Sprintf("glabs: %s für %s/%s geplant", job.Op, job.Course, job.Assignment)
+	if err := a.sendJobMail(job, mail.TmplScheduled, subject); err != nil {
+		log.Warn().Err(err).Str("job", job.ID).Msg("cannot send scheduling confirmation")
+	}
+}

--- a/web/app/mail_test.go
+++ b/web/app/mail_test.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/obcode/glabs/v3/web/db"
+)
+
+type sentMail struct{ to, subject string }
+
+type fakeMailer struct {
+	sent []sentMail
+	fail bool
+}
+
+func (m *fakeMailer) Send(_ bool, to, subject string, _, _ []byte) error {
+	if m.fail {
+		return fmt.Errorf("smtp down")
+	}
+	m.sent = append(m.sent, sentMail{to, subject})
+	return nil
+}
+
+func doneJob(id, owner string) *db.ScheduledJob {
+	return &db.ScheduledJob{
+		ID: id, Owner: owner, Op: "setaccess", Course: "mpd", Assignment: "blatt01",
+		Status: db.JobDone, RunAt: time.Now(), GraceMin: 60,
+	}
+}
+
+func TestNotifyFinishedJobs_sendsOnceAndMarks(t *testing.T) {
+	fs := newFakeStore()
+	fm := &fakeMailer{}
+	a := &App{db: fs, mailer: fm}
+	fs.jobs["j1"] = doneJob("j1", "prof@hm.edu")
+
+	a.notifyFinishedJobs(context.Background())
+
+	if len(fm.sent) != 1 {
+		t.Fatalf("sent %d mails, want 1", len(fm.sent))
+	}
+	if fm.sent[0].to != "prof@hm.edu" || !strings.Contains(fm.sent[0].subject, "erfolgreich") {
+		t.Errorf("mail = %+v, want to prof@hm.edu, subject 'erfolgreich'", fm.sent[0])
+	}
+	if !fs.jobs["j1"].Notified {
+		t.Error("job should be marked notified after a successful send")
+	}
+
+	// A second sweep must not re-mail an already-notified job.
+	a.notifyFinishedJobs(context.Background())
+	if len(fm.sent) != 1 {
+		t.Errorf("notified job was re-mailed (%d sends)", len(fm.sent))
+	}
+}
+
+func TestNotifyFinishedJobs_failureLeavesUnnotifiedForRetry(t *testing.T) {
+	fs := newFakeStore()
+	fm := &fakeMailer{fail: true}
+	a := &App{db: fs, mailer: fm}
+	fs.jobs["j1"] = doneJob("j1", "prof@hm.edu")
+
+	a.notifyFinishedJobs(context.Background())
+
+	if fs.jobs["j1"].Notified {
+		t.Error("a failed send must leave the job unnotified so the next tick retries")
+	}
+}
+
+func TestNotifyFinishedJobs_noMailerIsNoop(t *testing.T) {
+	fs := newFakeStore()
+	a := &App{db: fs} // no mailer
+	fs.jobs["j1"] = doneJob("j1", "prof@hm.edu")
+
+	a.notifyFinishedJobs(context.Background()) // must not panic
+
+	if fs.jobs["j1"].Notified {
+		t.Error("with no mailer the job should not be marked notified")
+	}
+}
+
+func TestScheduleOp_sendsConfirmation(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	withStoredToken(fs, owner)
+	fm := &fakeMailer{}
+	a := &App{db: fs, gitlabHost: "https://gl", sealer: testSealer(t), mailer: fm}
+	ctx := ctxAs(owner)
+
+	plan, err := a.PlanOp(ctx, "setaccess", "uc", "blatt1", nil, nil)
+	if err != nil {
+		t.Fatalf("PlanOp: %v", err)
+	}
+	if _, err := a.ScheduleOp(ctx, plan.Token, time.Now().Add(time.Hour), nil, ""); err != nil {
+		t.Fatalf("ScheduleOp: %v", err)
+	}
+	if len(fm.sent) != 1 || !strings.Contains(fm.sent[0].subject, "geplant") {
+		t.Errorf("scheduling confirmation not sent: %+v", fm.sent)
+	}
+}

--- a/web/app/runner.go
+++ b/web/app/runner.go
@@ -32,6 +32,7 @@ func (a *App) StartJobRunner(ctx context.Context) {
 	log.Info().Str("worker", worker).Dur("interval", jobPollInterval).Msg("scheduled-job runner started")
 	for {
 		a.runDueJobs(ctx, worker)
+		a.notifyFinishedJobs(ctx)
 		select {
 		case <-ctx.Done():
 			log.Info().Msg("scheduled-job runner stopped")

--- a/web/app/schedule.go
+++ b/web/app/schedule.go
@@ -74,6 +74,7 @@ func (a *App) ScheduleOp(ctx context.Context, token string, runAt time.Time, gra
 	if err := a.db.SaveJob(ctx, job); err != nil {
 		return nil, err
 	}
+	a.sendScheduledConfirmation(job)
 	return job, nil
 }
 

--- a/web/bootstrap/bootstrap.go
+++ b/web/bootstrap/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/obcode/glabs/v3/web/app"
 	"github.com/obcode/glabs/v3/web/db"
 	"github.com/obcode/glabs/v3/web/graph"
+	"github.com/obcode/glabs/v3/web/mail"
 	"github.com/obcode/glabs/v3/web/secrets"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -80,7 +81,26 @@ func Serve() error {
 		log.Error().Err(err).Msg("invalid secrets.key — storing GitLab tokens is disabled until it is fixed")
 	}
 
-	a := app.New(database_, sealer, viper.GetString("gitlab.host"))
+	// SMTP for job notifications is optional: without smtp.host, scheduling and
+	// running still work — only the emails are skipped.
+	var mailer app.Mailer
+	if smtpHost := viper.GetString("smtp.host"); smtpHost != "" {
+		mailer = mail.NewSender(mail.Config{
+			Host:                  smtpHost,
+			Port:                  viper.GetInt("smtp.port"),
+			Username:              viper.GetString("smtp.username"),
+			Password:              viper.GetString("smtp.password"),
+			From:                  viper.GetString("smtp.from"),
+			Hostname:              viper.GetString("smtp.hostname"),
+			TLSInsecureSkipVerify: viper.GetBool("smtp.tlsInsecureSkipVerify"),
+			TestRecipient:         viper.GetString("smtp.testRecipient"),
+		})
+		log.Info().Str("host", smtpHost).Bool("dryRun", viper.GetBool("smtp.dryRun")).Msg("SMTP configured; job notifications enabled")
+	} else {
+		log.Warn().Msg("no smtp.host configured; scheduled-job notifications are disabled")
+	}
+
+	a := app.New(database_, sealer, viper.GetString("gitlab.host"), mailer, viper.GetBool("smtp.dryRun"))
 	if err := seedUsers(ctx, database_); err != nil {
 		return err
 	}

--- a/web/db/jobs.go
+++ b/web/db/jobs.go
@@ -171,6 +171,27 @@ func (db *DB) JobsOf(ctx context.Context, owner string, statuses []string) ([]*S
 	return out, nil
 }
 
+// UnnotifiedTerminalJobs returns finished jobs (done/failed/expired) whose
+// notification email has not been sent yet, across all owners — the runner's
+// notify sweep. Cancelled jobs are excluded (there is no cancellation mail). This
+// is what makes "email on every terminal state" survive a crash between finishing
+// a job and mailing it: on restart the job is terminal and still unnotified, so
+// the mail is sent (once — MarkNotified then guards against a resend).
+func (db *DB) UnnotifiedTerminalJobs(ctx context.Context) ([]*ScheduledJob, error) {
+	cur, err := db.collection(collectionJobs).Find(ctx, bson.M{
+		"notified": false,
+		"status":   bson.M{"$in": []string{JobDone, JobFailed, JobExpired}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot read unnotified jobs: %w", err)
+	}
+	var out []*ScheduledJob
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("cannot decode unnotified jobs: %w", err)
+	}
+	return out, nil
+}
+
 // JobOf returns one of the owner's jobs, or ErrJobNotFound.
 func (db *DB) JobOf(ctx context.Context, owner, id string) (*ScheduledJob, error) {
 	var job ScheduledJob


### PR DESCRIPTION
## Was

Milestone **D4**: das D3-Mail-Paket wird von Runner + Scheduler getrieben.

## Änderungen

- `App` bekommt einen optionalen `Mailer` (Interface; `*mail.Sender` erfüllt ihn) + `mailDryRun`, in `bootstrap` aus `smtp.*` gebaut. Ohne `smtp.host` ist der Mailer nil → Benachrichtigungen werden still übersprungen; Scheduling/Runner laufen weiter.
- `ScheduleOp` sendet eine **Bestätigungsmail** („geplant") — best-effort, Mail-Fehler bricht das Planen nie ab.
- Runner-Tick macht einen **Notify-Sweep**: `db.UnnotifiedTerminalJobs` findet fertige-aber-ungemailte Jobs (done/failed/expired; Cancel bekommt keine Mail), mailt den Ausgang an die Owner-Adresse, dann `MarkNotified` gegen Doppelversand. Fehlgeschlagener Versand lässt den Job ungemailt → nächster Tick retryt (Poll-Intervall = Backoff). Weil der Sweep über `status+notified` läuft statt inline, wird ein Crash zwischen „Job fertig" und „Mail" beim Neustart aufgeholt → **„Mail bei jedem Endzustand" überlebt Neustarts.**
- `store`: `UnnotifiedTerminalJobs` + `MarkNotified`.

**Config** (`.glabs-web.yaml`): `smtp.host/port/username/password/from/hostname/tlsInsecureSkipVerify/testRecipient` + `smtp.dryRun` (leitet alle Sends an den TestRecipient). Tests mit Fake-Mailer: einmal-senden-und-markieren, Retry bei Fehler, No-Mailer-No-op, Bestätigungsmail. **SMTP-e2e via Mailpit = manuell.**

## Verifikation

`go build ./... && go vet ./... && go vet -tags=integration ./... && go test ./... && golangci-lint run` — alle grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)