### PR TITLE
feat(web): generate as a plan/run op (Milestone E1b)

### DIFF
--- a/web/app/op_plan.go
+++ b/web/app/op_plan.go
@@ -13,9 +13,10 @@ import (
 	"github.com/obcode/glabs/v3/web/secrets"
 )
 
-// validOps are the mutating GitLab operations the web can plan and run. None of
-// them touch git — they are pure GitLab API calls.
-var validOps = map[string]bool{"setaccess": true, "protect": true, "archive": true, "delete": true}
+// validOps are the mutating GitLab operations the web can plan and run. All but
+// generate are pure GitLab API calls; generate also pushes starter code over git
+// (in memory, so no server disk is involved).
+var validOps = map[string]bool{"setaccess": true, "protect": true, "archive": true, "delete": true, "generate": true}
 
 // PlannedTarget is one repository an operation would touch.
 type PlannedTarget struct {

--- a/web/app/op_plan_test.go
+++ b/web/app/op_plan_test.go
@@ -62,6 +62,33 @@ func TestPlanOp_deleteIsDestructive(t *testing.T) {
 	}
 }
 
+func TestPlanOp_generateIsPlannableAndNotDestructive(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gl", sealer: testSealer(t)}
+
+	plan, err := a.PlanOp(ctxAs(owner), "generate", "uc", "blatt1", nil, nil)
+	if err != nil {
+		t.Fatalf("PlanOp(generate): %v", err)
+	}
+	if plan.Op != "generate" || len(plan.Targets) != 2 {
+		t.Fatalf("generate plan wrong: op=%q targets=%d", plan.Op, len(plan.Targets))
+	}
+	// Generate creates repositories; it is not destructive, so no confirm phrase.
+	if plan.Destructive || plan.ConfirmPhrase != "" {
+		t.Errorf("generate must not be destructive: %+v", plan)
+	}
+	// The token carries the op so runOp dispatches to Generate.
+	tok, err := a.openOpToken(plan.Token)
+	if err != nil {
+		t.Fatalf("openOpToken: %v", err)
+	}
+	if tok.Op != "generate" {
+		t.Errorf("token op = %q, want generate", tok.Op)
+	}
+}
+
 func TestPlanOp_unknownOpRejected(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/app/report.go
+++ b/web/app/report.go
@@ -33,6 +33,9 @@ func (a *App) gitlabClientFor(ctx context.Context, owner string, rep reporter.Re
 		gitlab.WithHost(a.gitlabHost),
 		gitlab.WithToken(token),
 		gitlab.WithReporter(rep),
+		// Attribute starter-code commits (generate/update) to the acting user;
+		// harmless for the read-only and git-less ops that also use this client.
+		gitlab.WithCommitter(owner, owner),
 	)
 }
 

--- a/web/app/run_op.go
+++ b/web/app/run_op.go
@@ -124,6 +124,8 @@ func executeOp(client *gitlab.Client, tok *opToken, cfg *config.AssignmentConfig
 		return client.Archive(cfg, tok.Params["unarchive"] == "true")
 	case "delete":
 		return client.Delete(cfg)
+	case "generate":
+		return client.Generate(cfg)
 	}
 	return fmt.Errorf("unknown operation %q", tok.Op)
 }

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -2198,6 +2198,7 @@ enum Op {
   PROTECT
   ARCHIVE
   DELETE
+  GENERATE
 }
 
 "Optional parameters for an operation (op-specific; unset fields fall back to the assignment config)."

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -656,6 +656,7 @@ const (
 	OpProtect   Op = "PROTECT"
 	OpArchive   Op = "ARCHIVE"
 	OpDelete    Op = "DELETE"
+	OpGenerate  Op = "GENERATE"
 )
 
 var AllOp = []Op{
@@ -663,11 +664,12 @@ var AllOp = []Op{
 	OpProtect,
 	OpArchive,
 	OpDelete,
+	OpGenerate,
 }
 
 func (e Op) IsValid() bool {
 	switch e {
-	case OpSetaccess, OpProtect, OpArchive, OpDelete:
+	case OpSetaccess, OpProtect, OpArchive, OpDelete, OpGenerate:
 		return true
 	}
 	return false

--- a/web/graph/op.graphqls
+++ b/web/graph/op.graphqls
@@ -4,6 +4,7 @@ enum Op {
   PROTECT
   ARCHIVE
   DELETE
+  GENERATE
 }
 
 "Optional parameters for an operation (op-specific; unset fields fall back to the assignment config)."


### PR DESCRIPTION
## Was

Milestone **E1b**: `generate` in die vorhandene planOp/runOp-Maschinerie einhängen. Da E1a den Transport entsperrt hat, ist das klein.

## Änderungen

- Op-Enum bekommt `GENERATE`; `validOps` akzeptiert „generate" (die erste Op, die **git** anfasst — ein In-Memory-Startercode-Clone, also **kein Server-Disk**).
- `executeOp` dispatcht „generate" → `client.Generate(cfg)`.
- `gitlabClientFor` setzt jetzt `WithCommitter(owner, owner)` → Startercode-Commits werden dem handelnden User zugeschrieben (harmlos für die read-only/git-losen Ops, die denselben Builder nutzen).
- Generate ist **nicht destruktiv** → keine Confirm-Phrase; die Plan-Vorschau (aufgelöste Config + Ziel-Repos) ist das menschliche Gate wie bei den anderen Ops. Seeder wird im runOp-Preflight abgelehnt; Streaming + Aktivitäts-Log über denselben Pfad.
- Test: `generate` planbar, 2 Targets, nicht destruktiv, Token trägt `op=generate`.

GUI-Op-Picker listet noch die vier API-Ops; `GENERATE` dort ist ein Einzeiler-Follow-up (E4). `update` (E2) und `--no-invite` (E3) folgen.

## Verifikation

`go build/vet (inkl. -tags=integration)/test/golangci-lint` — grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)