### PR TITLE
fix(gitlab): skip missing repos instead of aborting update

### DIFF
--- a/gitlab/update.go
+++ b/gitlab/update.go
@@ -71,8 +71,10 @@ func (c *Client) updatePerStudent(assignmentCfg *config.AssignmentConfig, starte
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
+			// Skip a missing repo (e.g. one never generated) instead of aborting the
+			// whole run — one 404 must not stop every remaining repo (cf. #109).
 			c.rep.Printf("cannot update project %s failed with %s", projectname, err)
-			return
+			continue
 		}
 		c.update(assignmentCfg, project, starterrepo)
 	}
@@ -91,8 +93,10 @@ func (c *Client) updatePerGroup(assignmentCfg *config.AssignmentConfig, starterr
 			&gitlab.GetProjectOptions{},
 		)
 		if err != nil {
+			// Skip a missing repo (e.g. one never generated) instead of aborting the
+			// whole run — one 404 must not stop every remaining repo (cf. #109).
 			c.rep.Printf("cannot update project %s failed with %s", projectname, err)
-			return
+			continue
 		}
 		c.update(assignmentCfg, project, starterrepo)
 	}


### PR DESCRIPTION
## Was

`update` hatte noch den **#109-Abbruch-Bug**: `updatePerStudent`/`updatePerGroup` machten `return` aus der ganzen Schleife bei einem per-Repo-`GetProject`-Fehler → ein fehlendes Repo (ein Studi, dessen Repo nie generiert wurde → 404) brach das Update für **alle** restlichen Repos ab. Weil Roster alphabetisch sind, übersprang ein früher Treffer fast alle, sah aber „gelaufen" aus.

Gleicher Bug wie #109 (dort für setaccess/protect/archive gefixt); `update` war übersehen. `return` → `continue`.

## Verifikation

`go build/vet (inkl. -tags=integration)/test/golangci-lint` — grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)