### PR TITLE
feat: generate --no-invite / skipInvite — create repos without inviting (Milestone E3/F6)

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -9,8 +9,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var noInvite bool
+
 func init() {
 	rootCmd.AddCommand(generateCmd)
+	generateCmd.Flags().BoolVar(&noInvite, "no-invite", false,
+		"create repos and push starter code but do NOT add/invite students or groups (for debugging)")
 }
 
 var generateCmd = &cobra.Command{
@@ -32,7 +36,7 @@ A student needs to exist on GitLab, a group needs to exist in the configuration 
 		if err != nil {
 			er(err)
 		}
-		if err := c.Generate(assignmentConfig); err != nil {
+		if err := c.Generate(assignmentConfig, noInvite); err != nil {
 			er(err)
 		}
 	},

--- a/gitlab/generate.go
+++ b/gitlab/generate.go
@@ -9,7 +9,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) error {
+// Generate creates the repositories for an assignment. When skipInvite is true,
+// the repos are created and seeded with starter code but students/groups are NOT
+// added or invited — a debugging aid to exercise generation without notifying
+// anyone.
+func (c *Client) Generate(assignmentCfg *config.AssignmentConfig, skipInvite bool) error {
 	assignmentGitLabGroupID, err := c.getGroupID(assignmentCfg)
 	if err != nil {
 		// try to create group if it does not exist, otherwise return an error
@@ -39,9 +43,9 @@ func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) error {
 
 	switch per := assignmentCfg.Per; per {
 	case config.PerGroup:
-		c.generatePerGroup(assignmentCfg, assignmentGitLabGroupID, starterrepo)
+		c.generatePerGroup(assignmentCfg, assignmentGitLabGroupID, starterrepo, skipInvite)
 	case config.PerStudent:
-		c.generatePerStudent(assignmentCfg, assignmentGitLabGroupID, starterrepo)
+		c.generatePerStudent(assignmentCfg, assignmentGitLabGroupID, starterrepo, skipInvite)
 	default:
 		return fmt.Errorf("it is only possible to generate for students or groups, not for %v", per)
 	}
@@ -49,7 +53,7 @@ func (c *Client) Generate(assignmentCfg *config.AssignmentConfig) error {
 }
 
 func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGroupID int64,
-	projectname string, members []*config.Student, starterrepo *git.SourceRepo) {
+	projectname string, members []*config.Student, starterrepo *git.SourceRepo, skipInvite bool) {
 
 	task := c.rep.Task(aurora.Sprintf(aurora.Cyan(" generating project %s at %s"),
 		aurora.Yellow(projectname),
@@ -173,11 +177,15 @@ func (c *Client) generate(assignmentCfg *config.AssignmentConfig, assignmentGrou
 		}
 	}
 
+	if skipInvite {
+		c.rep.Println(aurora.Yellow("    ↪ skipping student/group invitation (--no-invite)"))
+		return
+	}
 	c.setaccess(assignmentCfg, project, members)
 }
 
 func (c *Client) generatePerStudent(assignmentCfg *config.AssignmentConfig, assignmentGroupID int64,
-	starterrepo *git.SourceRepo) {
+	starterrepo *git.SourceRepo, skipInvite bool) {
 	if len(assignmentCfg.Students) == 0 {
 		log.Info().Str("group", assignmentCfg.Course).Msg("no students found")
 		return
@@ -185,18 +193,18 @@ func (c *Client) generatePerStudent(assignmentCfg *config.AssignmentConfig, assi
 
 	for _, student := range assignmentCfg.Students {
 		name := assignmentCfg.RepoNameForStudent(student)
-		c.generate(assignmentCfg, assignmentGroupID, name, []*config.Student{student}, starterrepo)
+		c.generate(assignmentCfg, assignmentGroupID, name, []*config.Student{student}, starterrepo, skipInvite)
 	}
 }
 
 func (c *Client) generatePerGroup(assignmentCfg *config.AssignmentConfig, assignmentGroupID int64,
-	starterrepo *git.SourceRepo) {
+	starterrepo *git.SourceRepo, skipInvite bool) {
 	if len(assignmentCfg.Groups) == 0 {
 		log.Info().Str("group", assignmentCfg.Course).Msg("no groups found")
 		return
 	}
 
 	for _, grp := range assignmentCfg.Groups {
-		c.generate(assignmentCfg, assignmentGroupID, assignmentCfg.RepoNameForGroup(grp), grp.Members, starterrepo)
+		c.generate(assignmentCfg, assignmentGroupID, assignmentCfg.RepoNameForGroup(grp), grp.Members, starterrepo, skipInvite)
 	}
 }

--- a/gitlab/runtime_test.go
+++ b/gitlab/runtime_test.go
@@ -24,7 +24,7 @@ func TestGenerateReturnsErrorForInvalidPer(t *testing.T) {
 		Per:    config.PerFailed,
 	}
 
-	if err := client.Generate(cfg); err == nil {
+	if err := client.Generate(cfg, false); err == nil {
 		t.Fatal("Generate with an invalid per succeeded, want an error")
 	}
 }

--- a/web/app/op_plan_test.go
+++ b/web/app/op_plan_test.go
@@ -105,6 +105,25 @@ func TestPlanOp_updateIsDestructive(t *testing.T) {
 	}
 }
 
+func TestPlanOp_generateSkipInviteCarriedInToken(t *testing.T) {
+	const owner = "prof@hm.edu"
+	fs := newFakeStore()
+	fs.courses[owner+"/uc"] = storedCourse(t, owner, urlsCourse)
+	a := &App{db: fs, gitlabHost: "https://gl", sealer: testSealer(t)}
+
+	plan, err := a.PlanOp(ctxAs(owner), "generate", "uc", "blatt1", map[string]string{"skipInvite": "true"}, nil)
+	if err != nil {
+		t.Fatalf("PlanOp: %v", err)
+	}
+	tok, err := a.openOpToken(plan.Token)
+	if err != nil {
+		t.Fatalf("openOpToken: %v", err)
+	}
+	if tok.Params["skipInvite"] != "true" {
+		t.Errorf("token skipInvite = %q, want true — the --no-invite choice must survive into runOp", tok.Params["skipInvite"])
+	}
+}
+
 func TestPlanOp_unknownOpRejected(t *testing.T) {
 	const owner = "prof@hm.edu"
 	fs := newFakeStore()

--- a/web/app/run_op.go
+++ b/web/app/run_op.go
@@ -125,7 +125,7 @@ func executeOp(client *gitlab.Client, tok *opToken, cfg *config.AssignmentConfig
 	case "delete":
 		return client.Delete(cfg)
 	case "generate":
-		return client.Generate(cfg)
+		return client.Generate(cfg, tok.Params["skipInvite"] == "true")
 	case "update":
 		return client.Update(cfg)
 	}

--- a/web/graph/generated/generated.go
+++ b/web/graph/generated/generated.go
@@ -2210,6 +2210,8 @@ input OpParams {
   branch: String
   "archive: unarchive instead of archive."
   unarchive: Boolean
+  "generate: create repos and push starter code but do NOT add/invite students or groups (for debugging)."
+  skipInvite: Boolean
 }
 
 "One repository an operation would touch."
@@ -10296,7 +10298,7 @@ func (ec *executionContext) unmarshalInputOpParams(ctx context.Context, obj any)
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"accessLevel", "branch", "unarchive"}
+	fieldsInOrder := [...]string{"accessLevel", "branch", "unarchive", "skipInvite"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -10324,6 +10326,13 @@ func (ec *executionContext) unmarshalInputOpParams(ctx context.Context, obj any)
 				return it, err
 			}
 			it.Unarchive = data
+		case "skipInvite":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skipInvite"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkipInvite = data
 		}
 	}
 	return it, nil

--- a/web/graph/model/models_gen.go
+++ b/web/graph/model/models_gen.go
@@ -250,6 +250,8 @@ type OpParams struct {
 	Branch *string `json:"branch,omitempty"`
 	// archive: unarchive instead of archive.
 	Unarchive *bool `json:"unarchive,omitempty"`
+	// generate: create repos and push starter code but do NOT add/invite students or groups (for debugging).
+	SkipInvite *bool `json:"skipInvite,omitempty"`
 }
 
 // The preview of a mutating operation before it runs: the resolved config, the

--- a/web/graph/op.graphqls
+++ b/web/graph/op.graphqls
@@ -16,6 +16,8 @@ input OpParams {
   branch: String
   "archive: unarchive instead of archive."
   unarchive: Boolean
+  "generate: create repos and push starter code but do NOT add/invite students or groups (for debugging)."
+  skipInvite: Boolean
 }
 
 "One repository an operation would touch."

--- a/web/graph/op_mapping.go
+++ b/web/graph/op_mapping.go
@@ -30,6 +30,9 @@ func paramsToMap(p *model.OpParams) map[string]string {
 	if p.Unarchive != nil {
 		m["unarchive"] = strconv.FormatBool(*p.Unarchive)
 	}
+	if p.SkipInvite != nil {
+		m["skipInvite"] = strconv.FormatBool(*p.SkipInvite)
+	}
 	return m
 }
 


### PR DESCRIPTION
## Was

F6 (Debug-Wunsch): eine Menge Repos (mit Startercode) generieren, **ohne** Studierende/Gruppen hinzuzufügen/einzuladen — die Pipeline testen, ohne jemanden zu benachrichtigen.

## Änderungen

- **gitlab:** `Generate` nimmt `skipInvite`, durchgereicht bis `generate`; wenn gesetzt, wird das per-Repo-`c.setaccess` (das die Member hinzufügt/einlädt) übersprungen + ein Hinweis geloggt. Default false → unverändert.
- **CLI:** `glabs generate --no-invite`.
- **web:** `OpParams` bekommt `skipInvite`; `paramsToMap` trägt es; `executeOp` liest `tok.Params["skipInvite"]` → die Planungs-Entscheidung überlebt bis runOp (und einen geplanten Lauf). Test: Flag round-trippt durch den Plan-Token.

GUI-Checkbox folgt im glabs.gui-Gegenstück. Transport unberührt → kein Integrationslauf nötig.

## Verifikation

`go build/vet (inkl. -tags=integration)/test/golangci-lint` — grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)