### PR TITLE
feat(web): update as a plan/run op, treated as destructive (Milestone E2)

### DIFF
--- a/web/app/op_plan.go
+++ b/web/app/op_plan.go
@@ -14,9 +14,18 @@ import (
 )
 
 // validOps are the mutating GitLab operations the web can plan and run. All but
-// generate are pure GitLab API calls; generate also pushes starter code over git
-// (in memory, so no server disk is involved).
-var validOps = map[string]bool{"setaccess": true, "protect": true, "archive": true, "delete": true, "generate": true}
+// generate/update are pure GitLab API calls; those two also push starter code
+// over git (in memory, so no server disk is involved).
+var validOps = map[string]bool{"setaccess": true, "protect": true, "archive": true, "delete": true, "generate": true, "update": true}
+
+// isDestructiveOp reports whether an op needs the extra confirm-phrase gate. delete
+// and archive are obvious; update force-pushes the starter code over existing
+// student repositories (the CLI warns "USE WITH CARE — only untouched repos"), so
+// it can wipe student work and is treated the same. Kept in one place so the plan,
+// run and schedule paths cannot disagree.
+func isDestructiveOp(op string) bool {
+	return op == "archive" || op == "delete" || op == "update"
+}
 
 // PlannedTarget is one repository an operation would touch.
 type PlannedTarget struct {
@@ -122,7 +131,7 @@ func (a *App) PlanOp(ctx context.Context, op, course, assignment string, params 
 		Resolved:    cfg.Show(),
 		Targets:     targets,
 		Warnings:    warnings,
-		Destructive: op == "archive" || op == "delete",
+		Destructive: isDestructiveOp(op),
 		Token:       token,
 		ExpiresAt:   now.Add(opTokenTTL),
 	}

--- a/web/app/op_plan_test.go
+++ b/web/app/op_plan_test.go
@@ -89,6 +89,22 @@ func TestPlanOp_generateIsPlannableAndNotDestructive(t *testing.T) {
 	}
 }
 
+func TestPlanOp_updateIsDestructive(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gl", sealer: testSealer(t)}
+
+	// update force-pushes the starter code over existing repos → destructive.
+	plan, err := a.PlanOp(ctxAs(owner), "update", "uc", "blatt1", nil, nil)
+	if err != nil {
+		t.Fatalf("PlanOp(update): %v", err)
+	}
+	if !plan.Destructive || plan.ConfirmPhrase != "uc/blatt1" {
+		t.Fatalf("update should be destructive with a confirm phrase: %+v", plan)
+	}
+}
+
 func TestPlanOp_unknownOpRejected(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/app/run_op.go
+++ b/web/app/run_op.go
@@ -60,7 +60,7 @@ func (a *App) RunOp(ctx context.Context, token, confirmPhrase string) (<-chan Ru
 	if cfg.Seeder != nil {
 		return nil, fmt.Errorf("assignment %q configures a seeder, which the web cannot run — use the CLI", tok.Assignment)
 	}
-	if tok.Op == "archive" || tok.Op == "delete" {
+	if isDestructiveOp(tok.Op) {
 		want := tok.Course + "/" + tok.Assignment
 		if confirmPhrase != want {
 			return nil, fmt.Errorf("type %q to confirm this destructive operation", want)
@@ -126,6 +126,8 @@ func executeOp(client *gitlab.Client, tok *opToken, cfg *config.AssignmentConfig
 		return client.Delete(cfg)
 	case "generate":
 		return client.Generate(cfg)
+	case "update":
+		return client.Update(cfg)
 	}
 	return fmt.Errorf("unknown operation %q", tok.Op)
 }

--- a/web/app/schedule.go
+++ b/web/app/schedule.go
@@ -34,7 +34,7 @@ func (a *App) ScheduleOp(ctx context.Context, token string, runAt time.Time, gra
 	}
 	// Destructive ops keep the same confirm-phrase gate as running now: the
 	// deliberate phrase is the human confirmation, since no one watches at fire time.
-	if tok.Op == "archive" || tok.Op == "delete" {
+	if isDestructiveOp(tok.Op) {
 		want := tok.Course + "/" + tok.Assignment
 		if confirmPhrase != want {
 			return nil, fmt.Errorf("type %q to confirm scheduling this destructive operation", want)

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -2199,6 +2199,7 @@ enum Op {
   ARCHIVE
   DELETE
   GENERATE
+  UPDATE
 }
 
 "Optional parameters for an operation (op-specific; unset fields fall back to the assignment config)."

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -657,6 +657,7 @@ const (
 	OpArchive   Op = "ARCHIVE"
 	OpDelete    Op = "DELETE"
 	OpGenerate  Op = "GENERATE"
+	OpUpdate    Op = "UPDATE"
 )
 
 var AllOp = []Op{
@@ -665,11 +666,12 @@ var AllOp = []Op{
 	OpArchive,
 	OpDelete,
 	OpGenerate,
+	OpUpdate,
 }
 
 func (e Op) IsValid() bool {
 	switch e {
-	case OpSetaccess, OpProtect, OpArchive, OpDelete, OpGenerate:
+	case OpSetaccess, OpProtect, OpArchive, OpDelete, OpGenerate, OpUpdate:
 		return true
 	}
 	return false

--- a/web/graph/op.graphqls
+++ b/web/graph/op.graphqls
@@ -5,6 +5,7 @@ enum Op {
   ARCHIVE
   DELETE
   GENERATE
+  UPDATE
 }
 
 "Optional parameters for an operation (op-specific; unset fields fall back to the assignment config)."


### PR DESCRIPTION
## Was

Milestone **E2**: `update` als plan/run-Op. `update` pusht Startercode (force) über **bestehende** Studi-Repos → kann Studi-Arbeit überschreiben (CLI warnt „USE WITH CARE — nur untouched"). Im Web daher wie delete/archive behandelt: Plan destruktiv, runOp/scheduleOp verlangen die Confirm-Phrase.

## Änderungen

- Op-Enum bekommt `UPDATE`; `validOps` akzeptiert „update"; `executeOp`→`client.Update(cfg)` (git-Transport via E1a, In-Memory-Clone).
- **destructive-Check zentralisiert** in `isDestructiveOp(op)` — archive, delete, jetzt update — genutzt von PlanOp/RunOp/ScheduleOp (können nicht mehr auseinanderlaufen).
- Test: update plant destruktiv mit `course/assignment`-Confirm-Phrase.

GUI-Picker-Eintrag folgt im glabs.gui-Gegenstück.

## Verifikation

`go build/vet (inkl. -tags=integration)/test/golangci-lint` — grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)