### PR TITLE
ci(deps): add dependabot for go modules and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependency-Updates aktuell halten (nativ in GitHub, kein App-Setup nötig).
+# Wöchentliche PRs, gruppiert, damit es nicht zerfasert.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    # Nur Versionen vorschlagen, die schon ein paar Tage alt sind — vermeidet
+    # frisch veröffentlichte, evtl. noch fehlerhafte Releases (analog zum
+    # cooldown in glabs.gui, wo pnpm ohnehin ein 24h-Gate erzwingt).
+    cooldown:
+      default-days: 3
+    groups:
+      # alles an Minor/Patch gebündelt; Majors kommen einzeln, da sie brechen können
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 3
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Was

Fügt `.github/dependabot.yml` für glabs hinzu — analog zum Setup in glabs.gui:

- **gomod** (`/`): wöchentlich, Minor/Patch gruppiert in einen PR, Majors einzeln
- **github-actions** (`/`): wöchentlich, gruppiert
- **cooldown: 3 Tage** in beiden Ökosystemen: nur Versionen vorschlagen, die schon
  ein paar Tage alt sind (vermeidet frisch veröffentlichte, evtl. fehlerhafte Releases)

Kein Code-Change, nur CI-Config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)