### PR TITLE
feat(web): ZPA client for enriching the roster (Milestone F5d, Z1)

### DIFF
--- a/web/app/app.go
+++ b/web/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/obcode/glabs/v3/web/db"
 	"github.com/obcode/glabs/v3/web/graph/model"
 	"github.com/obcode/glabs/v3/web/secrets"
+	"github.com/obcode/glabs/v3/web/zpa"
 	"github.com/spf13/viper"
 )
 
@@ -63,9 +64,12 @@ type App struct {
 	// configured test recipient.
 	mailer     Mailer
 	mailDryRun bool
+	// zpa enriches the roster with student details; nil when ZPA is not configured
+	// (then the students page shows just the emails).
+	zpa *zpa.Client
 }
 
-func New(database *db.DB, sealer *secrets.Sealer, gitlabHost string, mailer Mailer, mailDryRun bool) *App {
+func New(database *db.DB, sealer *secrets.Sealer, gitlabHost string, mailer Mailer, mailDryRun bool, zpaClient *zpa.Client) *App {
 	return &App{
 		db:         database,
 		sealer:     sealer,
@@ -73,6 +77,7 @@ func New(database *db.DB, sealer *secrets.Sealer, gitlabHost string, mailer Mail
 		ops:        newOpGuard(),
 		mailer:     mailer,
 		mailDryRun: mailDryRun,
+		zpa:        zpaClient,
 	}
 }
 

--- a/web/bootstrap/bootstrap.go
+++ b/web/bootstrap/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/obcode/glabs/v3/web/graph"
 	"github.com/obcode/glabs/v3/web/mail"
 	"github.com/obcode/glabs/v3/web/secrets"
+	"github.com/obcode/glabs/v3/web/zpa"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -100,7 +101,17 @@ func Serve() error {
 		log.Warn().Msg("no smtp.host configured; scheduled-job notifications are disabled")
 	}
 
-	a := app.New(database_, sealer, viper.GetString("gitlab.host"), mailer, viper.GetBool("smtp.dryRun"))
+	// ZPA (student directory) is optional: without zpa.baseurl + zpa.token, the
+	// students page just shows the roster emails.
+	var zpaClient *zpa.Client
+	if base, tok := viper.GetString("zpa.baseurl"), viper.GetString("zpa.token"); base != "" && tok != "" {
+		zpaClient = zpa.New(zpa.Config{BaseURL: base, Token: tok})
+		log.Info().Str("baseurl", base).Msg("ZPA configured; the students page is enriched")
+	} else {
+		log.Warn().Msg("no zpa.baseurl/zpa.token configured; the students page shows only emails")
+	}
+
+	a := app.New(database_, sealer, viper.GetString("gitlab.host"), mailer, viper.GetBool("smtp.dryRun"), zpaClient)
 	if err := seedUsers(ctx, database_); err != nil {
 		return err
 	}

--- a/web/zpa/zpa.go
+++ b/web/zpa/zpa.go
@@ -1,0 +1,141 @@
+// Package zpa is a minimal read-only client for HM's ZPA (Prüfungsamt) REST API,
+// used to enrich a course roster with student details (name, group, gender). It
+// is deliberately small — glabs only needs to look a student up — and keeps the
+// HTTP details confined here, mirroring plexams.go's zpa package.
+//
+// glabs identifies students by email, but ZPA's get_student_info search is
+// primarily used with a Matrikelnummer in plexams. StudentByEmail therefore
+// looks up defensively (by full email, then the email's local part) and returns
+// nil when ZPA has no unambiguous match — so the students page degrades to just
+// the email rather than showing wrong data.
+package zpa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Config is the ZPA connection, read from the server config in bootstrap.
+type Config struct {
+	BaseURL string
+	Token   string
+}
+
+// Client talks to the ZPA REST API with a fixed token.
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// New builds a ZPA client. baseURL and token are required by the caller; an empty
+// config means ZPA is disabled (bootstrap passes nil then).
+func New(cfg Config) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		token:   cfg.Token,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Student is one ZPA student record.
+type Student struct {
+	Mtknr     string `json:"mtknr"`
+	Greeting  string `json:"greeting"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Email     string `json:"email"`
+	Gender    string `json:"gender"`
+	Group     string `json:"group"`
+}
+
+// StudentByEmail looks a student up defensively: first by the full email, then by
+// the email's local part. It returns (nil, nil) when ZPA has no unambiguous match,
+// so callers can show just the email rather than guessing.
+func (c *Client) StudentByEmail(ctx context.Context, email string) (*Student, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return nil, nil
+	}
+
+	students, err := c.search(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+	if s := pickMatch(students, email); s != nil {
+		return s, nil
+	}
+
+	// Fallback: the local part (HM emails are name-based, e.g. a.ciftci@hm.edu).
+	if local, _, ok := strings.Cut(email, "@"); ok && local != "" {
+		students, err = c.search(ctx, local)
+		if err != nil {
+			return nil, err
+		}
+		if s := pickMatch(students, email); s != nil {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+// pickMatch prefers an exact (case-insensitive) email match; failing that, a sole
+// result; otherwise nil (an ambiguous search must not enrich with the wrong
+// person).
+func pickMatch(students []*Student, email string) *Student {
+	for _, s := range students {
+		if s != nil && strings.EqualFold(strings.TrimSpace(s.Email), email) {
+			return s
+		}
+	}
+	if len(students) == 1 {
+		return students[0]
+	}
+	return nil
+}
+
+// search calls get_student_info?ask=<ask>.
+func (c *Client) search(ctx context.Context, ask string) ([]*Student, error) {
+	var students []*Student
+	err := c.get(ctx, "get_student_info?ask="+url.QueryEscape(ask), &students)
+	return students, err
+}
+
+func (c *Client) get(ctx context.Context, path string, v any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/"+path, nil)
+	if err != nil {
+		return fmt.Errorf("cannot build ZPA request for %s: %w", path, err)
+	}
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Authorization", "Token "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("cannot reach ZPA for %s: %w", path, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("ZPA returned %s for %s: %s", resp.Status, path, bodySnippet(body))
+	}
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("ZPA returned an unexpected (non-JSON) response for %s: %s", path, bodySnippet(body))
+	}
+	return nil
+}
+
+func bodySnippet(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	const max = 300
+	if len(s) > max {
+		s = s[:max] + " …(truncated)"
+	}
+	return s
+}

--- a/web/zpa/zpa_test.go
+++ b/web/zpa/zpa_test.go
@@ -1,0 +1,104 @@
+package zpa
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mockZPA serves get_student_info from a map of ask→students, and records the
+// Authorization header of the last request.
+func mockZPA(t *testing.T, byAsk map[string][]*Student) (*Client, *string) {
+	t.Helper()
+	lastAuth := new(string)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*lastAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/get_student_info" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		ask := r.URL.Query().Get("ask")
+		_ = json.NewEncoder(w).Encode(byAsk[ask])
+	}))
+	t.Cleanup(srv.Close)
+	return New(Config{BaseURL: srv.URL, Token: "tok-123"}), lastAuth
+}
+
+func TestStudentByEmail_exactMatchAndAuthHeader(t *testing.T) {
+	want := &Student{Mtknr: "123", FirstName: "Ada", LastName: "Ciftci", Email: "a.ciftci@hm.edu", Gender: "f", Group: "IF3A"}
+	c, lastAuth := mockZPA(t, map[string][]*Student{
+		"a.ciftci@hm.edu": {want},
+	})
+
+	got, err := c.StudentByEmail(context.Background(), "a.ciftci@hm.edu")
+	if err != nil {
+		t.Fatalf("StudentByEmail: %v", err)
+	}
+	if got == nil || got.Mtknr != "123" || got.FirstName != "Ada" || got.Group != "IF3A" {
+		t.Fatalf("got %+v, want Ada Ciftci (123)", got)
+	}
+	if *lastAuth != "Token tok-123" {
+		t.Errorf("Authorization = %q, want 'Token tok-123'", *lastAuth)
+	}
+}
+
+func TestStudentByEmail_fallsBackToLocalPart(t *testing.T) {
+	want := &Student{Mtknr: "9", FirstName: "Bo", LastName: "Rueedi", Email: "benjamin.rueedi@hm.edu"}
+	// The full-email search returns nothing; the local-part search finds the student.
+	c, _ := mockZPA(t, map[string][]*Student{
+		"benjamin.rueedi": {want},
+	})
+
+	got, err := c.StudentByEmail(context.Background(), "benjamin.rueedi@hm.edu")
+	if err != nil {
+		t.Fatalf("StudentByEmail: %v", err)
+	}
+	if got == nil || got.Mtknr != "9" {
+		t.Fatalf("got %+v, want the local-part match (9)", got)
+	}
+}
+
+func TestStudentByEmail_noMatchIsNil(t *testing.T) {
+	c, _ := mockZPA(t, map[string][]*Student{}) // ZPA knows nobody
+
+	got, err := c.StudentByEmail(context.Background(), "nobody@hm.edu")
+	if err != nil {
+		t.Fatalf("StudentByEmail: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %+v, want nil for an unknown email", got)
+	}
+}
+
+func TestStudentByEmail_ambiguousLocalPartIsNil(t *testing.T) {
+	// The local-part search returns two students, neither matching the email exactly
+	// → must not guess.
+	c, _ := mockZPA(t, map[string][]*Student{
+		"mueller": {
+			{Mtknr: "1", Email: "a.mueller@hm.edu"},
+			{Mtknr: "2", Email: "b.mueller@hm.edu"},
+		},
+	})
+
+	got, err := c.StudentByEmail(context.Background(), "mueller@hm.edu")
+	if err != nil {
+		t.Fatalf("StudentByEmail: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %+v, want nil for an ambiguous match", got)
+	}
+}
+
+func TestStudentByEmail_serverErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	c := New(Config{BaseURL: srv.URL, Token: "bad"})
+
+	if _, err := c.StudentByEmail(context.Background(), "a@hm.edu"); err == nil {
+		t.Error("a non-2xx ZPA response should be an error")
+	}
+}


### PR DESCRIPTION
## Was

Milestone F5d / **Z1**: ein minimaler read-only ZPA-Client (aus plexams.go/zpa), damit die Studierenden-Seite Name/Gruppe/Geschlecht zeigen kann. Nur in `web/zpa`, die CLI nutzt es nicht.

## Änderungen

- `Client.StudentByEmail` sucht **defensiv**: glabs kennt E-Mails, ZPAs `get_student_info` wird in plexams mit Matrikelnummer benutzt → erst volle E-Mail, dann lokaler Teil, sonst `(nil, nil)`. Exakter E-Mail-Treffer gewinnt; ein einziges Ergebnis wird akzeptiert; eine mehrdeutige Suche **nicht** (kein Raten).
- Auth via `Authorization: Token <token>`; non-2xx surfacet die ZPA-Meldung.
- App bekommt einen optionalen `*zpa.Client` (nil wenn `zpa.baseurl`/`zpa.token` fehlen → bootstrap loggt es, Seite zeigt nur E-Mails).
- Getestet gegen httptest-Mock (kein echtes ZPA nötig): exakter Treffer + Auth-Header, Lokalteil-Fallback, kein-Treffer-nil, mehrdeutig-nil, non-2xx-Fehler.

`courseStudents`-Query (Z2) + Studierenden-Seite (Z3) bauen darauf auf. Config-Keys: `zpa.baseurl`, `zpa.token`.

## Verifikation

`go build/vet (inkl. -tags=integration)/test/golangci-lint` — grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)