### PR TITLE
refactor(git): inject git auth and committer instead of reading viper (Milestone E1a)

### DIFF
--- a/git/auth.go
+++ b/git/auth.go
@@ -30,7 +30,9 @@ func GetAuth() (transport.AuthMethod, error) {
 	return &githttp.BasicAuth{Username: "oauth2", Password: token}, nil
 }
 
-// AuthForURL returns the credential to use when cloning the given URL.
+// AuthForURL returns the credential to use when cloning the given URL, reading
+// the token and host from viper. It is the CLI's single-token path; the web
+// server uses TokenAuth with a per-user token instead.
 //
 // The token authenticates against one host: the configured GitLab instance.
 // Under SSH this was invisible — the operator's key worked against any host, so
@@ -40,18 +42,38 @@ func GetAuth() (transport.AuthMethod, error) {
 // any other host is cloned unauthenticated, which works for public repositories
 // and fails with a plain "authentication required" for private ones.
 func AuthForURL(rawURL string) (transport.AuthMethod, error) {
-	onGitLab, err := isConfiguredGitLabHost(rawURL)
+	return TokenAuth{
+		GitLabHost: viper.GetString("gitlab.host"),
+		Token:      viper.GetString("gitlab.token"),
+	}.forURL(rawURL)
+}
+
+// TokenAuth resolves git credentials from an explicit GitLab host and token,
+// without touching viper — so the web server can authenticate git as a specific
+// user (its per-user PAT), rather than through a single package-global token that
+// cannot serve multiple users. It applies the same host rule as AuthForURL: the
+// token is attached only to URLs on the GitLab host, never to a foreign one.
+type TokenAuth struct {
+	GitLabHost string
+	Token      string
+}
+
+func (a TokenAuth) forURL(rawURL string) (transport.AuthMethod, error) {
+	onGitLab, err := sameHost(rawURL, a.GitLabHost)
 	if err != nil {
 		return nil, err
 	}
 	if !onGitLab {
 		return nil, nil
 	}
-	return GetAuth()
+	if a.Token == "" {
+		return nil, fmt.Errorf("gitlab token is required for git operations (needs the api and write_repository scopes)")
+	}
+	return &githttp.BasicAuth{Username: "oauth2", Password: a.Token}, nil
 }
 
-func isConfiguredGitLabHost(rawURL string) (bool, error) {
-	gitlabHost := viper.GetString("gitlab.host")
+// sameHost reports whether rawURL is on the given GitLab host.
+func sameHost(rawURL, gitlabHost string) (bool, error) {
 	if gitlabHost == "" {
 		return false, fmt.Errorf("gitlab.host is not configured")
 	}

--- a/git/sourcerepo.go
+++ b/git/sourcerepo.go
@@ -13,10 +13,32 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/obcode/glabs/v3/config"
 	"github.com/obcode/glabs/v3/reporter"
-	"github.com/spf13/viper"
 )
 
-func PrepareSourceRepo(rep reporter.Reporter, url, fromBranch string, singleCommit bool, commitMessage string) (*SourceRepo, error) {
+// Committer identifies who authors the starter-code commit. Empty fields fall
+// back to the glabs bot identity, so a caller that does not care (the common
+// case) can pass the zero value. The web server passes the acting user.
+type Committer struct {
+	Name  string
+	Email string
+}
+
+func (c Committer) signature(when time.Time) object.Signature {
+	name, email := c.Name, c.Email
+	if name == "" {
+		name = "glabs"
+	}
+	if email == "" {
+		email = "glabs-bot@noreply.example.com"
+	}
+	return object.Signature{Name: name, Email: email, When: when}
+}
+
+// PrepareSourceRepo clones the starter code into memory and returns it ready to
+// push. auth resolves the clone credential from an explicit host+token (no
+// viper), and committer authors the squashed single commit — both injected so
+// the web server can act as a specific user.
+func PrepareSourceRepo(rep reporter.Reporter, auth TokenAuth, committer Committer, url, fromBranch string, singleCommit bool, commitMessage string) (*SourceRepo, error) {
 	task := rep.Task(aurora.Sprintf(aurora.Cyan(" cloning source code from %s, branch %s"),
 		aurora.Yellow(url),
 		aurora.Yellow(fromBranch),
@@ -34,7 +56,7 @@ func PrepareSourceRepo(rep reporter.Reporter, url, fromBranch string, singleComm
 		return fail(err)
 	}
 
-	auth, err := AuthForURL(cloneURL)
+	resolvedAuth, err := auth.forURL(cloneURL)
 	if err != nil {
 		return fail(err)
 	}
@@ -48,7 +70,7 @@ func PrepareSourceRepo(rep reporter.Reporter, url, fromBranch string, singleComm
 		URL:           cloneURL,
 		ReferenceName: sourceRef,
 		SingleBranch:  true,
-		Auth:          auth,
+		Auth:          resolvedAuth,
 	})
 	if err != nil {
 		return fail(err)
@@ -71,7 +93,7 @@ func PrepareSourceRepo(rep reporter.Reporter, url, fromBranch string, singleComm
 		return &SourceRepo{
 			Repo: repo,
 			Ref:  sourceRef,
-			Auth: auth,
+			Auth: resolvedAuth,
 		}, nil
 	}
 
@@ -93,28 +115,13 @@ func PrepareSourceRepo(rep reporter.Reporter, url, fromBranch string, singleComm
 	singleCommitBranchName := fmt.Sprintf("orphan-%s-%d", sourceRef.Short(), time.Now().UnixNano())
 	refName := plumbing.NewBranchReferenceName(singleCommitBranchName)
 
-	committerName := "glabs"
-	committerEmail := "glabs-bot@noreply.example.com"
-
-	if viper.IsSet("committer") {
-		committerName = viper.GetString("committer.name")
-		committerEmail = viper.GetString("committer.email")
-	}
-
 	now := time.Now()
+	sig := committer.signature(now)
 	commit := &object.Commit{
-		Author: object.Signature{
-			Name:  committerName,
-			Email: committerEmail,
-			When:  now,
-		},
-		Committer: object.Signature{
-			Name:  committerName,
-			Email: committerEmail,
-			When:  now,
-		},
-		Message:  commitMessage,
-		TreeHash: tree.Hash,
+		Author:    sig,
+		Committer: sig,
+		Message:   commitMessage,
+		TreeHash:  tree.Hash,
 	}
 
 	encoded := repo.Storer.NewEncodedObject()
@@ -150,6 +157,6 @@ func PrepareSourceRepo(rep reporter.Reporter, url, fromBranch string, singleComm
 	return &SourceRepo{
 		Repo: repo,
 		Ref:  refName,
-		Auth: auth,
+		Auth: resolvedAuth,
 	}, nil
 }

--- a/gitlab/generate.go
+++ b/gitlab/generate.go
@@ -26,7 +26,7 @@ func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) error {
 	var starterrepo *git.SourceRepo
 
 	if assignmentCfg.Startercode != nil {
-		starterrepo, err = git.PrepareSourceRepo(c.rep,
+		starterrepo, err = git.PrepareSourceRepo(c.rep, c.gitAuth(), c.committer,
 			assignmentCfg.Startercode.URL,
 			assignmentCfg.Startercode.FromBranch,
 			assignmentCfg.Startercode.Template,

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/obcode/glabs/v3/git"
 	"github.com/obcode/glabs/v3/reporter"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -17,6 +18,12 @@ type Client struct {
 	// because a per-user web request builds its own Client anyway (per-user
 	// token), so the reporter is naturally request-scoped and never shared.
 	rep reporter.Reporter
+	// host and token are kept so the client can build git credentials (git and
+	// the API share one token) without reading the global viper config.
+	host  string
+	token string
+	// committer authors starter-code commits; empty falls back to the glabs bot.
+	committer git.Committer
 }
 
 // clientOptions holds what a Client needs to reach GitLab. They are injected
@@ -29,6 +36,8 @@ type clientOptions struct {
 	httpClient     *http.Client
 	withoutRetries bool
 	reporter       reporter.Reporter
+	committerName  string
+	committerEmail string
 }
 
 type Option func(*clientOptions)
@@ -45,6 +54,16 @@ func WithHTTPClient(hc *http.Client) Option {
 // ConsoleReporter (spinners on stdout); the web server passes a streaming one.
 func WithReporter(r reporter.Reporter) Option {
 	return func(o *clientOptions) { o.reporter = r }
+}
+
+// WithCommitter sets the identity that authors starter-code commits. Empty
+// values fall back to the glabs bot identity. The web server passes the acting
+// user so a generated commit is attributed to them.
+func WithCommitter(name, email string) Option {
+	return func(o *clientOptions) {
+		o.committerName = name
+		o.committerEmail = email
+	}
 }
 
 // WithoutRetries disables the client's retry-on-5xx wrapper. The contract tests
@@ -88,7 +107,19 @@ func NewClient(opts ...Option) (*Client, error) {
 		rep = reporter.NewConsoleReporter()
 	}
 
-	return &Client{Client: client, rep: rep}, nil
+	return &Client{
+		Client:    client,
+		rep:       rep,
+		host:      o.host,
+		token:     o.token,
+		committer: git.Committer{Name: o.committerName, Email: o.committerEmail},
+	}, nil
+}
+
+// gitAuth is the credential the client uses for git clone/push: the same token
+// as the API, attached only to the configured GitLab host.
+func (c *Client) gitAuth() git.TokenAuth {
+	return git.TokenAuth{GitLabHost: c.host, Token: c.token}
 }
 
 // NewClientFromViper builds a client from the global config. It is the CLI's
@@ -98,5 +129,6 @@ func NewClientFromViper() (*Client, error) {
 	return NewClient(
 		WithHost(viper.GetString("gitlab.host")),
 		WithToken(viper.GetString("gitlab.token")),
+		WithCommitter(viper.GetString("committer.name"), viper.GetString("committer.email")),
 	)
 }

--- a/gitlab/integration_gitlab_test.go
+++ b/gitlab/integration_gitlab_test.go
@@ -328,7 +328,8 @@ func TestIntegration_GitLab_Operations(t *testing.T) {
 		gitURL := func(p *gitlabapi.Project) string { return baseURL + "/" + p.PathWithNamespace + ".git" }
 
 		// Clone it over HTTPS+PAT — proves the clone side of the transport.
-		sourceRepo, err := g.PrepareSourceRepo(reporter.NewDiscardReporter(), gitURL(srcProject), "main", false, "")
+		auth := g.TokenAuth{GitLabHost: baseURL, Token: gitLabRootToken}
+		sourceRepo, err := g.PrepareSourceRepo(reporter.NewDiscardReporter(), auth, g.Committer{}, gitURL(srcProject), "main", false, "")
 		if err != nil {
 			t.Fatalf("PrepareSourceRepo over HTTPS failed: %v", err)
 		}

--- a/gitlab/push.go
+++ b/gitlab/push.go
@@ -13,7 +13,7 @@ func (c *Client) Push(assignmentCfg *config.AssignmentConfig, branchname string)
 		return fmt.Errorf("error: no config for deferred branch \"%s\" found\n", branchname)
 	}
 
-	sourceRepo, err := git.PrepareSourceRepo(c.rep, branch.URL, branch.FromBranch, branch.Orphan, branch.OrphanMessage)
+	sourceRepo, err := git.PrepareSourceRepo(c.rep, c.gitAuth(), c.committer, branch.URL, branch.FromBranch, branch.Orphan, branch.OrphanMessage)
 	if err != nil {
 		return err
 	}

--- a/gitlab/update.go
+++ b/gitlab/update.go
@@ -19,7 +19,7 @@ func (c *Client) Update(assignmentCfg *config.AssignmentConfig) error {
 	var starterrepo *git.SourceRepo
 
 	if assignmentCfg.Startercode != nil {
-		starterrepo, err = git.PrepareSourceRepo(c.rep,
+		starterrepo, err = git.PrepareSourceRepo(c.rep, c.gitAuth(), c.committer,
 			assignmentCfg.Startercode.URL,
 			assignmentCfg.Startercode.FromBranch,
 			assignmentCfg.Startercode.Template,


### PR DESCRIPTION
## Was

Milestone **E1a** (Vorarbeit für web-`generate`): der git-Transport holte Token/Host/Committer noch aus **global-viper** → nur eine Identität möglich. Für den Mehrbenutzer-Web-Server muss git als der **per-User-PAT** des angemeldeten Nutzers klonen/pushen. Dieser PR fädelt das durch — **ohne Verhaltenswechsel für die CLI**.

## Änderungen

- **git:** neuer `TokenAuth{GitLabHost, Token}` löst die Clone-Credential aus explizitem Host+Token (Token nur für den GitLab-Host, nie für einen fremden — gleiche Regel wie bisher); `Committer{Name, Email}` authort den Startercode-Commit (leer → glabs-Bot). `PrepareSourceRepo` nimmt beide. `AuthForURL` bleibt der viper-basierte CLI/clone-Pfad, auf `TokenAuth` reimplementiert.
- **gitlab.Client:** hält Host/Token/Committer, exponiert `gitAuth()`; `NewClient` bekommt `WithCommitter`; `NewClientFromViper` verdrahtet `committer.*` aus viper (unset → gleicher glabs-Bot-Default wie zuvor). `generate`/`update`/`push` übergeben `c.gitAuth()`+`c.committer`.
- **Integrationstest:** übergibt explizit `TokenAuth` aus Container-BaseURL + Root-Token.

Kein Web-Verhaltenswechsel hier; `generate` im Web ist **E1b**.

## Verifikation

`go build/vet (inkl. -tags=integration)/test/golangci-lint` — grün. **Die GitLab-CE-Integrationstests** (`GLABS_RUN_GITLAB_TC=1 -tags=integration`) laufen lokal als Transport-Beweis; gemergt wird erst, wenn sie durch sind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)